### PR TITLE
feat: support multiple extensions for routes file

### DIFF
--- a/.changeset/cold-icons-lick.md
+++ b/.changeset/cold-icons-lick.md
@@ -1,0 +1,5 @@
+---
+'rsbuild-plugin-react-router': patch
+---
+
+search for routes file with any extention

--- a/.changeset/social-flowers-itch.md
+++ b/.changeset/social-flowers-itch.md
@@ -1,0 +1,5 @@
+---
+'rsbuild-plugin-react-router': patch
+---
+
+support multiple extentions for routes file, like js,ts,jsx etc

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ export const pluginReactRouter = (
         return {} as Config;
       });
 
-    const routesPath = resolve(appDirectory, 'routes.ts');
+    const routesPath = findEntryFile(resolve(appDirectory, 'routes'));
 
     // Then read the routes
     const routeConfig = await jiti
@@ -105,8 +105,8 @@ export const pluginReactRouter = (
         default: true,
       })
       .catch(error => {
-        console.error('Failed to load routes.ts:', error);
-        console.error('No routes.ts found in app directory.');
+        console.error('Failed to load routes file:', error);
+        console.error('No routes file found in app directory.');
         return [] as RouteConfigEntry[];
       });
 


### PR DESCRIPTION
This pull request includes a change to the `pluginReactRouter` function in the `src/index.ts` file to improve the way the routes file is located and to generalize error messages.

* Changed the method for locating the routes file from `resolve` to `findEntryFile` to allow for more flexibility in finding the entry file.
* Updated error messages to be more general, replacing specific references to `routes.ts` with `routes file`.

https://github.com/rspack-contrib/rsbuild-plugin-react-router/issues/15