### PR TITLE
ci: add pkg.pr.new previews

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     branches: [main]
 
-permissions: {}
+permissions:
+  contents: read
+  pull-requests: write
 
 concurrency:
   group: pkg-pr-new-${{ github.event.pull_request.number }}

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,39 @@
+name: pkg.pr.new
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: pkg-pr-new-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Publish preview package
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build package
+        run: pnpm build
+
+      - name: Publish preview package
+        run: pnpm exec pkg-pr-new publish --commentWithSha --packageManager=pnpm

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "@types/react-dom": "^19.2.3",
     "es-module-lexer": "1.7.0",
     "kill-port": "^2.0.1",
+    "pkg-pr-new": "^0.0.75",
     "playwright": "^1.58.0",
     "prettier": "3.8.1",
     "react": "^19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       kill-port:
         specifier: ^2.0.1
         version: 2.0.1
+      pkg-pr-new:
+        specifier: ^0.0.75
+        version: 0.0.75
       playwright:
         specifier: ^1.58.0
         version: 1.58.0
@@ -7709,6 +7712,10 @@ packages:
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+
+  pkg-pr-new@0.0.75:
+    resolution: {integrity: sha512-u9mdErTewKSMsr+ceCt8VcNuNP0ro5AXiPXhUVApuEyqr2Zlvt+DdCFBcm+yGWN8mhOdZJ27meIDbnoZgfzpOw==}
+    hasBin: true
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
@@ -15957,6 +15964,8 @@ snapshots:
   pify@3.0.0: {}
 
   pify@4.0.1: {}
+
+  pkg-pr-new@0.0.75: {}
 
   pkg-types@2.3.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Add a `pkg.pr.new` workflow that publishes preview packages for PRs targeting `main`.
- Install `pkg-pr-new` as a dev dependency so CI runs it from the lockfile.
- Build the package before publishing the preview and comment with pnpm install instructions for the commit SHA.

## Test plan
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm exec pkg-pr-new --help`