### PR TITLE
perf: reduce route analysis and chunk overhead

### DIFF
--- a/.changeset/fast-routes-dance.md
+++ b/.changeset/fast-routes-dance.md
@@ -1,0 +1,5 @@
+---
+"rsbuild-plugin-react-router": patch
+---
+
+Reduce route analysis and route chunking overhead by reusing transformed export metadata and cached route chunk analysis.

--- a/scripts/bench-client-entry-analysis.mjs
+++ b/scripts/bench-client-entry-analysis.mjs
@@ -172,7 +172,7 @@ const runRoute = async ({
       benchmarkSource,
       benchmarkResourcePath
     );
-    const exportNames = await analysis.getExportNames();
+    const exportNames = analysis.exportNames;
     return { analysis, exportNames };
   });
 

--- a/src/export-utils.ts
+++ b/src/export-utils.ts
@@ -10,12 +10,19 @@ import {
 
 type TransformCacheEntry = {
   source: string;
-  transformed: Promise<string>;
+  transformed: Promise<TransformedModule>;
 };
 
-export type BundlerRouteAnalysis = {
-  code: string;
-  getExportNames: () => Promise<string[]>;
+type ExportInfo = {
+  readonly exportNames: readonly string[];
+  readonly exportAllModules: readonly string[];
+};
+
+type TransformedModule = ExportInfo & {
+  readonly code: string;
+};
+
+export type BundlerRouteAnalysis = TransformedModule & {
   getRouteChunkInfo: (
     cache: RouteChunkCache | undefined,
     config: RouteChunkConfig
@@ -28,9 +35,9 @@ type BundlerRouteAnalysisCacheEntry = {
 };
 
 type RouteModuleAnalysis = {
-  code: string;
-  exports: string[];
-  exportAllModules: string[];
+  readonly code: string;
+  readonly exports: readonly string[];
+  readonly exportAllModules: readonly string[];
 };
 
 type RouteModuleAnalysisCacheEntry = {
@@ -40,10 +47,7 @@ type RouteModuleAnalysisCacheEntry = {
 };
 
 const transformCache = new Map<string, TransformCacheEntry>();
-const exportInfoCache = new Map<
-  string,
-  Promise<{ exportNames: string[]; exportAllModules: string[] }>
->();
+const exportInfoCache = new Map<string, Promise<ExportInfo>>();
 const bundlerRouteAnalysisCache = new Map<
   string,
   BundlerRouteAnalysisCacheEntry
@@ -147,11 +151,18 @@ const getExportedName = (node: AnyNode): string | null => {
 };
 
 const isTypeOnlyExport = (node: AnyNode): boolean =>
-  node.exportKind === 'type' || node.type === 'TSExportAssignment';
+  node.exportKind === 'type' ||
+  node.type === 'TSExportAssignment' ||
+  (node.type === 'ExportDefaultDeclaration' &&
+    node.declaration?.type === 'TSInterfaceDeclaration');
 
 const collectExportNames = (program: AnyNode): string[] => {
   const exportNames = new Set<string>();
   for (const statement of program.body ?? []) {
+    if (isTypeOnlyExport(statement)) {
+      continue;
+    }
+
     if (statement.type === 'ExportAllDeclaration') {
       const exported = getExportedName(statement.exported);
       if (exported) {
@@ -168,10 +179,6 @@ const collectExportNames = (program: AnyNode): string[] => {
     if (statement.type !== 'ExportNamedDeclaration') {
       continue;
     }
-    if (isTypeOnlyExport(statement)) {
-      continue;
-    }
-
     const declaration = statement.declaration;
     if (declaration) {
       if (declaration.type === 'VariableDeclaration') {
@@ -206,7 +213,10 @@ const collectExportNames = (program: AnyNode): string[] => {
 const collectExportAllModules = (program: AnyNode): string[] => {
   const modules: string[] = [];
   for (const statement of program.body ?? []) {
-    if (statement.type !== 'ExportAllDeclaration') {
+    if (
+      statement.type !== 'ExportAllDeclaration' ||
+      isTypeOnlyExport(statement)
+    ) {
       continue;
     }
     if (statement.exported) {
@@ -220,16 +230,16 @@ const collectExportAllModules = (program: AnyNode): string[] => {
   return modules;
 };
 
-export const transformToEsm = async (
+const getTransformedModule = async (
   code: string,
   resourcePath: string
-): Promise<string> => {
+): Promise<TransformedModule> => {
   const cached = transformCache.get(resourcePath);
   if (cached?.source === code) {
     return cached.transformed;
   }
 
-  let transformed: Promise<string>;
+  let transformed: Promise<TransformedModule>;
   transformed = cachePromiseOnReject(
     (async () => {
       const program = parseProgram(code, resourcePath);
@@ -237,7 +247,11 @@ export const transformToEsm = async (
       if (stripped.errors.length > 0) {
         throw new Error(stripped.errors.map(error => error.message).join('\n'));
       }
-      return stripped.code;
+      return {
+        code: stripped.code,
+        exportNames: collectExportNames(program),
+        exportAllModules: collectExportAllModules(program),
+      };
     })(),
     () => {
       if (transformCache.get(resourcePath)?.transformed === transformed) {
@@ -253,7 +267,14 @@ export const transformToEsm = async (
   return transformed;
 };
 
-export const getExportNames = async (code: string): Promise<string[]> => {
+export const transformToEsm = async (
+  code: string,
+  resourcePath: string
+): Promise<string> => (await getTransformedModule(code, resourcePath)).code;
+
+export const getExportNames = async (
+  code: string
+): Promise<readonly string[]> => {
   return (await getExportNamesAndExportAll(code)).exportNames;
 };
 
@@ -267,16 +288,11 @@ export const getBundlerRouteAnalysis = async (
   }
 
   const analysis = (async () => {
-    const code = await transformToEsm(source, resourcePath);
-    let exportNames: Promise<string[]> | undefined;
+    const transformed = await getTransformedModule(source, resourcePath);
     const routeChunkInfoCache = new Map<string, Promise<RouteChunkInfo>>();
 
     return {
-      code,
-      getExportNames: () => {
-        exportNames ??= getExportNames(code);
-        return exportNames;
-      },
+      ...transformed,
       getRouteChunkInfo: (
         cache: RouteChunkCache | undefined,
         config: RouteChunkConfig
@@ -289,7 +305,12 @@ export const getBundlerRouteAnalysis = async (
 
         let routeChunkInfo: Promise<RouteChunkInfo>;
         routeChunkInfo = cachePromiseOnReject(
-          detectRouteChunksIfEnabled(cache, config, resourcePath, code),
+          detectRouteChunksIfEnabled(
+            cache,
+            config,
+            resourcePath,
+            transformed.code
+          ),
           () => {
             if (routeChunkInfoCache.get(cacheKey) === routeChunkInfo) {
               routeChunkInfoCache.delete(cacheKey);
@@ -321,7 +342,7 @@ export const getBundlerRouteAnalysis = async (
 
 export const getExportNamesAndExportAll = async (
   code: string
-): Promise<{ exportNames: string[]; exportAllModules: string[] }> => {
+): Promise<ExportInfo> => {
   const cached = exportInfoCache.get(code);
   if (cached) {
     return cached;
@@ -335,10 +356,7 @@ export const getExportNamesAndExportAll = async (
     };
   })();
 
-  let trackedExportInfo: Promise<{
-    exportNames: string[];
-    exportAllModules: string[];
-  }>;
+  let trackedExportInfo: Promise<ExportInfo>;
   trackedExportInfo = cachePromiseOnReject(exportInfo, () => {
     if (exportInfoCache.get(code) === trackedExportInfo) {
       exportInfoCache.delete(code);
@@ -360,10 +378,12 @@ export const getRouteModuleAnalysis = async (
 
   const analysis = (async () => {
     const source = await readFile(resourcePath, 'utf8');
-    const code = await transformToEsm(source, resourcePath);
-    const { exportNames, exportAllModules } =
-      await getExportNamesAndExportAll(code);
-    return { code, exports: exportNames, exportAllModules };
+    const transformed = await getTransformedModule(source, resourcePath);
+    return {
+      code: transformed.code,
+      exports: transformed.exportNames,
+      exportAllModules: transformed.exportAllModules,
+    };
   })();
 
   let trackedAnalysis: Promise<RouteModuleAnalysis>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,14 +46,14 @@ import {
   getReactRouterManifestForDev,
   getRouteManifestModuleExports,
   configRoutesToRouteManifest,
+  REACT_ROUTER_MANIFEST_STATS_OPTIONS,
+  type ReactRouterManifestStats,
 } from './manifest.js';
 import { createModifyBrowserManifestPlugin } from './modify-browser-manifest.js';
 import { createRequestHandler, matchRoutes } from 'react-router';
 import {
   getBundlerRouteAnalysis,
-  getExportNamesAndExportAll,
   getRouteModuleAnalysis,
-  transformToEsm,
 } from './export-utils.js';
 import {
   getRouteChunkEntryName,
@@ -415,6 +415,7 @@ export const pluginReactRouter = (
     type ReactRouterManifest = Awaited<
       ReturnType<typeof getReactRouterManifestForDev>
     >;
+    let latestBrowserManifest: ReactRouterManifest | null = null;
     let latestServerManifest: ReactRouterManifest | null = null;
     const latestServerManifestsByBundleId: Record<string, ReactRouterManifest> =
       {};
@@ -468,10 +469,10 @@ export const pluginReactRouter = (
     const outputClientPath = resolve(buildDirectory, 'client');
     const assetsBuildDirectory = relative(process.cwd(), outputClientPath);
 
-    let clientStats: Rspack.StatsCompilation | undefined;
+    let clientStats: ReactRouterManifestStats | undefined;
     api.onAfterEnvironmentCompile(({ stats, environment }) => {
       if (environment.name === 'web') {
-        clientStats = stats?.toJson();
+        clientStats = stats?.toJson(REACT_ROUTER_MANIFEST_STATS_OPTIONS);
       }
       if (pluginOptions.federation && ssr) {
         const serverBuildDir = resolve(buildDirectory, 'server');
@@ -865,15 +866,17 @@ export const pluginReactRouter = (
         const requestHandler = createRequestHandler(build, 'production');
 
         if (isPrerenderEnabled) {
-          const manifest = await getReactRouterManifestForDev(
-            routes,
-            pluginOptions,
-            clientStats,
-            appDirectory,
-            assetPrefix,
-            routeChunkOptions
-          );
           if (!ssr) {
+            const manifest =
+              latestBrowserManifest ??
+              (await getReactRouterManifestForDev(
+                routes,
+                pluginOptions,
+                clientStats,
+                appDirectory,
+                assetPrefix,
+                routeChunkOptions
+              ));
             await validateSsrFalsePrerenderExports(manifest, prerenderPaths);
           }
 
@@ -991,11 +994,6 @@ export const pluginReactRouter = (
       }
 
       if (buildEnd) {
-        const buildManifest = await getBuildManifest({
-          reactRouterConfig: resolvedConfigWithRoutes,
-          routes,
-          rootDirectory: process.cwd(),
-        });
         await buildEnd({
           buildManifest,
           reactRouterConfig: resolvedConfigWithRoutes,
@@ -1256,6 +1254,7 @@ export const pluginReactRouter = (
                           'manifest:stage',
                           'virtual/react-router/browser-manifest',
                           () => {
+                            latestBrowserManifest = manifest;
                             const baseServerManifest = {
                               ...manifest,
                               sri,
@@ -1437,7 +1436,7 @@ export const pluginReactRouter = (
               return { code: args.code, map: null };
             }
 
-            const sourceExports = await analysis.getExportNames();
+            const sourceExports = analysis.exportNames;
             const chunkedExportSet = new Set<string>(chunkedExports);
             const isMainChunkExport = (name: string) =>
               !chunkedExportSet.has(name);
@@ -1500,9 +1499,12 @@ export const pluginReactRouter = (
           'module:client-only-stub',
           args.resource,
           async () => {
-            const code = await transformToEsm(args.code, args.resourcePath);
+            const analysis = await getBundlerRouteAnalysis(
+              args.code,
+              args.resourcePath
+            );
             const { exportNames: directExportNames, exportAllModules } =
-              await getExportNamesAndExportAll(code);
+              analysis;
             const exportNames = new Set(directExportNames);
             const unresolvedExportAll = new Set<string>();
             const visitedModules = new Set<string>();
@@ -1667,7 +1669,7 @@ export const pluginReactRouter = (
             // In SPA mode, server-only route exports are invalid (except root `loader`),
             // and `HydrateFallback` is only allowed on the root route.
             if (args.environment.name === 'web' && !ssr && isSpaMode) {
-              const resolvedExportNames = await analysis.getExportNames();
+              const resolvedExportNames = analysis.exportNames;
               const isRootRoute = args.resourcePath === rootRoutePath;
               const relativePath = relative(process.cwd(), args.resourcePath);
 
@@ -1677,9 +1679,7 @@ export const pluginReactRouter = (
               });
 
               if (invalidServerOnly.length > 0) {
-                const list = invalidServerOnly
-                  .map(e => `\`${e}\``)
-                  .join(', ');
+                const list = invalidServerOnly.map(e => `\`${e}\``).join(', ');
                 throw new Error(
                   `SPA Mode: ${invalidServerOnly.length} invalid route export(s) in ` +
                     `\`${relativePath}\`: ${list}. ` +

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -79,6 +79,16 @@ export type ReactRouterManifestForDev = {
   routes: Record<string, RouteManifestItem>;
 };
 
+export type ReactRouterManifestStats = Pick<
+  Rspack.StatsCompilation,
+  'assetsByChunkName'
+>;
+
+export const REACT_ROUTER_MANIFEST_STATS_OPTIONS = {
+  all: false,
+  assets: true,
+} as const;
+
 export type RouteManifestModuleExports = Record<string, readonly string[]>;
 
 const routeManifestModuleExports = new WeakMap<
@@ -138,7 +148,7 @@ export async function getReactRouterManifestForDev(
   routes: Record<string, Route>,
   //@ts-ignore
   options: PluginOptions,
-  clientStats: Rspack.StatsCompilation | undefined,
+  clientStats: ReactRouterManifestStats | undefined,
   context: string,
   assetPrefix = '/',
   routeChunkOptions?: RouteChunkManifestOptions
@@ -182,7 +192,7 @@ export async function getReactRouterManifestForDev(
       let cssAssets = assets.filter(asset => asset.endsWith('.css')) || [];
       const routeFilePath = resolve(context, route.file);
       let exports = new Set<string>();
-      let routeModuleExports: string[] = [];
+      let routeModuleExports: readonly string[] = [];
       let hasRouteChunkByExportName = createEmptyRouteChunkByExportName();
 
       try {
@@ -223,10 +233,7 @@ export async function getReactRouterManifestForDev(
         validateRouteChunks({
           config: routeChunkConfig,
           id: routeFilePath,
-          valid: buildManifestChunkValidity(
-            exports,
-            hasRouteChunkByExportName
-          ),
+          valid: buildManifestChunkValidity(exports, hasRouteChunkByExportName),
         });
       }
 

--- a/src/modify-browser-manifest.ts
+++ b/src/modify-browser-manifest.ts
@@ -5,6 +5,7 @@ import type { Rspack } from '@rsbuild/core';
 import {
   getReactRouterManifestForDev,
   getReactRouterManifestPath,
+  REACT_ROUTER_MANIFEST_STATS_OPTIONS,
 } from './manifest.js';
 import { combineURLs } from './plugin-utils.js';
 import jsesc from 'jsesc';
@@ -35,7 +36,9 @@ export function createModifyBrowserManifestPlugin(
       compiler.hooks.emit.tapAsync(
         'ModifyBrowserManifest',
         async (compilation: Rspack.Compilation, callback) => {
-          const stats = compilation.getStats().toJson();
+          const stats = compilation
+            .getStats()
+            .toJson(REACT_ROUTER_MANIFEST_STATS_OPTIONS);
           const manifest = await getReactRouterManifestForDev(
             routes,
             pluginOptions,

--- a/src/plugin-utils.ts
+++ b/src/plugin-utils.ts
@@ -288,7 +288,21 @@ const isNonReferenceIdentifier = (node: AnyNode, parent: AnyNode | null) => {
   ) {
     return true;
   }
-  if (parent.type === 'LabeledStatement' || parent.type === 'BreakStatement') {
+  if (
+    parent.type === 'ExportSpecifier' ||
+    parent.type === 'ExportDefaultSpecifier' ||
+    parent.type === 'ExportNamespaceSpecifier'
+  ) {
+    return true;
+  }
+  if (parent.type === 'ImportSpecifier' && parent.imported === node) {
+    return true;
+  }
+  if (
+    parent.type === 'LabeledStatement' ||
+    parent.type === 'BreakStatement' ||
+    parent.type === 'ContinueStatement'
+  ) {
     return true;
   }
   return false;
@@ -296,9 +310,9 @@ const isNonReferenceIdentifier = (node: AnyNode, parent: AnyNode | null) => {
 
 const isUppercaseName = (name: string): boolean => /^[A-Z]/.test(name);
 
-const collectReferencedNames = (program: AnyNode): Set<string> => {
+const collectReferencedNames = (node: AnyNode): Set<string> => {
   const referenced = new Set<string>();
-  walk(program as any, {
+  walk(node as any, {
     Identifier(node: AnyNode, ctx: any) {
       const parent = ctx.parent as AnyNode | null;
       if (!isNonReferenceIdentifier(node, parent)) {
@@ -322,8 +336,14 @@ const collectReferencedNames = (program: AnyNode): Set<string> => {
         referenced.add(node.name);
       }
     },
-    ExportSpecifier(node: AnyNode) {
-      if (node.local?.name && node.exportKind !== 'type') {
+    ExportSpecifier(node: AnyNode, ctx: any) {
+      const declaration = ctx.parent as AnyNode | null;
+      if (
+        !declaration?.source &&
+        declaration?.exportKind !== 'type' &&
+        node.local?.name &&
+        node.exportKind !== 'type'
+      ) {
         referenced.add(node.local.name);
       }
     },
@@ -345,66 +365,124 @@ const getExportedName = (specifier: AnyNode): string | null => {
   return null;
 };
 
-const collectExportedLocalNames = (program: AnyNode): Set<string> => {
-  const names = new Set<string>();
-  for (const statement of program.body ?? []) {
-    if (statement.type === 'ExportDefaultDeclaration') {
-      if (statement.declaration?.id?.name) {
-        names.add(statement.declaration.id.name);
-      }
-      continue;
-    }
-    if (statement.type !== 'ExportNamedDeclaration') {
-      continue;
-    }
-    if (statement.declaration) {
-      for (const name of getDeclaredNames(statement.declaration)) {
-        names.add(name);
-      }
-    }
-    for (const specifier of statement.specifiers ?? []) {
-      if (specifier.local?.name && specifier.exportKind !== 'type') {
-        names.add(specifier.local.name);
-      }
-    }
-  }
-  return names;
+type TopLevelDeclaration = {
+  referencedNames: Set<string>;
 };
 
-const removeUnusedTopLevelDeclarations = (program: AnyNode): void => {
-  let changed = true;
-  while (changed) {
-    changed = false;
-    const referenced = collectReferencedNames(program);
-    const exported = collectExportedLocalNames(program);
-    for (const statement of [...program.body]) {
-      if (statement.type !== 'VariableDeclaration') {
-        if (
-          (statement.type === 'FunctionDeclaration' ||
-            statement.type === 'ClassDeclaration') &&
-          statement.id?.name &&
-          !referenced.has(statement.id.name) &&
-          !exported.has(statement.id.name)
-        ) {
-          removeFromArray(program.body, statement);
-          changed = true;
-        }
-        continue;
+type TopLevelDeclarationGraph = {
+  declarationsByNode: Map<AnyNode, TopLevelDeclaration>;
+  declarationsByName: Map<string, Set<TopLevelDeclaration>>;
+};
+
+const createTopLevelDeclarationGraph = (
+  program: AnyNode
+): TopLevelDeclarationGraph => {
+  const declarationsByNode = new Map<AnyNode, TopLevelDeclaration>();
+  const declarationsByName = new Map<string, Set<TopLevelDeclaration>>();
+
+  const registerDeclaration = (
+    node: AnyNode,
+    declarationNode: AnyNode,
+    declaredNames: Set<string>
+  ) => {
+    const declaration: TopLevelDeclaration = {
+      referencedNames: collectReferencedNames(declarationNode),
+    };
+    declarationsByNode.set(node, declaration);
+    for (const name of declaredNames) {
+      const namedDeclarations = declarationsByName.get(name) ?? new Set();
+      namedDeclarations.add(declaration);
+      declarationsByName.set(name, namedDeclarations);
+    }
+  };
+
+  for (const statement of program.body) {
+    if (statement.type === 'VariableDeclaration') {
+      for (const declarator of statement.declarations) {
+        registerDeclaration(
+          declarator,
+          declarator,
+          getPatternIdentifierNames(declarator.id)
+        );
       }
-      statement.declarations = statement.declarations.filter(
-        (declarator: AnyNode) => {
-          const names = getPatternIdentifierNames(declarator.id);
-          return Array.from(names).some(
-            name => referenced.has(name) || exported.has(name)
-          );
+      continue;
+    }
+    if (
+      statement.type === 'FunctionDeclaration' ||
+      statement.type === 'ClassDeclaration'
+    ) {
+      registerDeclaration(statement, statement, getDeclaredNames(statement));
+    }
+  }
+
+  return { declarationsByNode, declarationsByName };
+};
+
+const collectLiveTopLevelDeclarations = (
+  program: AnyNode,
+  graph: TopLevelDeclarationGraph
+): Set<TopLevelDeclaration> => {
+  const pendingNames: string[] = [];
+
+  for (const statement of program.body) {
+    if (statement.type === 'VariableDeclaration') {
+      continue;
+    }
+    if (graph.declarationsByNode.has(statement)) {
+      continue;
+    }
+    for (const name of collectReferencedNames(statement)) {
+      pendingNames.push(name);
+    }
+  }
+
+  // This is intentionally name-based and conservative: shadowing may retain a
+  // declaration, but it must never make a live declaration removable.
+  const visitedNames = new Set<string>();
+  const liveDeclarations = new Set<TopLevelDeclaration>();
+  while (pendingNames.length > 0) {
+    const name = pendingNames.pop();
+    if (!name || visitedNames.has(name)) {
+      continue;
+    }
+    visitedNames.add(name);
+    for (const declaration of graph.declarationsByName.get(name) ?? []) {
+      if (!liveDeclarations.has(declaration)) {
+        liveDeclarations.add(declaration);
+        for (const referencedName of declaration.referencedNames) {
+          pendingNames.push(referencedName);
         }
-      );
-      if (statement.declarations.length === 0) {
-        removeFromArray(program.body, statement);
-        changed = true;
       }
     }
   }
+
+  return liveDeclarations;
+};
+
+const removeNewlyDeadTopLevelDeclarations = (
+  program: AnyNode,
+  graph: TopLevelDeclarationGraph,
+  previouslyLive: ReadonlySet<TopLevelDeclaration>
+): void => {
+  const currentlyLive = collectLiveTopLevelDeclarations(program, graph);
+  const isNewlyDead = (node: AnyNode) => {
+    const declaration = graph.declarationsByNode.get(node);
+    return (
+      declaration &&
+      previouslyLive.has(declaration) &&
+      !currentlyLive.has(declaration)
+    );
+  };
+
+  program.body = program.body.filter((statement: AnyNode) => {
+    if (statement.type === 'VariableDeclaration') {
+      statement.declarations = statement.declarations.filter(
+        (declarator: AnyNode) => !isNewlyDead(declarator)
+      );
+      return statement.declarations.length > 0;
+    }
+    return !isNewlyDead(statement);
+  });
 };
 
 export const removeExports = (
@@ -412,7 +490,12 @@ export const removeExports = (
   exportsToRemove: readonly string[]
 ): void => {
   const program = getProgram(ast);
-  let exportsFiltered = false;
+  const declarationGraph = createTopLevelDeclarationGraph(program);
+  const previouslyLive = collectLiveTopLevelDeclarations(
+    program,
+    declarationGraph
+  );
+  let exportsChanged = false;
   const removedExportLocalNames = new Set<string>();
 
   for (const statement of [...program.body]) {
@@ -425,7 +508,7 @@ export const removeExports = (
             }
             const exportedName = getExportedName(specifier);
             if (exportedName && exportsToRemove.includes(exportedName)) {
-              exportsFiltered = true;
+              exportsChanged = true;
               if (specifier.local?.name) {
                 removedExportLocalNames.add(specifier.local.name);
               }
@@ -445,7 +528,7 @@ export const removeExports = (
           (declarator: AnyNode) => {
             if (declarator.id.type === 'Identifier') {
               if (exportsToRemove.includes(declarator.id.name)) {
-                exportsFiltered = true;
+                exportsChanged = true;
                 removedExportLocalNames.add(declarator.id.name);
                 return false;
               }
@@ -467,6 +550,7 @@ export const removeExports = (
         declaration.id?.name &&
         exportsToRemove.includes(declaration.id.name)
       ) {
+        exportsChanged = true;
         removedExportLocalNames.add(declaration.id.name);
         removeFromArray(program.body, statement);
       }
@@ -476,6 +560,7 @@ export const removeExports = (
       statement.type === 'ExportDefaultDeclaration' &&
       exportsToRemove.includes('default')
     ) {
+      exportsChanged = true;
       const declaration = statement.declaration;
       if (declaration?.type === 'Identifier') {
         removedExportLocalNames.add(declaration.name);
@@ -494,15 +579,18 @@ export const removeExports = (
     if (
       left?.type === 'MemberExpression' &&
       left.object?.type === 'Identifier' &&
-      (exportsToRemove.includes(left.object.name) ||
-        removedExportLocalNames.has(left.object.name))
+      removedExportLocalNames.has(left.object.name)
     ) {
       removeFromArray(program.body, statement);
     }
   }
 
-  if (exportsFiltered || removedExportLocalNames.size > 0) {
-    removeUnusedTopLevelDeclarations(program);
+  if (exportsChanged) {
+    removeNewlyDeadTopLevelDeclarations(
+      program,
+      declarationGraph,
+      previouslyLive
+    );
   }
 };
 

--- a/src/plugin-utils.ts
+++ b/src/plugin-utils.ts
@@ -463,10 +463,17 @@ const declarationReferencesName = (
   declaration: TopLevelDeclaration,
   names: ReadonlySet<string>,
   graph: TopLevelDeclarationGraph,
+  cache: Map<TopLevelDeclaration, boolean>,
   visitedNames = new Set<string>()
 ): boolean => {
+  const cached = cache.get(declaration);
+  if (cached !== undefined) {
+    return cached;
+  }
+
   for (const referencedName of declaration.referencedNames) {
     if (names.has(referencedName)) {
+      cache.set(declaration, true);
       return true;
     }
     if (visitedNames.has(referencedName)) {
@@ -481,13 +488,16 @@ const declarationReferencesName = (
           referencedDeclaration,
           names,
           graph,
+          cache,
           visitedNames
         )
       ) {
+        cache.set(declaration, true);
         return true;
       }
     }
   }
+  cache.set(declaration, false);
   return false;
 };
 
@@ -498,6 +508,7 @@ const removeNewlyDeadTopLevelDeclarations = (
   removedExportReferencedNames: ReadonlySet<string>
 ): void => {
   const currentlyLive = collectLiveTopLevelDeclarations(program, graph);
+  const removedReferenceCache = new Map<TopLevelDeclaration, boolean>();
   const isRemovableDeadDeclaration = (node: AnyNode) => {
     const declaration = graph.declarationsByNode.get(node);
     if (!declaration || currentlyLive.has(declaration)) {
@@ -508,7 +519,8 @@ const removeNewlyDeadTopLevelDeclarations = (
       declarationReferencesName(
         declaration,
         removedExportReferencedNames,
-        graph
+        graph,
+        removedReferenceCache
       )
     );
   };

--- a/src/plugin-utils.ts
+++ b/src/plugin-utils.ts
@@ -396,7 +396,7 @@ const createTopLevelDeclarationGraph = (
     }
   };
 
-  for (const statement of program.body) {
+  for (const statement of program.body ?? []) {
     if (statement.type === 'VariableDeclaration') {
       for (const declarator of statement.declarations) {
         registerDeclaration(
@@ -424,7 +424,7 @@ const collectLiveTopLevelDeclarations = (
 ): Set<TopLevelDeclaration> => {
   const pendingNames: string[] = [];
 
-  for (const statement of program.body) {
+  for (const statement of program.body ?? []) {
     if (statement.type === 'VariableDeclaration') {
       continue;
     }
@@ -459,29 +459,68 @@ const collectLiveTopLevelDeclarations = (
   return liveDeclarations;
 };
 
+const declarationReferencesName = (
+  declaration: TopLevelDeclaration,
+  names: ReadonlySet<string>,
+  graph: TopLevelDeclarationGraph,
+  visitedNames = new Set<string>()
+): boolean => {
+  for (const referencedName of declaration.referencedNames) {
+    if (names.has(referencedName)) {
+      return true;
+    }
+    if (visitedNames.has(referencedName)) {
+      continue;
+    }
+    visitedNames.add(referencedName);
+    for (const referencedDeclaration of graph.declarationsByName.get(
+      referencedName
+    ) ?? []) {
+      if (
+        declarationReferencesName(
+          referencedDeclaration,
+          names,
+          graph,
+          visitedNames
+        )
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
 const removeNewlyDeadTopLevelDeclarations = (
   program: AnyNode,
   graph: TopLevelDeclarationGraph,
-  previouslyLive: ReadonlySet<TopLevelDeclaration>
+  previouslyLive: ReadonlySet<TopLevelDeclaration>,
+  removedExportReferencedNames: ReadonlySet<string>
 ): void => {
   const currentlyLive = collectLiveTopLevelDeclarations(program, graph);
-  const isNewlyDead = (node: AnyNode) => {
+  const isRemovableDeadDeclaration = (node: AnyNode) => {
     const declaration = graph.declarationsByNode.get(node);
+    if (!declaration || currentlyLive.has(declaration)) {
+      return false;
+    }
     return (
-      declaration &&
-      previouslyLive.has(declaration) &&
-      !currentlyLive.has(declaration)
+      previouslyLive.has(declaration) ||
+      declarationReferencesName(
+        declaration,
+        removedExportReferencedNames,
+        graph
+      )
     );
   };
 
   program.body = program.body.filter((statement: AnyNode) => {
     if (statement.type === 'VariableDeclaration') {
       statement.declarations = statement.declarations.filter(
-        (declarator: AnyNode) => !isNewlyDead(declarator)
+        (declarator: AnyNode) => !isRemovableDeadDeclaration(declarator)
       );
       return statement.declarations.length > 0;
     }
-    return !isNewlyDead(statement);
+    return !isRemovableDeadDeclaration(statement);
   });
 };
 
@@ -497,6 +536,17 @@ export const removeExports = (
   );
   let exportsChanged = false;
   const removedExportLocalNames = new Set<string>();
+  const removedExportReferencedNames = new Set<string>();
+  const trackRemovedExportReferences = (node: AnyNode | null | undefined) => {
+    if (!node) {
+      return;
+    }
+    const declaration = declarationGraph.declarationsByNode.get(node);
+    for (const name of declaration?.referencedNames ??
+      collectReferencedNames(node)) {
+      removedExportReferencedNames.add(name);
+    }
+  };
 
   for (const statement of [...program.body]) {
     if (statement.type === 'ExportNamedDeclaration') {
@@ -511,6 +561,7 @@ export const removeExports = (
               exportsChanged = true;
               if (specifier.local?.name) {
                 removedExportLocalNames.add(specifier.local.name);
+                removedExportReferencedNames.add(specifier.local.name);
               }
               return false;
             }
@@ -530,6 +581,8 @@ export const removeExports = (
               if (exportsToRemove.includes(declarator.id.name)) {
                 exportsChanged = true;
                 removedExportLocalNames.add(declarator.id.name);
+                removedExportReferencedNames.add(declarator.id.name);
+                trackRemovedExportReferences(declarator);
                 return false;
               }
               return true;
@@ -552,6 +605,8 @@ export const removeExports = (
       ) {
         exportsChanged = true;
         removedExportLocalNames.add(declaration.id.name);
+        removedExportReferencedNames.add(declaration.id.name);
+        trackRemovedExportReferences(statement);
         removeFromArray(program.body, statement);
       }
     }
@@ -564,9 +619,12 @@ export const removeExports = (
       const declaration = statement.declaration;
       if (declaration?.type === 'Identifier') {
         removedExportLocalNames.add(declaration.name);
+        removedExportReferencedNames.add(declaration.name);
       } else if (declaration?.id?.name) {
         removedExportLocalNames.add(declaration.id.name);
+        removedExportReferencedNames.add(declaration.id.name);
       }
+      trackRemovedExportReferences(statement);
       removeFromArray(program.body, statement);
     }
   }
@@ -589,7 +647,8 @@ export const removeExports = (
     removeNewlyDeadTopLevelDeclarations(
       program,
       declarationGraph,
-      previouslyLive
+      previouslyLive,
+      removedExportReferencedNames
     );
   }
 };

--- a/src/route-artifacts.ts
+++ b/src/route-artifacts.ts
@@ -84,7 +84,6 @@ export const createRouteClientEntryArtifact = async ({
   routeChunkConfig,
 }: RouteClientEntryArtifactOptions): Promise<RouteClientEntryArtifact> => {
   const analysis = await getBundlerRouteAnalysis(code, resourcePath);
-  const exportNames = await analysis.getExportNames();
   const isServer = environmentName === 'node';
   const splitRouteModules = routeChunkConfig.splitRouteModules;
   const chunkedExports =
@@ -94,7 +93,7 @@ export const createRouteClientEntryArtifact = async ({
       : [];
   return {
     code: buildRouteClientEntryCode({
-      exportNames,
+      exportNames: analysis.exportNames,
       chunkedExports,
       isServer,
       resourcePath,

--- a/src/route-chunks.ts
+++ b/src/route-chunks.ts
@@ -85,14 +85,11 @@ const invariant: (value: unknown, message: string) => asserts value = (
 };
 
 const getOrSetFromCache = <T>(
-  cache: RouteChunkCache | undefined,
+  cache: RouteChunkCache,
   key: string,
   version: string,
   getValue: () => T
 ): T => {
-  if (!cache) {
-    return getValue();
-  }
   const entry = cache.get(key) as RouteChunkCacheEntry<T> | undefined;
   if (entry?.version === version) {
     return entry.value;
@@ -104,12 +101,14 @@ const getOrSetFromCache = <T>(
 
 type AnalyzedModule = {
   module: Module;
+  // Dependency sets use these node identities. Consumers must shallow-copy
+  // any node whose children they narrow instead of mutating this cached AST.
   program: AnyNode;
 };
 
 const analyzeCode = (
   code: string,
-  cache: RouteChunkCache | undefined,
+  cache: RouteChunkCache,
   cacheKey: string
 ): AnalyzedModule => {
   return getOrSetFromCache(cache, `${cacheKey}::analyzeCode`, code, () => {
@@ -128,12 +127,6 @@ const analyzeCode = (
     return { module, program: module.ast as AnyNode };
   });
 };
-
-const cloneProgram = (
-  code: string,
-  cache: RouteChunkCache | undefined,
-  cacheKey: string
-): AnyNode => structuredClone(analyzeCode(code, cache, cacheKey).program);
 
 type ExportDependencies = {
   topLevelStatements: Set<AnyNode>;
@@ -192,11 +185,6 @@ const getExportedName = (exported: AnyNode): string => {
   return String(exported.value);
 };
 
-const sameNode = (left: AnyNode, right: AnyNode): boolean =>
-  left.type === right.type &&
-  left.start === right.start &&
-  left.end === right.end;
-
 const setsIntersect = <T>(set1: Set<T>, set2: Set<T>) => {
   let smallerSet = set1;
   let largerSet = set2;
@@ -214,7 +202,7 @@ const setsIntersect = <T>(set1: Set<T>, set2: Set<T>) => {
 
 const getExportDependencies = (
   code: string,
-  cache: RouteChunkCache | undefined,
+  cache: RouteChunkCache,
   cacheKey: string
 ): Map<string, ExportDependencies> => {
   return getOrSetFromCache(
@@ -317,7 +305,7 @@ const getExportDependencies = (
 const hasChunkableExport = (
   code: string,
   exportName: string,
-  cache: RouteChunkCache | undefined,
+  cache: RouteChunkCache,
   cacheKey: string
 ) => {
   return getOrSetFromCache(
@@ -390,16 +378,16 @@ const filterImportSpecifiers = (
   if (node.specifiers.length === 0) {
     return node;
   }
-  node.specifiers = node.specifiers.filter((specifier: AnyNode) =>
+  const specifiers = node.specifiers.filter((specifier: AnyNode) =>
     shouldKeep(specifier.local.name)
   );
-  return node.specifiers.length > 0 ? node : null;
+  return specifiers.length > 0 ? { ...node, specifiers } : null;
 };
 
 const getChunkedExport = (
   code: string,
   exportName: string,
-  cache: RouteChunkCache | undefined,
+  cache: RouteChunkCache,
   cacheKey: string
 ): string | undefined => {
   return getOrSetFromCache(
@@ -414,18 +402,9 @@ const getChunkedExport = (
       const dependencies = exportDependencies.get(exportName);
       invariant(dependencies, 'Expected export to have dependencies');
 
-      const topLevelStatementsArray = Array.from(
-        dependencies.topLevelStatements
-      );
-      const exportedVariableDeclaratorsArray = Array.from(
-        dependencies.exportedVariableDeclarators
-      );
-
-      const program = cloneProgram(code, cache, cacheKey);
-      program.body = program.body
-        .filter((node: AnyNode) =>
-          topLevelStatementsArray.some(statement => sameNode(node, statement))
-        )
+      const program = analyzeCode(code, cache, cacheKey).program;
+      const body = program.body
+        .filter((node: AnyNode) => dependencies.topLevelStatements.has(node))
         .map((node: AnyNode) => {
           if (node.type !== 'ImportDeclaration') {
             return node;
@@ -449,13 +428,16 @@ const getChunkedExport = (
           }
           const { declaration } = node;
           if (declaration?.type === 'VariableDeclaration') {
-            declaration.declarations = declaration.declarations.filter(
+            const declarations = declaration.declarations.filter(
               (declarationNode: AnyNode) =>
-                exportedVariableDeclaratorsArray.some(declarator =>
-                  sameNode(declarationNode, declarator)
-                )
+                dependencies.exportedVariableDeclarators.has(declarationNode)
             );
-            return declaration.declarations.length > 0 ? node : null;
+            return declarations.length > 0
+              ? {
+                  ...node,
+                  declaration: { ...declaration, declarations },
+                }
+              : null;
           }
           if (
             declaration?.type === 'FunctionDeclaration' ||
@@ -464,17 +446,17 @@ const getChunkedExport = (
             return declaration.id?.name === exportName ? node : null;
           }
           if (node.type === 'ExportNamedDeclaration') {
-            node.specifiers = node.specifiers.filter(
+            const specifiers = node.specifiers.filter(
               (specifier: AnyNode) =>
                 getExportedName(specifier.exported) === exportName
             );
-            return node.specifiers.length > 0 ? node : null;
+            return specifiers.length > 0 ? { ...node, specifiers } : null;
           }
           throw new Error('Unknown export node type');
         })
         .filter(Boolean) as AnyNode[];
 
-      return generateCode(program);
+      return generateCode({ ...program, body });
     }
   );
 };
@@ -482,7 +464,7 @@ const getChunkedExport = (
 const omitChunkedExports = (
   code: string,
   exportNames: string[],
-  cache: RouteChunkCache | undefined,
+  cache: RouteChunkCache,
   cacheKey: string
 ): string | undefined => {
   return getOrSetFromCache(
@@ -518,16 +500,9 @@ const omitChunkedExports = (
         }
       }
 
-      const omittedStatementsArray = Array.from(omittedStatements);
-      const omittedExportedVariableDeclaratorsArray = Array.from(
-        omittedExportedVariableDeclarators
-      );
-
-      const program = cloneProgram(code, cache, cacheKey);
-      program.body = program.body
-        .filter((node: AnyNode) =>
-          omittedStatementsArray.every(statement => !sameNode(node, statement))
-        )
+      const program = analyzeCode(code, cache, cacheKey).program;
+      const body = program.body
+        .filter((node: AnyNode) => !omittedStatements.has(node))
         .map((node: AnyNode) => {
           if (node.type !== 'ImportDeclaration') {
             return node;
@@ -559,13 +534,16 @@ const omitChunkedExports = (
             return isOmitted('default') ? null : node;
           }
           if (node.declaration?.type === 'VariableDeclaration') {
-            node.declaration.declarations =
-              node.declaration.declarations.filter((declarationNode: AnyNode) =>
-                omittedExportedVariableDeclaratorsArray.every(
-                  declarator => !sameNode(declarationNode, declarator)
-                )
-              );
-            return node.declaration.declarations.length > 0 ? node : null;
+            const declarations = node.declaration.declarations.filter(
+              (declarationNode: AnyNode) =>
+                !omittedExportedVariableDeclarators.has(declarationNode)
+            );
+            return declarations.length > 0
+              ? {
+                  ...node,
+                  declaration: { ...node.declaration, declarations },
+                }
+              : null;
           }
           if (
             node.declaration?.type === 'FunctionDeclaration' ||
@@ -574,17 +552,19 @@ const omitChunkedExports = (
             return isOmitted(node.declaration.id.name) ? null : node;
           }
           if (node.type === 'ExportNamedDeclaration') {
-            node.specifiers = node.specifiers.filter((specifier: AnyNode) => {
+            const specifiers = node.specifiers.filter((specifier: AnyNode) => {
               const exportedName = getExportedName(specifier.exported);
               return !isOmitted(exportedName);
             });
-            return node.specifiers.length > 0 || node.declaration ? node : null;
+            return specifiers.length > 0 || node.declaration
+              ? { ...node, specifiers }
+              : null;
           }
           throw new Error('Unknown node type');
         })
         .filter(Boolean) as AnyNode[];
 
-      return generateCode(program);
+      return generateCode({ ...program, body });
     }
   );
 };
@@ -594,8 +574,9 @@ export const detectRouteChunks = (
   cache: RouteChunkCache | undefined,
   cacheKey: string
 ): RouteChunkInfo => {
+  const analysisCache = cache ?? new Map();
   const hasRouteChunkByExportName = createRouteChunkExportMap(exportName =>
-    hasChunkableExport(code, exportName, cache, cacheKey)
+    hasChunkableExport(code, exportName, analysisCache, cacheKey)
   );
   const chunkedExports = Object.entries(hasRouteChunkByExportName)
     .filter(([, isChunked]) => isChunked)
@@ -619,10 +600,16 @@ export const getRouteChunkCode: (
   cache: RouteChunkCache | undefined,
   cacheKey: string
 ) => {
+  const analysisCache = cache ?? new Map();
   if (chunkName === 'main') {
-    return omitChunkedExports(code, routeChunkExportNames, cache, cacheKey);
+    return omitChunkedExports(
+      code,
+      routeChunkExportNames,
+      analysisCache,
+      cacheKey
+    );
   }
-  return getChunkedExport(code, chunkName, cache, cacheKey);
+  return getChunkedExport(code, chunkName, analysisCache, cacheKey);
 };
 
 export const getRouteChunkModuleId = (

--- a/tests/export-utils.test.ts
+++ b/tests/export-utils.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from '@rstest/core';
 import { parse } from '../src/babel';
-import { getBundlerRouteAnalysis, transformToEsm } from '../src/export-utils';
+import {
+  getBundlerRouteAnalysis,
+  getExportNamesAndExportAll,
+  transformToEsm,
+} from '../src/export-utils';
 
 const routeChunkConfig = {
   splitRouteModules: true as const,
@@ -21,15 +25,12 @@ describe('getBundlerRouteAnalysis', () => {
 
     expect(second).toBe(first);
     expect(second.code).toBe(first.code);
-    expect(second.getExportNames()).toBe(first.getExportNames());
+    expect(second.exportNames).toBe(first.exportNames);
     expect(second.getRouteChunkInfo(undefined, routeChunkConfig)).toBe(
       first.getRouteChunkInfo(undefined, routeChunkConfig)
     );
 
-    expect(await first.getExportNames()).toEqual([
-      'clientAction',
-      'default',
-    ]);
+    expect(first.exportNames).toEqual(['clientAction', 'default']);
     await expect(
       first.getRouteChunkInfo(undefined, routeChunkConfig)
     ).resolves.toMatchObject({
@@ -51,7 +52,51 @@ describe('getBundlerRouteAnalysis', () => {
     );
 
     expect(updated).not.toBe(initial);
-    await expect(updated.getExportNames()).resolves.toEqual(['clientLoader']);
+    expect(updated.exportNames).toEqual(['clientLoader']);
+  });
+
+  it('collects runtime exports and export-all modules from the initial parse', async () => {
+    const analysis = await getBundlerRouteAnalysis(
+      `
+        export type LoaderData = { value: string };
+        export interface RouteHandle { title: string }
+        export type * from './types';
+        export type * as typeHelpers from './type-helpers';
+        export * from './shared';
+        export * as helpers from './helpers';
+        export const loader = () => null;
+        export default function Route() { return null; }
+      `,
+      '/app/routes/runtime-exports.tsx'
+    );
+
+    const exportInfo = {
+      exportNames: analysis.exportNames,
+      exportAllModules: analysis.exportAllModules,
+    };
+    expect(exportInfo).toEqual({
+      exportNames: ['helpers', 'loader', 'default'],
+      exportAllModules: ['./shared'],
+    });
+    await expect(getExportNamesAndExportAll(analysis.code)).resolves.toEqual(
+      exportInfo
+    );
+  });
+
+  it('does not report an erased default interface as a runtime export', async () => {
+    const analysis = await getBundlerRouteAnalysis(
+      `export default interface RouteType { value: string }`,
+      '/app/routes/type-only-default.tsx'
+    );
+    const exportInfo = {
+      exportNames: analysis.exportNames,
+      exportAllModules: analysis.exportAllModules,
+    };
+
+    expect(exportInfo).toEqual({ exportNames: [], exportAllModules: [] });
+    await expect(getExportNamesAndExportAll(analysis.code)).resolves.toEqual(
+      exportInfo
+    );
   });
 });
 

--- a/tests/export-utils.test.ts
+++ b/tests/export-utils.test.ts
@@ -98,6 +98,30 @@ describe('getBundlerRouteAnalysis', () => {
       exportInfo
     );
   });
+
+  it('does not report erased ambient declarations as runtime exports', async () => {
+    const analysis = await getBundlerRouteAnalysis(
+      `
+        export declare function loader(): void;
+        export declare const action: () => void;
+        export declare class ServerOnly {}
+        export const clientLoader = () => null;
+      `,
+      '/app/routes/ambient-exports.tsx'
+    );
+    const exportInfo = {
+      exportNames: analysis.exportNames,
+      exportAllModules: analysis.exportAllModules,
+    };
+
+    expect(exportInfo).toEqual({
+      exportNames: ['clientLoader'],
+      exportAllModules: [],
+    });
+    await expect(getExportNamesAndExportAll(analysis.code)).resolves.toEqual(
+      exportInfo
+    );
+  });
 });
 
 describe('transformToEsm', () => {

--- a/tests/remove-exports.test.ts
+++ b/tests/remove-exports.test.ts
@@ -230,6 +230,30 @@ describe('removeExports', () => {
     expect(result).toContain('Route');
   });
 
+  it('removes multiple pre-existing unused declarations through shared removed export dependencies', () => {
+    const code = `
+      const shared = () => loader();
+      const first = () => shared();
+      const second = () => shared();
+      export function loader() {
+        return null;
+      }
+      export default function Route() {
+        return null;
+      }
+    `;
+
+    const ast = parse(code, { sourceType: 'module' });
+    removeExports(ast, ['loader']);
+
+    const result = generate(ast).code;
+    expect(result).not.toContain('shared');
+    expect(result).not.toContain('first');
+    expect(result).not.toContain('second');
+    expect(result).not.toContain('loader');
+    expect(result).toContain('Route');
+  });
+
   it('does not treat an exported alias as a reference to its exported name', () => {
     const code = `
       const loader = register();

--- a/tests/remove-exports.test.ts
+++ b/tests/remove-exports.test.ts
@@ -187,6 +187,49 @@ describe('removeExports', () => {
     expect(result).not.toContain('loader');
   });
 
+  it('removes pre-existing unused declarations that reference removed export locals', () => {
+    const code = `
+      const leaked = loader;
+      export function loader() {
+        return null;
+      }
+      export default function Route() {
+        return null;
+      }
+    `;
+
+    const ast = parse(code, { sourceType: 'module' });
+    removeExports(ast, ['loader']);
+
+    const result = generate(ast).code;
+    expect(result).not.toContain('leaked');
+    expect(result).not.toContain('loader');
+    expect(result).toContain('Route');
+  });
+
+  it('removes pre-existing unused declarations that retain server-only imports', () => {
+    const code = `
+      import { readSecret } from './data.server';
+      const leaked = readSecret();
+      export function loader() {
+        return readSecret();
+      }
+      export default function Route() {
+        return null;
+      }
+    `;
+
+    const ast = parse(code, { sourceType: 'module' });
+    removeExports(ast, ['loader']);
+    removeUnusedImports(ast);
+
+    const result = generate(ast).code;
+    expect(result).not.toContain('./data.server');
+    expect(result).not.toContain('leaked');
+    expect(result).not.toContain('readSecret');
+    expect(result).toContain('Route');
+  });
+
   it('does not treat an exported alias as a reference to its exported name', () => {
     const code = `
       const loader = register();

--- a/tests/remove-exports.test.ts
+++ b/tests/remove-exports.test.ts
@@ -74,6 +74,27 @@ describe('removeExports', () => {
     expect(hasThemeImport).toBe(false);
   });
 
+  it('does not treat imported names as local references', () => {
+    const code = `
+      import {
+        loaderDependency as dependency,
+        unrelated as loaderDependency,
+      } from './data.server';
+      export function loader() {
+        return dependency();
+      }
+      export default function Route() {
+        return null;
+      }
+    `;
+
+    const ast = parse(code, { sourceType: 'module' });
+    removeExports(ast, ['loader']);
+    removeUnusedImports(ast);
+
+    expect(generate(ast).code).not.toContain('./data.server');
+  });
+
   it('keeps top-level declarations referenced from JSX after removing exports', () => {
     const code = `
       export function loader() {
@@ -96,5 +117,124 @@ describe('removeExports', () => {
 
     expect(result).toContain('function ProgressBar');
     expect(result).toContain('<ProgressBar');
+  });
+
+  it('removes cascading dead declarators from the same statement', () => {
+    const code = `
+      const leaf = 1, middle = leaf;
+      export function loader() {
+        return middle;
+      }
+      export default function Route() {
+        return null;
+      }
+    `;
+
+    const ast = parse(code, { sourceType: 'module' });
+    removeExports(ast, ['loader']);
+
+    const result = generate(ast).code;
+    expect(result).not.toContain('leaf');
+    expect(result).not.toContain('middle');
+    expect(result).not.toContain('loader');
+    expect(result).toContain('Route');
+  });
+
+  it('removes every declaration in a deep dead dependency chain', () => {
+    const helperCount = 64;
+    const helpers = Array.from({ length: helperCount }, (_, index) => {
+      const value =
+        index === helperCount - 1 ? '1' : `helper${index + 1}()`;
+      return `const helper${index} = () => ${value};`;
+    }).join('\n');
+    const code = `
+      ${helpers}
+      export function loader() {
+        return helper0();
+      }
+      export default function Route() {
+        return null;
+      }
+    `;
+
+    const ast = parse(code, { sourceType: 'module' });
+    removeExports(ast, ['loader']);
+
+    const result = generate(ast).code;
+    expect(result).not.toMatch(/\bhelper\d+\b/);
+    expect(result).toContain('Route');
+  });
+
+  it('preserves declarations that were already unused before export removal', () => {
+    const code = `
+      import { register } from './registry';
+      const registration = register();
+      export function loader() {
+        return null;
+      }
+      export default function Route() {
+        return null;
+      }
+    `;
+
+    const ast = parse(code, { sourceType: 'module' });
+    removeExports(ast, ['loader']);
+    removeUnusedImports(ast);
+
+    const result = generate(ast).code;
+    expect(result).toContain("import { register } from './registry'");
+    expect(result).toContain('const registration = register()');
+    expect(result).not.toContain('loader');
+  });
+
+  it('does not treat an exported alias as a reference to its exported name', () => {
+    const code = `
+      const loader = register();
+      const implementation = () => null;
+      export { implementation as loader };
+      export default function Route() {
+        return null;
+      }
+    `;
+
+    const ast = parse(code, { sourceType: 'module' });
+    removeExports(ast, ['loader']);
+
+    const result = generate(ast).code;
+    expect(result).toContain('const loader = register()');
+    expect(result).not.toContain('implementation');
+  });
+
+  it('removes a dead declaration cycle reached only by a removed export', () => {
+    const code = `
+      const first = () => second();
+      const second = () => first();
+      export function loader() {
+        return first();
+      }
+      export default function Route() {
+        return null;
+      }
+    `;
+
+    const ast = parse(code, { sourceType: 'module' });
+    removeExports(ast, ['loader']);
+
+    const result = generate(ast).code;
+    expect(result).not.toContain('first');
+    expect(result).not.toContain('second');
+    expect(result).toContain('Route');
+  });
+
+  it('removes dependencies of an anonymous default export', () => {
+    const code = `
+      const render = () => null;
+      export default () => render();
+    `;
+
+    const ast = parse(code, { sourceType: 'module' });
+    removeExports(ast, ['default']);
+
+    expect(generate(ast).code).not.toContain('render');
   });
 });


### PR DESCRIPTION
## Summary
- Reuse transformed route module metadata so route analysis does less duplicate work.
- Reduce route chunk overhead by caching export info, memoizing removed-export dependency cleanup, and tightening chunk traversal.
- Add coverage for type-only exports, export-star behavior, removed export dependency cleanup, and benchmark harness compatibility.

## Verification
- `pnpm test:core tests/remove-exports.test.ts` — 1 file, 14 tests passed
- `pnpm test:core` — 22 files, 165 tests passed
- `pnpm build` — passed

## Benchmark
Command:

```bash
pnpm bench:micro --routes 256 --iterations 50 --warmup 5 --variant ssr-esm-split --fixture default --environment both --cache cold --format json
```

Comparison: `origin/perf/bundling-performance` baseline vs this PR on the same machine.

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| transform/export-info mean | 0.075ms | 0.060ms | -20.4% |
| transform/export-info p95 | 0.106ms | 0.109ms | 2.6% |
| route-chunk-info mean | 0.078ms | 0.032ms | -58.5% |
| filter/codegen-string mean | 0.003ms | 0.002ms | -12.7% |
| total per-route mean | 0.155ms | 0.094ms | -39.4% |
| iteration wall mean | 81.515ms | 50.029ms | -38.6% |
| route executions | 25,600 | 25,600 | 0.0% |
| export names scanned | 154,000 | 154,000 | 0.0% |
| generated reexports | 119,700 | 119,700 | 0.0% |