### PR TITLE
fix: restart dev server for route entry changes

### DIFF
--- a/examples/default-template/playwright.config.ts
+++ b/examples/default-template/playwright.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
   },
   // Run tests in files in parallel
   fullyParallel: false,
+  // This suite includes dev-route-watch, which mutates routes.ts and restarts
+  // the shared dev server. Keep this example serial so other tests do not race
+  // the intentional restart.
+  workers: 1,
   // Fail the build on CI if you accidentally left test.only in the source code
   forbidOnly: !!process.env.CI,
   // Retry on CI only
@@ -47,4 +51,4 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     timeout: 120000,
   },
-}); 
+});

--- a/examples/default-template/tests/e2e/dev-route-watch.test.ts
+++ b/examples/default-template/tests/e2e/dev-route-watch.test.ts
@@ -41,6 +41,25 @@ const readRestartMarker = (): string | null =>
     ? readFileSync(restartMarkerPath, 'utf8')
     : null;
 
+const expectRestartMarkerStable = async (
+  expectedMarker: string | null,
+  quietMs = 750
+) => {
+  const startedAt = Date.now();
+  await expect
+    .poll(
+      () => {
+        const marker = readRestartMarker();
+        if (marker !== expectedMarker) {
+          return `changed:${marker ?? 'missing'}`;
+        }
+        return Date.now() - startedAt >= quietMs ? 'stable' : 'waiting';
+      },
+      { intervals: [100], timeout: quietMs + 1000 }
+    )
+    .toBe('stable');
+};
+
 const waitForRouteText = async (
   page: Page,
   url: string,
@@ -127,6 +146,6 @@ test.describe('dev route watch', () => {
     );
 
     await waitForRouteText(page, addedRouteUrl, editedAddedRouteText);
-    expect(readRestartMarker()).toBe(restartMarkerBefore);
+    await expectRestartMarkerStable(restartMarkerBefore);
   });
 });

--- a/examples/default-template/tests/e2e/dev-route-watch.test.ts
+++ b/examples/default-template/tests/e2e/dev-route-watch.test.ts
@@ -7,7 +7,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const appDirectory = join(__dirname, '../../app');
 const restartMarkerPath = join(
   __dirname,
-  '../../.react-router/route-watch'
+  '../../build/client/.react-router/route-watch'
 );
 const routesConfigPath = join(appDirectory, 'routes.ts');
 const addedRoutePath = join(appDirectory, 'routes/dev-added-route.tsx');

--- a/examples/default-template/tests/e2e/dev-route-watch.test.ts
+++ b/examples/default-template/tests/e2e/dev-route-watch.test.ts
@@ -1,37 +1,96 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const appDirectory = join(__dirname, '../../app');
+const restartMarkerPath = join(
+  __dirname,
+  '../../.react-router/route-watch'
+);
 const routesConfigPath = join(appDirectory, 'routes.ts');
 const addedRoutePath = join(appDirectory, 'routes/dev-added-route.tsx');
 const addedRouteUrl = '/dev-added-route';
 const addedRouteText = 'Route added while dev server is running';
+const editedAddedRouteText = 'Route edited without dev server restart';
 const addedRouteConfigEntry = `  route('dev-added-route', 'routes/dev-added-route.tsx'),`;
 
-const cleanupAddedRoute = () => {
-  if (existsSync(addedRoutePath)) {
-    rmSync(addedRoutePath, { force: true });
-  }
-
+const removeAddedRouteConfig = (): boolean => {
   const routesConfig = readFileSync(routesConfigPath, 'utf8');
   if (routesConfig.includes(addedRouteConfigEntry)) {
     writeFileSync(
       routesConfigPath,
       routesConfig.replace(`${addedRouteConfigEntry}\n\n`, '')
     );
+    return true;
   }
+  return false;
+};
+
+const removeAddedRouteFile = (): boolean => {
+  if (existsSync(addedRoutePath)) {
+    rmSync(addedRoutePath, { force: true });
+    return true;
+  }
+  return false;
+};
+
+const readRestartMarker = (): string | null =>
+  existsSync(restartMarkerPath)
+    ? readFileSync(restartMarkerPath, 'utf8')
+    : null;
+
+const waitForRouteText = async (
+  page: Page,
+  url: string,
+  text: string
+) => {
+  await expect
+    .poll(
+      async () => {
+        try {
+          const response = await page.request.get(url, {
+            timeout: 2000,
+          });
+          if (!response.ok()) {
+            return `status:${response.status()}`;
+          }
+          const body = await response.text();
+          return body.includes(text) ? 'ready' : 'missing-text';
+        } catch (error) {
+          return error instanceof Error ? error.message : String(error);
+        }
+      },
+      { timeout: 60000 }
+    )
+    .toBe('ready');
 };
 
 test.describe('dev route watch', () => {
   test.setTimeout(90000);
 
-  test.beforeEach(cleanupAddedRoute);
-  test.afterEach(cleanupAddedRoute);
+  test.beforeEach(async ({ page }) => {
+    if (removeAddedRouteConfig()) {
+      await waitForRouteText(page, '/', 'Welcome to React Router');
+    }
+    if (removeAddedRouteFile()) {
+      await waitForRouteText(page, '/', 'Welcome to React Router');
+    }
+  });
 
-  test('serves a route added after the dev server starts', async ({ page }) => {
+  test.afterEach(async ({ page }) => {
+    if (removeAddedRouteConfig()) {
+      await waitForRouteText(page, '/', 'Welcome to React Router');
+    }
+    if (removeAddedRouteFile()) {
+      await waitForRouteText(page, '/', 'Welcome to React Router');
+    }
+  });
+
+  test('serves a route added after the dev server starts without restarting on later edits', async ({
+    page,
+  }) => {
     await page.goto('/');
     await expect(page.locator('h1')).toContainText('Welcome to React Router');
 
@@ -52,27 +111,22 @@ test.describe('dev route watch', () => {
       )
     );
 
-    await expect
-      .poll(
-        async () => {
-          try {
-            const response = await page.request.get(addedRouteUrl, {
-              timeout: 2000,
-            });
-            if (!response.ok()) {
-              return `status:${response.status()}`;
-            }
-            const body = await response.text();
-            return body.includes(addedRouteText) ? 'ready' : 'missing-text';
-          } catch (error) {
-            return error instanceof Error ? error.message : String(error);
-          }
-        },
-        { timeout: 60000 }
-      )
-      .toBe('ready');
+    await waitForRouteText(page, addedRouteUrl, addedRouteText);
 
     await page.goto(addedRouteUrl);
     await expect(page.locator('h1')).toHaveText(addedRouteText);
+
+    await expect.poll(readRestartMarker, { timeout: 10000 }).not.toBe(null);
+    const restartMarkerBefore = readRestartMarker();
+    writeFileSync(
+      addedRoutePath,
+      `export default function DevAddedRoute() {
+  return <h1>${editedAddedRouteText}</h1>;
+}
+`
+    );
+
+    await waitForRouteText(page, addedRouteUrl, editedAddedRouteText);
+    expect(readRestartMarker()).toBe(restartMarkerBefore);
   });
 });

--- a/examples/default-template/tests/e2e/dev-route-watch.test.ts
+++ b/examples/default-template/tests/e2e/dev-route-watch.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const appDirectory = join(__dirname, '../../app');
+const routesConfigPath = join(appDirectory, 'routes.ts');
+const addedRoutePath = join(appDirectory, 'routes/dev-added-route.tsx');
+const addedRouteUrl = '/dev-added-route';
+const addedRouteText = 'Route added while dev server is running';
+const addedRouteConfigEntry = `  route('dev-added-route', 'routes/dev-added-route.tsx'),`;
+
+const cleanupAddedRoute = () => {
+  if (existsSync(addedRoutePath)) {
+    rmSync(addedRoutePath, { force: true });
+  }
+
+  const routesConfig = readFileSync(routesConfigPath, 'utf8');
+  if (routesConfig.includes(addedRouteConfigEntry)) {
+    writeFileSync(
+      routesConfigPath,
+      routesConfig.replace(`${addedRouteConfigEntry}\n\n`, '')
+    );
+  }
+};
+
+test.describe('dev route watch', () => {
+  test.setTimeout(90000);
+
+  test.beforeEach(cleanupAddedRoute);
+  test.afterEach(cleanupAddedRoute);
+
+  test('serves a route added after the dev server starts', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('h1')).toContainText('Welcome to React Router');
+
+    writeFileSync(
+      addedRoutePath,
+      `export default function DevAddedRoute() {
+  return <h1>${addedRouteText}</h1>;
+}
+`
+    );
+
+    const routesConfig = readFileSync(routesConfigPath, 'utf8');
+    writeFileSync(
+      routesConfigPath,
+      routesConfig.replace(
+        '  // Docs section with nested routes',
+        `${addedRouteConfigEntry}\n\n  // Docs section with nested routes`
+      )
+    );
+
+    await expect
+      .poll(
+        async () => {
+          try {
+            const response = await page.request.get(addedRouteUrl, {
+              timeout: 2000,
+            });
+            if (!response.ok()) {
+              return `status:${response.status()}`;
+            }
+            const body = await response.text();
+            return body.includes(addedRouteText) ? 'ready' : 'missing-text';
+          } catch (error) {
+            return error instanceof Error ? error.message : String(error);
+          }
+        },
+        { timeout: 60000 }
+      )
+      .toBe('ready');
+
+    await page.goto(addedRouteUrl);
+    await expect(page.locator('h1')).toHaveText(addedRouteText);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,11 @@
-import { existsSync, readFileSync, statSync } from 'node:fs';
-import { mkdir, writeFile } from 'node:fs/promises';
+import {
+  existsSync,
+  readFileSync,
+  statSync,
+  watch,
+  type FSWatcher,
+} from 'node:fs';
+import { mkdir, readdir, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
 import fsExtra from 'fs-extra';
@@ -111,6 +117,157 @@ const mergeWatchFiles = (
     ...(Array.isArray(existing) ? existing : [existing]),
     ...additions,
   ] as WatchFilesConfig;
+};
+
+type RouteDirectoryState = {
+  directories: Set<string>;
+  files: Set<string>;
+};
+
+const isRouteModuleFile = (filePath: string): boolean =>
+  JS_EXTENSIONS.some(extension => filePath.endsWith(extension));
+
+const areSetsEqual = <T>(left: Set<T>, right: Set<T>): boolean => {
+  if (left.size !== right.size) {
+    return false;
+  }
+  for (const value of left) {
+    if (!right.has(value)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const readRouteDirectoryState = async (
+  routesDirectory: string
+): Promise<RouteDirectoryState> => {
+  const state: RouteDirectoryState = {
+    directories: new Set(),
+    files: new Set(),
+  };
+
+  const walkDirectory = async (directory: string): Promise<void> => {
+    let entries;
+    try {
+      entries = await readdir(directory, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    state.directories.add(directory);
+    await Promise.all(
+      entries.map(async entry => {
+        const entryPath = resolve(directory, entry.name);
+        if (entry.isDirectory()) {
+          await walkDirectory(entryPath);
+          return;
+        }
+        if (entry.isFile() && isRouteModuleFile(entryPath)) {
+          state.files.add(entryPath);
+        }
+      })
+    );
+  };
+
+  await walkDirectory(routesDirectory);
+  return state;
+};
+
+const createRouteFileSetWatcher = async ({
+  routesDirectory,
+  restartMarkerPath,
+  onError,
+}: {
+  routesDirectory: string;
+  restartMarkerPath: string;
+  onError: (error: unknown) => void;
+}): Promise<() => void> => {
+  let state = await readRouteDirectoryState(routesDirectory);
+  let closed = false;
+  let rescanTimer: ReturnType<typeof setTimeout> | undefined;
+  const directoryWatchers = new Map<string, FSWatcher>();
+
+  const touchRestartMarker = async (): Promise<void> => {
+    await mkdir(dirname(restartMarkerPath), { recursive: true });
+    await writeFile(restartMarkerPath, String(Date.now()));
+  };
+
+  const closeRemovedDirectoryWatchers = (
+    nextDirectories: Set<string>
+  ): void => {
+    for (const [directory, watcher] of directoryWatchers) {
+      if (!nextDirectories.has(directory)) {
+        watcher.close();
+        directoryWatchers.delete(directory);
+      }
+    }
+  };
+
+  const watchNewDirectories = (nextDirectories: Set<string>): void => {
+    for (const directory of nextDirectories) {
+      if (directoryWatchers.has(directory)) {
+        continue;
+      }
+      try {
+        const watcher = watch(directory, (eventType: string) => {
+          if (eventType === 'rename') {
+            scheduleRescan();
+          }
+        });
+        watcher.on('error', onError);
+        directoryWatchers.set(directory, watcher);
+      } catch (error) {
+        onError(error);
+      }
+    }
+  };
+
+  const syncDirectoryWatchers = (nextDirectories: Set<string>): void => {
+    closeRemovedDirectoryWatchers(nextDirectories);
+    watchNewDirectories(nextDirectories);
+  };
+
+  const rescan = async (): Promise<void> => {
+    if (closed) {
+      return;
+    }
+    try {
+      const nextState = await readRouteDirectoryState(routesDirectory);
+      syncDirectoryWatchers(nextState.directories);
+      if (!areSetsEqual(state.files, nextState.files)) {
+        state = nextState;
+        await touchRestartMarker();
+        return;
+      }
+      state = nextState;
+    } catch (error) {
+      onError(error);
+    }
+  };
+
+  const scheduleRescan = (): void => {
+    if (rescanTimer) {
+      clearTimeout(rescanTimer);
+    }
+    rescanTimer = setTimeout(() => {
+      rescanTimer = undefined;
+      void rescan();
+    }, 100);
+  };
+
+  syncDirectoryWatchers(state.directories);
+
+  return () => {
+    closed = true;
+    if (rescanTimer) {
+      clearTimeout(rescanTimer);
+    }
+    for (const watcher of directoryWatchers.values()) {
+      watcher.close();
+    }
+    directoryWatchers.clear();
+  };
 };
 
 const ensureFederationAsyncStartup = (
@@ -436,16 +593,41 @@ export const pluginReactRouter = (
       isBuild,
       cache: routeChunkCache,
     };
+    const routesDirectory = resolve(appDirectory, 'routes');
+    const routeRestartMarkerPath = resolve(
+      buildDirectory,
+      '.react-router-route-watch'
+    );
     const routeWatchFiles: WatchFileConfig[] = [
       {
         paths: routesPath,
         type: 'reload-server',
       },
       {
-        paths: resolve(appDirectory, 'routes'),
+        paths: routeRestartMarkerPath,
         type: 'reload-server',
       },
     ];
+    let closeRouteFileSetWatcher: (() => void) | undefined;
+
+    api.onBeforeStartDevServer(async () => {
+      await mkdir(dirname(routeRestartMarkerPath), { recursive: true });
+      await writeFile(routeRestartMarkerPath, String(Date.now()));
+      closeRouteFileSetWatcher = await createRouteFileSetWatcher({
+        routesDirectory,
+        restartMarkerPath: routeRestartMarkerPath,
+        onError: error => {
+          api.logger.warn(
+            `[${PLUGIN_NAME}] Failed to watch route file set changes: ${error}`
+          );
+        },
+      });
+    });
+
+    api.onCloseDevServer(() => {
+      closeRouteFileSetWatcher?.();
+      closeRouteFileSetWatcher = undefined;
+    });
 
     type ReactRouterManifest = Awaited<
       ReturnType<typeof getReactRouterManifestForDev>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,11 @@
-import {
-  existsSync,
-  readFileSync,
-  statSync,
-  watch,
-  type FSWatcher,
-} from 'node:fs';
-import { mkdir, readdir, writeFile } from 'node:fs/promises';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
 import fsExtra from 'fs-extra';
 import type { Config } from './react-router-config.js';
 import type { RouteConfigEntry } from '@react-router/dev/routes';
-import {
-  rspack,
-  type RsbuildConfig,
-  type RsbuildPlugin,
-  type Rspack,
-} from '@rsbuild/core';
+import { rspack, type RsbuildPlugin, type Rspack } from '@rsbuild/core';
 import { createJiti } from 'jiti';
 import jsesc from 'jsesc';
 import { basename as pathBasename, dirname, relative, resolve } from 'pathe';
@@ -78,8 +67,13 @@ import {
   createRouteClientEntryArtifact,
 } from './route-artifacts.js';
 import {
+  createRouteTopologyWatcher,
   createRouteManifestSnapshot,
-  ensureRestartMarker,
+  emitRouteRestartMarkerAsset,
+  ensureDevRestartMarker,
+  getRouteRestartMarkerPath,
+  mergeWatchFiles,
+  type WatchFileConfig,
 } from './route-watch.js';
 import { validateRouteConfig } from './route-config.js';
 import {
@@ -101,186 +95,6 @@ type ModuleFederationPluginLike = {
   name?: string;
   _options?: { experiments?: { asyncStartup?: boolean } };
   options?: { experiments?: { asyncStartup?: boolean } };
-};
-
-type WatchFilesConfig = NonNullable<
-  NonNullable<RsbuildConfig['dev']>['watchFiles']
->;
-type WatchFileConfig =
-  | Exclude<WatchFilesConfig, readonly unknown[]>
-  | Extract<WatchFilesConfig, readonly unknown[]>[number];
-
-const mergeWatchFiles = (
-  existing: WatchFilesConfig | undefined,
-  additions: WatchFileConfig[]
-): WatchFilesConfig => {
-  if (!existing) {
-    return additions as WatchFilesConfig;
-  }
-  return [
-    ...(Array.isArray(existing) ? existing : [existing]),
-    ...additions,
-  ] as WatchFilesConfig;
-};
-
-type RouteDirectoryState = {
-  directories: Set<string>;
-  routeTopology: Set<string>;
-};
-
-const areSetsEqual = <T>(left: Set<T>, right: Set<T>): boolean => {
-  if (left.size !== right.size) {
-    return false;
-  }
-  for (const value of left) {
-    if (!right.has(value)) {
-      return false;
-    }
-  }
-  return true;
-};
-
-const readRouteDirectoryState = async ({
-  watchDirectory,
-  getRouteTopology,
-}: {
-  watchDirectory: string;
-  getRouteTopology: () => Promise<Set<string>>;
-}): Promise<RouteDirectoryState> => {
-  const directories = new Set<string>();
-
-  const walkDirectory = async (directory: string): Promise<void> => {
-    let entries;
-    try {
-      entries = await readdir(directory, { withFileTypes: true });
-    } catch {
-      return;
-    }
-
-    directories.add(directory);
-    await Promise.all(
-      entries.map(async entry => {
-        const entryPath = resolve(directory, entry.name);
-        if (entry.isDirectory()) {
-          await walkDirectory(entryPath);
-        }
-      })
-    );
-  };
-
-  await walkDirectory(watchDirectory);
-  return {
-    directories,
-    routeTopology: await getRouteTopology(),
-  };
-};
-
-const createRouteTopologyWatcher = async ({
-  watchDirectory,
-  getRouteTopology,
-  restartMarkerPath,
-  onError,
-}: {
-  watchDirectory: string;
-  getRouteTopology: () => Promise<Set<string>>;
-  restartMarkerPath: string;
-  onError: (error: unknown) => void;
-}): Promise<() => void> => {
-  let state = await readRouteDirectoryState({
-    watchDirectory,
-    getRouteTopology,
-  });
-  let closed = false;
-  let rescanTimer: ReturnType<typeof setTimeout> | undefined;
-  let rescanQueue = Promise.resolve();
-  const directoryWatchers = new Map<string, FSWatcher>();
-
-  const touchRestartMarker = async (): Promise<void> => {
-    await mkdir(dirname(restartMarkerPath), { recursive: true });
-    await writeFile(restartMarkerPath, String(Date.now()));
-  };
-
-  const closeRemovedDirectoryWatchers = (
-    nextDirectories: Set<string>
-  ): void => {
-    for (const [directory, watcher] of directoryWatchers) {
-      if (!nextDirectories.has(directory)) {
-        watcher.close();
-        directoryWatchers.delete(directory);
-      }
-    }
-  };
-
-  const watchNewDirectories = (nextDirectories: Set<string>): void => {
-    for (const directory of nextDirectories) {
-      if (directoryWatchers.has(directory)) {
-        continue;
-      }
-      try {
-        const watcher = watch(directory, () => {
-          scheduleRescan();
-        });
-        watcher.on('error', onError);
-        directoryWatchers.set(directory, watcher);
-      } catch (error) {
-        onError(error);
-      }
-    }
-  };
-
-  const syncDirectoryWatchers = (nextDirectories: Set<string>): void => {
-    closeRemovedDirectoryWatchers(nextDirectories);
-    watchNewDirectories(nextDirectories);
-  };
-
-  const runRescan = async (): Promise<void> => {
-    if (closed) {
-      return;
-    }
-    try {
-      const nextState = await readRouteDirectoryState({
-        watchDirectory,
-        getRouteTopology,
-      });
-      syncDirectoryWatchers(nextState.directories);
-      if (!areSetsEqual(state.routeTopology, nextState.routeTopology)) {
-        state = nextState;
-        await touchRestartMarker();
-        return;
-      }
-      state = nextState;
-    } catch (error) {
-      onError(error);
-    }
-  };
-
-  const rescan = (): Promise<void> => {
-    rescanQueue = rescanQueue.then(runRescan, runRescan);
-    return rescanQueue;
-  };
-
-  const scheduleRescan = (): void => {
-    if (rescanTimer) {
-      clearTimeout(rescanTimer);
-    }
-    rescanTimer = setTimeout(() => {
-      rescanTimer = undefined;
-      void rescan();
-    }, 100);
-  };
-
-  syncDirectoryWatchers(state.directories);
-
-  return () => {
-    closed = true;
-    if (rescanTimer) {
-      clearTimeout(rescanTimer);
-    }
-    for (const watcher of directoryWatchers.values()) {
-      watcher.close();
-    }
-    directoryWatchers.clear();
-  };
 };
 
 const ensureFederationAsyncStartup = (
@@ -619,8 +433,10 @@ export const pluginReactRouter = (
       isBuild,
       cache: routeChunkCache,
     };
+    const outputClientPath = resolve(buildDirectory, 'client');
+    const assetsBuildDirectory = relative(process.cwd(), outputClientPath);
     const watchDirectory = resolve(appDirectory);
-    const routeRestartMarkerPath = resolve('.react-router', 'route-watch');
+    const routeRestartMarkerPath = getRouteRestartMarkerPath(outputClientPath);
     const routeWatchFiles: WatchFileConfig[] = [
       {
         paths: routesPath,
@@ -634,7 +450,7 @@ export const pluginReactRouter = (
     let closeRouteTopologyWatcher: (() => void) | undefined;
 
     api.onBeforeStartDevServer(async () => {
-      await ensureRestartMarker(routeRestartMarkerPath);
+      await ensureDevRestartMarker(routeRestartMarkerPath);
       closeRouteTopologyWatcher = await createRouteTopologyWatcher({
         watchDirectory,
         getRouteTopology: getWatchedRouteTopology,
@@ -705,9 +521,6 @@ export const pluginReactRouter = (
       rootDirectory: process.cwd(),
     });
     const routesByServerBundleId = getRoutesByServerBundleId(buildManifest);
-
-    const outputClientPath = resolve(buildDirectory, 'client');
-    const assetsBuildDirectory = relative(process.cwd(), outputClientPath);
 
     let clientStats: ReactRouterManifestStats | undefined;
     api.onAfterEnvironmentCompile(({ stats, environment }) => {
@@ -1573,6 +1386,19 @@ export const pluginReactRouter = (
         });
       }
     );
+
+    if (isBuild) {
+      api.processAssets(
+        { stage: 'additional', targets: ['web'] },
+        ({ sources, compilation }) => {
+          emitRouteRestartMarkerAsset({
+            restartMarkerPath: routeRestartMarkerPath,
+            sources,
+            compilation,
+          });
+        }
+      );
+    }
 
     api.processAssets(
       { stage: 'additional', targets: ['node'] },

--- a/src/index.ts
+++ b/src/index.ts
@@ -442,7 +442,7 @@ export const pluginReactRouter = (
         type: 'reload-server',
       },
       {
-        paths: resolve(appDirectory, 'routes/**/*'),
+        paths: resolve(appDirectory, 'routes'),
         type: 'reload-server',
       },
     ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,12 @@ import { pathToFileURL } from 'node:url';
 import fsExtra from 'fs-extra';
 import type { Config } from './react-router-config.js';
 import type { RouteConfigEntry } from '@react-router/dev/routes';
-import { rspack, type RsbuildPlugin, type Rspack } from '@rsbuild/core';
+import {
+  rspack,
+  type RsbuildConfig,
+  type RsbuildPlugin,
+  type Rspack,
+} from '@rsbuild/core';
 import { createJiti } from 'jiti';
 import jsesc from 'jsesc';
 import { basename as pathBasename, dirname, relative, resolve } from 'pathe';
@@ -86,6 +91,26 @@ type ModuleFederationPluginLike = {
   name?: string;
   _options?: { experiments?: { asyncStartup?: boolean } };
   options?: { experiments?: { asyncStartup?: boolean } };
+};
+
+type WatchFilesConfig = NonNullable<
+  NonNullable<RsbuildConfig['dev']>['watchFiles']
+>;
+type WatchFileConfig =
+  | Exclude<WatchFilesConfig, readonly unknown[]>
+  | Extract<WatchFilesConfig, readonly unknown[]>[number];
+
+const mergeWatchFiles = (
+  existing: WatchFilesConfig | undefined,
+  additions: WatchFileConfig[]
+): WatchFilesConfig => {
+  if (!existing) {
+    return additions as WatchFilesConfig;
+  }
+  return [
+    ...(Array.isArray(existing) ? existing : [existing]),
+    ...additions,
+  ] as WatchFilesConfig;
 };
 
 const ensureFederationAsyncStartup = (
@@ -411,6 +436,16 @@ export const pluginReactRouter = (
       isBuild,
       cache: routeChunkCache,
     };
+    const routeWatchFiles: WatchFileConfig[] = [
+      {
+        paths: routesPath,
+        type: 'reload-server',
+      },
+      {
+        paths: resolve(appDirectory, 'routes/**/*'),
+        type: 'reload-server',
+      },
+    ];
 
     type ReactRouterManifest = Awaited<
       ReturnType<typeof getReactRouterManifestForDev>
@@ -1149,6 +1184,7 @@ export const pluginReactRouter = (
         dev: {
           writeToDisk: true,
           ...lazyCompilation,
+          watchFiles: mergeWatchFiles(config.dev?.watchFiles, routeWatchFiles),
           // Only add SSR middleware if SSR is enabled and not using a custom server
           // In SPA mode (ssr: false), we just serve static files from the client build
           setupMiddlewares:

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,11 +121,8 @@ const mergeWatchFiles = (
 
 type RouteDirectoryState = {
   directories: Set<string>;
-  files: Set<string>;
+  routeFiles: Set<string>;
 };
-
-const isRouteModuleFile = (filePath: string): boolean =>
-  JS_EXTENSIONS.some(extension => filePath.endsWith(extension));
 
 const areSetsEqual = <T>(left: Set<T>, right: Set<T>): boolean => {
   if (left.size !== right.size) {
@@ -139,13 +136,14 @@ const areSetsEqual = <T>(left: Set<T>, right: Set<T>): boolean => {
   return true;
 };
 
-const readRouteDirectoryState = async (
-  routesDirectory: string
-): Promise<RouteDirectoryState> => {
-  const state: RouteDirectoryState = {
-    directories: new Set(),
-    files: new Set(),
-  };
+const readRouteDirectoryState = async ({
+  watchDirectory,
+  getRouteFiles,
+}: {
+  watchDirectory: string;
+  getRouteFiles: () => Promise<Set<string>>;
+}): Promise<RouteDirectoryState> => {
+  const directories = new Set<string>();
 
   const walkDirectory = async (directory: string): Promise<void> => {
     let entries;
@@ -155,37 +153,42 @@ const readRouteDirectoryState = async (
       return;
     }
 
-    state.directories.add(directory);
+    directories.add(directory);
     await Promise.all(
       entries.map(async entry => {
         const entryPath = resolve(directory, entry.name);
         if (entry.isDirectory()) {
           await walkDirectory(entryPath);
-          return;
-        }
-        if (entry.isFile() && isRouteModuleFile(entryPath)) {
-          state.files.add(entryPath);
         }
       })
     );
   };
 
-  await walkDirectory(routesDirectory);
-  return state;
+  await walkDirectory(watchDirectory);
+  return {
+    directories,
+    routeFiles: await getRouteFiles(),
+  };
 };
 
 const createRouteFileSetWatcher = async ({
-  routesDirectory,
+  watchDirectory,
+  getRouteFiles,
   restartMarkerPath,
   onError,
 }: {
-  routesDirectory: string;
+  watchDirectory: string;
+  getRouteFiles: () => Promise<Set<string>>;
   restartMarkerPath: string;
   onError: (error: unknown) => void;
 }): Promise<() => void> => {
-  let state = await readRouteDirectoryState(routesDirectory);
+  let state = await readRouteDirectoryState({
+    watchDirectory,
+    getRouteFiles,
+  });
   let closed = false;
   let rescanTimer: ReturnType<typeof setTimeout> | undefined;
+  let rescanQueue = Promise.resolve();
   const directoryWatchers = new Map<string, FSWatcher>();
 
   const touchRestartMarker = async (): Promise<void> => {
@@ -210,10 +213,8 @@ const createRouteFileSetWatcher = async ({
         continue;
       }
       try {
-        const watcher = watch(directory, (eventType: string) => {
-          if (eventType === 'rename') {
-            scheduleRescan();
-          }
+        const watcher = watch(directory, () => {
+          scheduleRescan();
         });
         watcher.on('error', onError);
         directoryWatchers.set(directory, watcher);
@@ -228,14 +229,17 @@ const createRouteFileSetWatcher = async ({
     watchNewDirectories(nextDirectories);
   };
 
-  const rescan = async (): Promise<void> => {
+  const runRescan = async (): Promise<void> => {
     if (closed) {
       return;
     }
     try {
-      const nextState = await readRouteDirectoryState(routesDirectory);
+      const nextState = await readRouteDirectoryState({
+        watchDirectory,
+        getRouteFiles,
+      });
       syncDirectoryWatchers(nextState.directories);
-      if (!areSetsEqual(state.files, nextState.files)) {
+      if (!areSetsEqual(state.routeFiles, nextState.routeFiles)) {
         state = nextState;
         await touchRestartMarker();
         return;
@@ -244,6 +248,11 @@ const createRouteFileSetWatcher = async ({
     } catch (error) {
       onError(error);
     }
+  };
+
+  const rescan = (): Promise<void> => {
+    rescanQueue = rescanQueue.then(runRescan, runRescan);
+    return rescanQueue;
   };
 
   const scheduleRescan = (): void => {
@@ -521,21 +530,24 @@ export const pluginReactRouter = (
       );
     }
 
-    const routeConfigExport = await jiti.import<RouteConfigEntry[]>(
-      routesPath,
-      {
-        default: true,
+    const loadRouteConfig = async (): Promise<RouteConfigEntry[]> => {
+      const routeConfigExport = await jiti.import<RouteConfigEntry[]>(
+        routesPath,
+        {
+          default: true,
+        }
+      );
+      const routeConfigValue = await routeConfigExport;
+      const validation = validateRouteConfig({
+        routeConfigFile: relative(process.cwd(), routesPath),
+        routeConfig: routeConfigValue,
+      });
+      if (!validation.valid) {
+        throw new Error(validation.message);
       }
-    );
-    const routeConfigValue = await routeConfigExport;
-    const validation = validateRouteConfig({
-      routeConfigFile: relative(process.cwd(), routesPath),
-      routeConfig: routeConfigValue,
-    });
-    if (!validation.valid) {
-      throw new Error(validation.message);
-    }
-    const routeConfig = validation.routeConfig;
+      return validation.routeConfig;
+    };
+    const routeConfig = await loadRouteConfig();
 
     const entryClientPath = findEntryFile(
       resolve(appDirectory, 'entry.client')
@@ -567,6 +579,18 @@ export const pluginReactRouter = (
     // React Router's server build expects route files relative to `appDirectory`
     // so it can resolve them correctly during compilation.
     const rootRouteFile = relative(appDirectory, rootRoutePath);
+    const getWatchedRouteFiles = async (): Promise<Set<string>> => {
+      const latestRouteConfig = await loadRouteConfig();
+      const latestRoutes = {
+        root: { path: '', id: 'root', file: rootRouteFile },
+        ...configRoutesToRouteManifest(appDirectory, latestRouteConfig),
+      };
+      return new Set(
+        Object.values(latestRoutes).map(route =>
+          resolve(appDirectory, route.file)
+        )
+      );
+    };
 
     const routes = {
       root: { path: '', id: 'root', file: rootRouteFile },
@@ -606,7 +630,7 @@ export const pluginReactRouter = (
       isBuild,
       cache: routeChunkCache,
     };
-    const routesDirectory = resolve(appDirectory, 'routes');
+    const watchDirectory = resolve(appDirectory);
     const routeRestartMarkerPath = resolve('.react-router', 'route-watch');
     const routeWatchFiles: WatchFileConfig[] = [
       {
@@ -623,7 +647,8 @@ export const pluginReactRouter = (
     api.onBeforeStartDevServer(async () => {
       await ensureRestartMarker(routeRestartMarkerPath);
       closeRouteFileSetWatcher = await createRouteFileSetWatcher({
-        routesDirectory,
+        watchDirectory,
+        getRouteFiles: getWatchedRouteFiles,
         restartMarkerPath: routeRestartMarkerPath,
         onError: error => {
           api.logger.warn(

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import {
   watch,
   type FSWatcher,
 } from 'node:fs';
-import { access, mkdir, readdir, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
 import fsExtra from 'fs-extra';
@@ -77,6 +77,10 @@ import {
   createRouteChunkArtifact,
   createRouteClientEntryArtifact,
 } from './route-artifacts.js';
+import {
+  createRouteManifestSnapshot,
+  ensureRestartMarker,
+} from './route-watch.js';
 import { validateRouteConfig } from './route-config.js';
 import {
   getBuildManifest,
@@ -121,7 +125,7 @@ const mergeWatchFiles = (
 
 type RouteDirectoryState = {
   directories: Set<string>;
-  routeFiles: Set<string>;
+  routeTopology: Set<string>;
 };
 
 const areSetsEqual = <T>(left: Set<T>, right: Set<T>): boolean => {
@@ -138,10 +142,10 @@ const areSetsEqual = <T>(left: Set<T>, right: Set<T>): boolean => {
 
 const readRouteDirectoryState = async ({
   watchDirectory,
-  getRouteFiles,
+  getRouteTopology,
 }: {
   watchDirectory: string;
-  getRouteFiles: () => Promise<Set<string>>;
+  getRouteTopology: () => Promise<Set<string>>;
 }): Promise<RouteDirectoryState> => {
   const directories = new Set<string>();
 
@@ -167,24 +171,24 @@ const readRouteDirectoryState = async ({
   await walkDirectory(watchDirectory);
   return {
     directories,
-    routeFiles: await getRouteFiles(),
+    routeTopology: await getRouteTopology(),
   };
 };
 
-const createRouteFileSetWatcher = async ({
+const createRouteTopologyWatcher = async ({
   watchDirectory,
-  getRouteFiles,
+  getRouteTopology,
   restartMarkerPath,
   onError,
 }: {
   watchDirectory: string;
-  getRouteFiles: () => Promise<Set<string>>;
+  getRouteTopology: () => Promise<Set<string>>;
   restartMarkerPath: string;
   onError: (error: unknown) => void;
 }): Promise<() => void> => {
   let state = await readRouteDirectoryState({
     watchDirectory,
-    getRouteFiles,
+    getRouteTopology,
   });
   let closed = false;
   let rescanTimer: ReturnType<typeof setTimeout> | undefined;
@@ -236,10 +240,10 @@ const createRouteFileSetWatcher = async ({
     try {
       const nextState = await readRouteDirectoryState({
         watchDirectory,
-        getRouteFiles,
+        getRouteTopology,
       });
       syncDirectoryWatchers(nextState.directories);
-      if (!areSetsEqual(state.routeFiles, nextState.routeFiles)) {
+      if (!areSetsEqual(state.routeTopology, nextState.routeTopology)) {
         state = nextState;
         await touchRestartMarker();
         return;
@@ -277,17 +281,6 @@ const createRouteFileSetWatcher = async ({
     }
     directoryWatchers.clear();
   };
-};
-
-export const ensureRestartMarker = async (
-  restartMarkerPath: string
-): Promise<void> => {
-  await mkdir(dirname(restartMarkerPath), { recursive: true });
-  try {
-    await access(restartMarkerPath);
-  } catch {
-    await writeFile(restartMarkerPath, String(Date.now()));
-  }
 };
 
 const ensureFederationAsyncStartup = (
@@ -579,17 +572,13 @@ export const pluginReactRouter = (
     // React Router's server build expects route files relative to `appDirectory`
     // so it can resolve them correctly during compilation.
     const rootRouteFile = relative(appDirectory, rootRoutePath);
-    const getWatchedRouteFiles = async (): Promise<Set<string>> => {
+    const getWatchedRouteTopology = async (): Promise<Set<string>> => {
       const latestRouteConfig = await loadRouteConfig();
       const latestRoutes = {
         root: { path: '', id: 'root', file: rootRouteFile },
         ...configRoutesToRouteManifest(appDirectory, latestRouteConfig),
       };
-      return new Set(
-        Object.values(latestRoutes).map(route =>
-          resolve(appDirectory, route.file)
-        )
-      );
+      return createRouteManifestSnapshot(latestRoutes);
     };
 
     const routes = {
@@ -642,25 +631,25 @@ export const pluginReactRouter = (
         type: 'reload-server',
       },
     ];
-    let closeRouteFileSetWatcher: (() => void) | undefined;
+    let closeRouteTopologyWatcher: (() => void) | undefined;
 
     api.onBeforeStartDevServer(async () => {
       await ensureRestartMarker(routeRestartMarkerPath);
-      closeRouteFileSetWatcher = await createRouteFileSetWatcher({
+      closeRouteTopologyWatcher = await createRouteTopologyWatcher({
         watchDirectory,
-        getRouteFiles: getWatchedRouteFiles,
+        getRouteTopology: getWatchedRouteTopology,
         restartMarkerPath: routeRestartMarkerPath,
         onError: error => {
           api.logger.warn(
-            `[${PLUGIN_NAME}] Failed to watch route file set changes: ${error}`
+            `[${PLUGIN_NAME}] Failed to watch route topology changes: ${error}`
           );
         },
       });
     });
 
     api.onCloseDevServer(() => {
-      closeRouteFileSetWatcher?.();
-      closeRouteFileSetWatcher = undefined;
+      closeRouteTopologyWatcher?.();
+      closeRouteTopologyWatcher = undefined;
     });
 
     type ReactRouterManifest = Awaited<

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import {
   watch,
   type FSWatcher,
 } from 'node:fs';
-import { mkdir, readdir, writeFile } from 'node:fs/promises';
+import { access, mkdir, readdir, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
 import fsExtra from 'fs-extra';
@@ -270,6 +270,17 @@ const createRouteFileSetWatcher = async ({
   };
 };
 
+export const ensureRestartMarker = async (
+  restartMarkerPath: string
+): Promise<void> => {
+  await mkdir(dirname(restartMarkerPath), { recursive: true });
+  try {
+    await access(restartMarkerPath);
+  } catch {
+    await writeFile(restartMarkerPath, String(Date.now()));
+  }
+};
+
 const ensureFederationAsyncStartup = (
   rspackConfig: Rspack.Configuration | undefined
 ): void => {
@@ -380,7 +391,9 @@ export const pluginReactRouter = (
       });
     });
 
-    const jiti = createJiti(process.cwd());
+    const jiti = createJiti(process.cwd(), {
+      moduleCache: false,
+    });
 
     // Read the react-router.config file first (supports .ts, .js, .mjs, etc.)
     const configPath = findEntryFile(resolve('react-router.config'));
@@ -594,10 +607,7 @@ export const pluginReactRouter = (
       cache: routeChunkCache,
     };
     const routesDirectory = resolve(appDirectory, 'routes');
-    const routeRestartMarkerPath = resolve(
-      buildDirectory,
-      '.react-router-route-watch'
-    );
+    const routeRestartMarkerPath = resolve('.react-router', 'route-watch');
     const routeWatchFiles: WatchFileConfig[] = [
       {
         paths: routesPath,
@@ -611,8 +621,7 @@ export const pluginReactRouter = (
     let closeRouteFileSetWatcher: (() => void) | undefined;
 
     api.onBeforeStartDevServer(async () => {
-      await mkdir(dirname(routeRestartMarkerPath), { recursive: true });
-      await writeFile(routeRestartMarkerPath, String(Date.now()));
+      await ensureRestartMarker(routeRestartMarkerPath);
       closeRouteFileSetWatcher = await createRouteFileSetWatcher({
         routesDirectory,
         restartMarkerPath: routeRestartMarkerPath,

--- a/src/route-watch.ts
+++ b/src/route-watch.ts
@@ -1,0 +1,38 @@
+import { access, mkdir, writeFile } from 'node:fs/promises';
+import { dirname } from 'pathe';
+import type { Route } from './types.js';
+
+type RouteManifestSnapshotEntry = Pick<
+  Route,
+  'caseSensitive' | 'file' | 'id' | 'index' | 'parentId' | 'path'
+>;
+
+export const createRouteManifestSnapshot = (
+  routes: Record<string, RouteManifestSnapshotEntry>
+): Set<string> =>
+  new Set(
+    Object.entries(routes)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([routeId, route]) =>
+        JSON.stringify([
+          routeId,
+          route.id,
+          route.parentId ?? null,
+          route.path ?? null,
+          route.index ?? null,
+          route.caseSensitive ?? null,
+          route.file,
+        ])
+      )
+  );
+
+export const ensureRestartMarker = async (
+  restartMarkerPath: string
+): Promise<void> => {
+  await mkdir(dirname(restartMarkerPath), { recursive: true });
+  try {
+    await access(restartMarkerPath);
+  } catch {
+    await writeFile(restartMarkerPath, String(Date.now()));
+  }
+};

--- a/src/route-watch.ts
+++ b/src/route-watch.ts
@@ -1,11 +1,80 @@
-import { access, mkdir, writeFile } from 'node:fs/promises';
-import { dirname } from 'pathe';
+import { existsSync, readFileSync, watch, type FSWatcher } from 'node:fs';
+import { access, mkdir, readdir, writeFile } from 'node:fs/promises';
+import type { ProcessAssetsHandler, RsbuildConfig } from '@rsbuild/core';
+import { dirname, resolve } from 'pathe';
 import type { Route } from './types.js';
+
+export const ROUTE_RESTART_MARKER_ASSET = '.react-router/route-watch';
+const INITIAL_RESTART_MARKER_CONTENT = 'react-router-route-watch';
 
 type RouteManifestSnapshotEntry = Pick<
   Route,
   'caseSensitive' | 'file' | 'id' | 'index' | 'parentId' | 'path'
 >;
+
+type WatchFilesConfig = NonNullable<
+  NonNullable<RsbuildConfig['dev']>['watchFiles']
+>;
+export type WatchFileConfig =
+  | Exclude<WatchFilesConfig, readonly unknown[]>
+  | Extract<WatchFilesConfig, readonly unknown[]>[number];
+
+type RouteDirectoryState = {
+  directories: Set<string>;
+  routeTopology: Set<string>;
+};
+
+type ProcessAssetsContext = Parameters<ProcessAssetsHandler>[0];
+type RouteRestartMarkerAssetOptions = Pick<
+  ProcessAssetsContext,
+  'compilation' | 'sources'
+> & {
+  restartMarkerPath: string;
+};
+
+export const mergeWatchFiles = (
+  existing: WatchFilesConfig | undefined,
+  additions: WatchFileConfig[]
+): WatchFilesConfig => {
+  if (!existing) {
+    return additions as WatchFilesConfig;
+  }
+  return [
+    ...(Array.isArray(existing) ? existing : [existing]),
+    ...additions,
+  ] as WatchFilesConfig;
+};
+
+export const getRouteRestartMarkerPath = (outputClientPath: string): string =>
+  resolve(outputClientPath, ROUTE_RESTART_MARKER_ASSET);
+
+const readRestartMarkerContent = (restartMarkerPath: string): string => {
+  if (!existsSync(restartMarkerPath)) {
+    return INITIAL_RESTART_MARKER_CONTENT;
+  }
+
+  try {
+    const content = readFileSync(restartMarkerPath, 'utf8');
+    return content || INITIAL_RESTART_MARKER_CONTENT;
+  } catch {
+    return INITIAL_RESTART_MARKER_CONTENT;
+  }
+};
+
+export const emitRouteRestartMarkerAsset = ({
+  restartMarkerPath,
+  sources,
+  compilation,
+}: RouteRestartMarkerAssetOptions): void => {
+  const source = new sources.RawSource(
+    readRestartMarkerContent(restartMarkerPath)
+  );
+  if (compilation.getAsset(ROUTE_RESTART_MARKER_ASSET)) {
+    compilation.updateAsset(ROUTE_RESTART_MARKER_ASSET, source);
+    return;
+  }
+  compilation.emitAsset(ROUTE_RESTART_MARKER_ASSET, source);
+};
 
 export const createRouteManifestSnapshot = (
   routes: Record<string, RouteManifestSnapshotEntry>
@@ -26,13 +95,170 @@ export const createRouteManifestSnapshot = (
       )
   );
 
-export const ensureRestartMarker = async (
+export const ensureDevRestartMarker = async (
   restartMarkerPath: string
 ): Promise<void> => {
+  // Build emits this marker through processAssets. Dev owns the watched file
+  // directly so ordinary rebuilds do not rewrite it and trigger reload loops.
   await mkdir(dirname(restartMarkerPath), { recursive: true });
   try {
     await access(restartMarkerPath);
   } catch {
-    await writeFile(restartMarkerPath, String(Date.now()));
+    await writeFile(restartMarkerPath, INITIAL_RESTART_MARKER_CONTENT);
   }
+};
+
+const areSetsEqual = <T>(left: Set<T>, right: Set<T>): boolean => {
+  if (left.size !== right.size) {
+    return false;
+  }
+  for (const value of left) {
+    if (!right.has(value)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const readRouteDirectoryState = async ({
+  watchDirectory,
+  getRouteTopology,
+}: {
+  watchDirectory: string;
+  getRouteTopology: () => Promise<Set<string>>;
+}): Promise<RouteDirectoryState> => {
+  const directories = new Set<string>();
+
+  const walkDirectory = async (directory: string): Promise<void> => {
+    let entries;
+    try {
+      entries = await readdir(directory, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    directories.add(directory);
+    await Promise.all(
+      entries.map(async entry => {
+        const entryPath = resolve(directory, entry.name);
+        if (entry.isDirectory()) {
+          await walkDirectory(entryPath);
+        }
+      })
+    );
+  };
+
+  await walkDirectory(watchDirectory);
+  return {
+    directories,
+    routeTopology: await getRouteTopology(),
+  };
+};
+
+export const createRouteTopologyWatcher = async ({
+  watchDirectory,
+  getRouteTopology,
+  restartMarkerPath,
+  onError,
+}: {
+  watchDirectory: string;
+  getRouteTopology: () => Promise<Set<string>>;
+  restartMarkerPath: string;
+  onError: (error: unknown) => void;
+}): Promise<() => void> => {
+  let state = await readRouteDirectoryState({
+    watchDirectory,
+    getRouteTopology,
+  });
+  let closed = false;
+  let rescanTimer: ReturnType<typeof setTimeout> | undefined;
+  let rescanQueue = Promise.resolve();
+  const directoryWatchers = new Map<string, FSWatcher>();
+
+  const touchRestartMarker = async (): Promise<void> => {
+    await mkdir(dirname(restartMarkerPath), { recursive: true });
+    await writeFile(restartMarkerPath, String(Date.now()));
+  };
+
+  const closeRemovedDirectoryWatchers = (
+    nextDirectories: Set<string>
+  ): void => {
+    for (const [directory, watcher] of directoryWatchers) {
+      if (!nextDirectories.has(directory)) {
+        watcher.close();
+        directoryWatchers.delete(directory);
+      }
+    }
+  };
+
+  const watchNewDirectories = (nextDirectories: Set<string>): void => {
+    for (const directory of nextDirectories) {
+      if (directoryWatchers.has(directory)) {
+        continue;
+      }
+      try {
+        const watcher = watch(directory, () => {
+          scheduleRescan();
+        });
+        watcher.on('error', onError);
+        directoryWatchers.set(directory, watcher);
+      } catch (error) {
+        onError(error);
+      }
+    }
+  };
+
+  const syncDirectoryWatchers = (nextDirectories: Set<string>): void => {
+    closeRemovedDirectoryWatchers(nextDirectories);
+    watchNewDirectories(nextDirectories);
+  };
+
+  const runRescan = async (): Promise<void> => {
+    if (closed) {
+      return;
+    }
+    try {
+      const nextState = await readRouteDirectoryState({
+        watchDirectory,
+        getRouteTopology,
+      });
+      syncDirectoryWatchers(nextState.directories);
+      if (!areSetsEqual(state.routeTopology, nextState.routeTopology)) {
+        state = nextState;
+        await touchRestartMarker();
+        return;
+      }
+      state = nextState;
+    } catch (error) {
+      onError(error);
+    }
+  };
+
+  const rescan = (): Promise<void> => {
+    rescanQueue = rescanQueue.then(runRescan, runRescan);
+    return rescanQueue;
+  };
+
+  const scheduleRescan = (): void => {
+    if (rescanTimer) {
+      clearTimeout(rescanTimer);
+    }
+    rescanTimer = setTimeout(() => {
+      rescanTimer = undefined;
+      void rescan();
+    }, 100);
+  };
+
+  syncDirectoryWatchers(state.directories);
+
+  return () => {
+    closed = true;
+    if (rescanTimer) {
+      clearTimeout(rescanTimer);
+    }
+    for (const watcher of directoryWatchers.values()) {
+      watcher.close();
+    }
+    directoryWatchers.clear();
+  };
 };

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { createStubRsbuild } from '@scripts/test-helper';
-import { describe, expect, it } from '@rstest/core';
+import { describe, expect, it, rstest } from '@rstest/core';
 import { pluginReactRouter } from '../src';
 
 describe('pluginReactRouter', () => {
@@ -44,11 +44,58 @@ describe('pluginReactRouter', () => {
           type: 'reload-server',
         },
         {
-          paths: expect.stringMatching(/\.react-router\/route-watch$/),
+          paths: expect.stringMatching(
+            /build\/client\/\.react-router\/route-watch$/
+          ),
           type: 'reload-server',
         },
       ])
     );
+  });
+
+  it('emits the route restart marker as a web build asset', async () => {
+    const rsbuild = await createStubRsbuild({
+      action: 'build',
+      rsbuildConfig: {},
+    });
+
+    rsbuild.addPlugins([pluginReactRouter()]);
+    await rsbuild.unwrapConfig();
+
+    const processAssetsCall = rsbuild.processAssets.mock.calls.find(
+      ([options]) =>
+        options.stage === 'additional' && options.targets?.includes('web')
+    );
+    expect(processAssetsCall).toBeDefined();
+
+    const handler = processAssetsCall?.[1];
+    const emitAsset = rstest.fn();
+    const updateAsset = rstest.fn();
+    const RawSource = class {
+      constructor(private readonly content: string) {}
+      source() {
+        return this.content;
+      }
+      size() {
+        return this.content.length;
+      }
+    };
+
+    handler({
+      sources: { RawSource },
+      compilation: {
+        getAsset: rstest.fn().mockReturnValue(undefined),
+        emitAsset,
+        updateAsset,
+      },
+    });
+
+    expect(emitAsset).toHaveBeenCalledWith(
+      '.react-router/route-watch',
+      expect.any(RawSource)
+    );
+    expect(emitAsset.mock.calls[0][1].source()).not.toBe('');
+    expect(updateAsset).not.toHaveBeenCalled();
   });
 
   it('should respect server output format', async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -44,7 +44,7 @@ describe('pluginReactRouter', () => {
           type: 'reload-server',
         },
         {
-          paths: expect.stringMatching(/app\/routes$/),
+          paths: expect.stringMatching(/build\/\.react-router-route-watch$/),
           type: 'reload-server',
         },
       ])

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -18,6 +18,39 @@ describe('pluginReactRouter', () => {
     expect(config.dev.lazyCompilation).toBeUndefined();
   });
 
+  it('should restart the dev server when route entries are added', async () => {
+    const rsbuild = await createStubRsbuild({
+      rsbuildConfig: {
+        dev: {
+          watchFiles: {
+            paths: 'custom.config.ts',
+            type: 'reload-server',
+          },
+        },
+      },
+    });
+
+    rsbuild.addPlugins([pluginReactRouter()]);
+    const config = await rsbuild.unwrapConfig();
+
+    expect(config.dev.watchFiles).toEqual(
+      expect.arrayContaining([
+        {
+          paths: 'custom.config.ts',
+          type: 'reload-server',
+        },
+        {
+          paths: expect.stringMatching(/app\/routes\.[cm]?[jt]sx?$/),
+          type: 'reload-server',
+        },
+        {
+          paths: expect.stringMatching(/app\/routes\/\*\*\/\*$/),
+          type: 'reload-server',
+        },
+      ])
+    );
+  });
+
   it('should respect server output format', async () => {
     const rsbuild = await createStubRsbuild({
       rsbuildConfig: {},

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -44,7 +44,7 @@ describe('pluginReactRouter', () => {
           type: 'reload-server',
         },
         {
-          paths: expect.stringMatching(/build\/\.react-router-route-watch$/),
+          paths: expect.stringMatching(/\.react-router\/route-watch$/),
           type: 'reload-server',
         },
       ])

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -44,7 +44,7 @@ describe('pluginReactRouter', () => {
           type: 'reload-server',
         },
         {
-          paths: expect.stringMatching(/app\/routes\/\*\*\/\*$/),
+          paths: expect.stringMatching(/app\/routes$/),
           type: 'reload-server',
         },
       ])

--- a/tests/route-watch.test.ts
+++ b/tests/route-watch.test.ts
@@ -11,16 +11,23 @@ import { join } from 'node:path';
 import { describe, expect, it } from '@rstest/core';
 import {
   createRouteManifestSnapshot,
-  ensureRestartMarker,
+  ensureDevRestartMarker,
+  getRouteRestartMarkerPath,
 } from '../src/route-watch';
 
 describe('route watch restart marker', () => {
+  it('places the restart marker in the client build output', () => {
+    expect(getRouteRestartMarkerPath('/project/build/client')).toBe(
+      '/project/build/client/.react-router/route-watch'
+    );
+  });
+
   it('creates the restart marker when missing', async () => {
     const root = mkdtempSync(join(tmpdir(), 'rr-route-watch-'));
     try {
       const markerPath = join(root, 'build/.react-router-route-watch');
 
-      await ensureRestartMarker(markerPath);
+      await ensureDevRestartMarker(markerPath);
 
       expect(readFileSync(markerPath, 'utf8')).not.toBe('');
     } finally {
@@ -35,7 +42,7 @@ describe('route watch restart marker', () => {
       mkdirSync(join(root, 'build'), { recursive: true });
       writeFileSync(markerPath, 'existing');
 
-      await ensureRestartMarker(markerPath);
+      await ensureDevRestartMarker(markerPath);
 
       expect(readFileSync(markerPath, 'utf8')).toBe('existing');
     } finally {

--- a/tests/route-watch.test.ts
+++ b/tests/route-watch.test.ts
@@ -9,7 +9,10 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from '@rstest/core';
-import { ensureRestartMarker } from '../src/index';
+import {
+  createRouteManifestSnapshot,
+  ensureRestartMarker,
+} from '../src/route-watch';
 
 describe('route watch restart marker', () => {
   it('creates the restart marker when missing', async () => {
@@ -38,5 +41,55 @@ describe('route watch restart marker', () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe('route watch topology snapshot', () => {
+  it('changes when route topology changes but route files stay the same', () => {
+    const baseRoutes = {
+      root: { id: 'root', path: '', file: 'root.tsx' },
+      'routes/demo': {
+        id: 'routes/demo',
+        parentId: 'root',
+        path: 'demo',
+        file: 'routes/demo.tsx',
+      },
+    };
+
+    const changedRoutes = {
+      ...baseRoutes,
+      'routes/demo': {
+        ...baseRoutes['routes/demo'],
+        path: 'renamed-demo',
+      },
+    };
+
+    expect(createRouteManifestSnapshot(baseRoutes)).not.toEqual(
+      createRouteManifestSnapshot(changedRoutes)
+    );
+  });
+
+  it('is stable for equivalent route manifests with different object insertion order', () => {
+    const first = createRouteManifestSnapshot({
+      root: { id: 'root', path: '', file: 'root.tsx' },
+      'routes/demo': {
+        id: 'routes/demo',
+        parentId: 'root',
+        path: 'demo',
+        file: 'routes/demo.tsx',
+      },
+    });
+
+    const second = createRouteManifestSnapshot({
+      'routes/demo': {
+        id: 'routes/demo',
+        parentId: 'root',
+        path: 'demo',
+        file: 'routes/demo.tsx',
+      },
+      root: { id: 'root', path: '', file: 'root.tsx' },
+    });
+
+    expect(second).toEqual(first);
   });
 });

--- a/tests/route-watch.test.ts
+++ b/tests/route-watch.test.ts
@@ -1,0 +1,42 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from '@rstest/core';
+import { ensureRestartMarker } from '../src/index';
+
+describe('route watch restart marker', () => {
+  it('creates the restart marker when missing', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'rr-route-watch-'));
+    try {
+      const markerPath = join(root, 'build/.react-router-route-watch');
+
+      await ensureRestartMarker(markerPath);
+
+      expect(readFileSync(markerPath, 'utf8')).not.toBe('');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not rewrite an existing restart marker on dev server startup', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'rr-route-watch-'));
+    try {
+      const markerPath = join(root, 'build/.react-router-route-watch');
+      mkdirSync(join(root, 'build'), { recursive: true });
+      writeFileSync(markerPath, 'existing');
+
+      await ensureRestartMarker(markerPath);
+
+      expect(readFileSync(markerPath, 'utf8')).toBe('existing');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -51,7 +51,7 @@ const deepMerge = (base: any, overrides: any): any => {
 
 // Mock the @scripts/test-helper module
 rstest.mock('@scripts/test-helper', () => ({
-  createStubRsbuild: rstest.fn().mockImplementation(async ({ rsbuildConfig = {} } = {}) => {
+  createStubRsbuild: rstest.fn().mockImplementation(async ({ action = 'dev', rsbuildConfig = {} } = {}) => {
     const baseConfig = {
       dev: {
         // Match Rsbuild defaults so plugin changes are observable in tests.
@@ -128,7 +128,7 @@ rstest.mock('@scripts/test-helper', () => ({
       },
       context: {
         rootPath: '/Users/bytedance/dev/rsbuild-plugin-react-router',
-        action: 'dev',
+        action,
       },
       compiler: {
         webpack: {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -110,6 +110,7 @@ rstest.mock('@scripts/test-helper', () => ({
       unwrapConfig: rstest.fn(),
       processAssets: rstest.fn(),
       onBeforeStartDevServer: rstest.fn(),
+      onCloseDevServer: rstest.fn(),
       onBeforeBuild: rstest.fn(),
       onAfterBuild: rstest.fn(),
       getNormalizedConfig: rstest.fn().mockImplementation(() => mergedConfig),


### PR DESCRIPTION
## Summary
- Stack this route-watch fix on top of #39 (`perf/bundling-performance`) so this PR only contains the dev route-entry watch changes.
- Keep Rsbuild's `reload-server` watch list narrow: the route config file plus a generated route restart marker.
- Add a lightweight app-directory watcher that reloads the latest route config and touches the marker only when the route manifest topology changes.
- Preserve existing route-module HMR for normal edits by avoiding `reload-server` watches on all existing route files.

## Test plan
- `pnpm test:core tests/index.test.ts tests/route-watch.test.ts`
- `pnpm build`
- CI: `examples/default-template` Playwright e2e includes `tests/e2e/dev-route-watch.test.ts`, which adds a route after dev startup and verifies later route edits do not restart the dev server.
