### PR TITLE
[codex] Preserve route topology declaration order

### DIFF
--- a/.changeset/quiet-topology-order.md
+++ b/.changeset/quiet-topology-order.md
@@ -1,0 +1,6 @@
+---
+"rsbuild-plugin-react-router": patch
+---
+
+Preserve route topology declaration order during development so reordering route
+entries is detected as a topology change.

--- a/src/route-watch.ts
+++ b/src/route-watch.ts
@@ -61,19 +61,20 @@ export const createRouteManifestSnapshot = (
   routes: Record<string, RouteManifestSnapshotEntry>
 ): Set<string> =>
   new Set(
-    Object.entries(routes)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([routeId, route]) =>
-        JSON.stringify([
-          routeId,
-          route.id,
-          route.parentId ?? null,
-          route.path ?? null,
-          route.index ?? null,
-          route.caseSensitive ?? null,
-          route.file,
-        ])
-      )
+    // React Router uses sibling declaration order as a match tiebreaker, so the
+    // snapshot must preserve route-manifest insertion order.
+    Object.entries(routes).map(([routeId, route], order) =>
+      JSON.stringify([
+        order,
+        routeId,
+        route.id,
+        route.parentId ?? null,
+        route.path ?? null,
+        route.index ?? null,
+        route.caseSensitive ?? null,
+        route.file,
+      ])
+    )
   );
 
 export const ensureDevRestartMarker = async (

--- a/tests/route-watch.test.ts
+++ b/tests/route-watch.test.ts
@@ -170,27 +170,39 @@ describe('route watch topology snapshot', () => {
     );
   });
 
-  it('is stable for equivalent route manifests with different object insertion order', () => {
+  it('changes when sibling declaration order changes', () => {
     const first = createRouteManifestSnapshot({
       root: { id: 'root', path: '', file: 'root.tsx' },
-      'routes/demo': {
-        id: 'routes/demo',
+      'routes/a': {
+        id: 'routes/a',
         parentId: 'root',
-        path: 'demo',
-        file: 'routes/demo.tsx',
+        path: ':value',
+        file: 'routes/a.tsx',
+      },
+      'routes/b': {
+        id: 'routes/b',
+        parentId: 'root',
+        path: ':value',
+        file: 'routes/b.tsx',
       },
     });
 
     const second = createRouteManifestSnapshot({
-      'routes/demo': {
-        id: 'routes/demo',
-        parentId: 'root',
-        path: 'demo',
-        file: 'routes/demo.tsx',
-      },
       root: { id: 'root', path: '', file: 'root.tsx' },
+      'routes/b': {
+        id: 'routes/b',
+        parentId: 'root',
+        path: ':value',
+        file: 'routes/b.tsx',
+      },
+      'routes/a': {
+        id: 'routes/a',
+        parentId: 'root',
+        path: ':value',
+        file: 'routes/a.tsx',
+      },
     });
 
-    expect(second).toEqual(first);
+    expect(second).not.toEqual(first);
   });
 });


### PR DESCRIPTION
## Summary
- make route topology snapshots preserve route-manifest insertion order
- encode route ordinal positions so sibling reorder triggers topology changes
- update route-watch tests for React Router sibling declaration-order semantics

## Context
This follows up on the Slack design note in /home/zack/Downloads/react_router_request.md. Most of that note describes a future in-place route topology design or items already covered by PR #46; this PR addresses the remaining small current-baseline correction that route order is semantic.

## Verification
- pnpm test:core -- tests/route-watch.test.ts
- pnpm build
- pnpm format:check
- git diff --check