### PR TITLE
[codex] Tighten route topology watcher lifecycle

### DIFF
--- a/.changeset/warm-watchers-rest.md
+++ b/.changeset/warm-watchers-rest.md
@@ -1,0 +1,6 @@
+---
+"rsbuild-plugin-react-router": patch
+---
+
+Avoid duplicate startup route topology scans and tighten development watcher
+lifecycle handling for route additions and removals.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -18,7 +18,9 @@ counts for stress testing.
 
 All benchmark profiles generate deterministic synthetic React Router apps under
 `.benchmark/fixtures/`, build the current plugin package once, then run Rsbuild
-builds with `pluginReactRouter({ logPerformance: true })`.
+builds with plugin performance instrumentation disabled by default. Pass
+`--log-performance` when you need diagnostic `[react-router:performance]`
+operation reports.
 
 To capture Rspack tracing output for a benchmark, pass `--rspack-profile`:
 
@@ -57,11 +59,12 @@ Each run writes:
 - `.benchmark/results/<profile>/baseline.json`
 - `.benchmark/results/<profile>/baseline.md`
 
-The JSON includes wall time, optional GNU `/usr/bin/time -v` user/sys/RSS data,
-parsed `[react-router:performance]` reports from the plugin, and an aggregated
+The JSON includes wall time and optional GNU `/usr/bin/time -v` user/sys/RSS
+data. Diagnostic runs with `--log-performance` also include parsed
+`[react-router:performance]` reports from the plugin and an aggregated
 `pluginOperations` table per fixture. The markdown report includes the same
-operation breakdown so route transforms and manifest work can be compared
-without opening the raw JSON.
+operation breakdown when instrumentation is enabled so route transforms and
+manifest work can be compared without opening the raw JSON.
 
 ## Hygiene
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import {
   getReactRouterManifestForDev,
   generateReactRouterManifestForDev,
   configRoutesToRouteManifest,
+  configRoutesToRouteManifestEntries,
   createReactRouterManifestStats,
   type ReactRouterManifestStats,
   type RouteManifestModuleExports,
@@ -412,14 +413,21 @@ export const pluginReactRouter = (
     // React Router's server build expects route files relative to `appDirectory`
     // so it can resolve them correctly during compilation.
     const rootRouteFile = relative(appDirectory, rootRoutePath);
+    const createRouteTopologySnapshot = (
+      latestRootRouteFile: string,
+      latestRouteConfig: RouteConfigEntry[]
+    ) =>
+      createRouteManifestSnapshot([
+        ['root', { path: '', id: 'root', file: latestRootRouteFile }],
+        ...configRoutesToRouteManifestEntries(appDirectory, latestRouteConfig),
+      ]);
     const getWatchedRouteTopology = async (): Promise<Set<string>> => {
       const latestRouteConfig = await loadRouteConfig();
       const latestRootRouteFile = relative(appDirectory, getRootRoutePath());
-      const latestRoutes = {
-        root: { path: '', id: 'root', file: latestRootRouteFile },
-        ...configRoutesToRouteManifest(appDirectory, latestRouteConfig),
-      };
-      return createRouteManifestSnapshot(latestRoutes);
+      return createRouteTopologySnapshot(
+        latestRootRouteFile,
+        latestRouteConfig
+      );
     };
 
     const routes = {
@@ -475,19 +483,25 @@ export const pluginReactRouter = (
     const assetsBuildDirectory = relative(process.cwd(), outputClientPath);
     const watchDirectory = resolve(appDirectory);
     const routeRestartMarkerPath = getRouteRestartMarkerPath(outputClientPath);
+    const routeTopologyWatchFiles: WatchFileConfig[] =
+      pluginOptions.onRouteTopologyChange
+        ? []
+        : [
+            {
+              paths: routesPath,
+              type: 'reload-server',
+            },
+            {
+              paths: routeRestartMarkerPath,
+              type: 'reload-server',
+            },
+          ];
     const routeWatchFiles: WatchFileConfig[] = [
       {
         paths: configWatchPaths,
         type: 'reload-server',
       },
-      {
-        paths: routesPath,
-        type: 'reload-server',
-      },
-      {
-        paths: routeRestartMarkerPath,
-        type: 'reload-server',
-      },
+      ...routeTopologyWatchFiles,
     ];
     let closeRouteTopologyWatcher: (() => Promise<void>) | undefined;
 
@@ -496,7 +510,10 @@ export const pluginReactRouter = (
       closeRouteTopologyWatcher = await createRouteTopologyWatcher({
         watchDirectory,
         getRouteTopology: getWatchedRouteTopology,
-        initialRouteTopology: createRouteManifestSnapshot(routes),
+        initialRouteTopology: createRouteTopologySnapshot(
+          rootRouteFile,
+          routeConfig
+        ),
         restartMarkerPath: routeRestartMarkerPath,
         onRouteTopologyChange: pluginOptions.onRouteTopologyChange,
         onError: error => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -414,12 +414,12 @@ export const pluginReactRouter = (
     // so it can resolve them correctly during compilation.
     const rootRouteFile = relative(appDirectory, rootRoutePath);
     const createRouteTopologySnapshot = (
-      latestRootRouteFile: string,
-      latestRouteConfig: RouteConfigEntry[]
+      routeFile: string,
+      routeConfig: RouteConfigEntry[]
     ) =>
       createRouteManifestSnapshot([
-        ['root', { path: '', id: 'root', file: latestRootRouteFile }],
-        ...configRoutesToRouteManifestEntries(appDirectory, latestRouteConfig),
+        ['root', { path: '', id: 'root', file: routeFile }],
+        ...configRoutesToRouteManifestEntries(appDirectory, routeConfig),
       ]);
     const getWatchedRouteTopology = async (): Promise<Set<string>> => {
       const latestRouteConfig = await loadRouteConfig();

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -21,7 +21,18 @@ export function configRoutesToRouteManifest(
   routes: RouteConfigEntry[],
   rootId = 'root'
 ): Record<string, Route> {
-  const routeManifest: Record<string, Route> = {};
+  return Object.fromEntries(
+    configRoutesToRouteManifestEntries(appDirectory, routes, rootId)
+  );
+}
+
+export function configRoutesToRouteManifestEntries(
+  appDirectory: string,
+  routes: RouteConfigEntry[],
+  rootId = 'root'
+): Array<[string, Route]> {
+  const routeManifestEntries: Array<[string, Route]> = [];
+  const routeIds = new Set<string>();
 
   function walk(route: RouteConfigEntry, parentId: string) {
     const id = route.id || createRouteId(route.file);
@@ -36,12 +47,13 @@ export function configRoutesToRouteManifest(
       caseSensitive: route.caseSensitive,
     };
 
-    if (Object.prototype.hasOwnProperty.call(routeManifest, id)) {
+    if (routeIds.has(id)) {
       throw new Error(
         `Unable to define routes with duplicate route id: "${id}"`
       );
     }
-    routeManifest[id] = manifestItem;
+    routeIds.add(id);
+    routeManifestEntries.push([id, manifestItem]);
 
     if (route.children) {
       for (const child of route.children) {
@@ -54,7 +66,7 @@ export function configRoutesToRouteManifest(
     walk(route, rootId);
   }
 
-  return routeManifest;
+  return routeManifestEntries;
 }
 
 type RouteChunkManifestOptions = {

--- a/src/route-watch.ts
+++ b/src/route-watch.ts
@@ -11,6 +11,9 @@ type RouteManifestSnapshotEntry = Pick<
   Route,
   'caseSensitive' | 'file' | 'id' | 'index' | 'parentId' | 'path'
 >;
+type RouteManifestSnapshotEntries =
+  | Record<string, RouteManifestSnapshotEntry>
+  | Iterable<readonly [string, RouteManifestSnapshotEntry]>;
 
 type WatchFilesConfig = NonNullable<
   NonNullable<RsbuildConfig['dev']>['watchFiles']
@@ -58,23 +61,25 @@ export const getRouteRestartMarkerPath = (outputClientPath: string): string =>
   resolve(outputClientPath, ROUTE_RESTART_MARKER_ASSET);
 
 export const createRouteManifestSnapshot = (
-  routes: Record<string, RouteManifestSnapshotEntry>
+  routes: RouteManifestSnapshotEntries
 ): Set<string> =>
   new Set(
-    // React Router uses sibling declaration order as a match tiebreaker, so the
-    // snapshot must preserve route-manifest insertion order.
-    Object.entries(routes).map(([routeId, route], order) =>
-      JSON.stringify([
-        order,
-        routeId,
-        route.id,
-        route.parentId ?? null,
-        route.path ?? null,
-        route.index ?? null,
-        route.caseSensitive ?? null,
-        route.file,
-      ])
-    )
+    (Symbol.iterator in routes ? Array.from(routes) : Object.entries(routes))
+      // React Router uses sibling declaration order as a match tiebreaker, so
+      // callers that have ordered route config should pass ordered entries
+      // instead of a record with numeric-like keys.
+      .map(([routeId, route], order) =>
+        JSON.stringify([
+          order,
+          routeId,
+          route.id,
+          route.parentId ?? null,
+          route.path ?? null,
+          route.index ?? null,
+          route.caseSensitive ?? null,
+          route.file,
+        ])
+      )
   );
 
 export const ensureDevRestartMarker = async (
@@ -102,13 +107,9 @@ const areSetsEqual = <T>(left: Set<T>, right: Set<T>): boolean => {
   return true;
 };
 
-const readRouteDirectoryState = async ({
-  watchDirectory,
-  getRouteTopology,
-}: {
-  watchDirectory: string;
-  getRouteTopology: () => Promise<Set<string>>;
-}): Promise<RouteDirectoryState> => {
+const readRouteDirectories = async (
+  watchDirectory: string
+): Promise<Set<string>> => {
   const directories = new Set<string>();
 
   const walkDirectory = async (directory: string): Promise<void> => {
@@ -131,10 +132,7 @@ const readRouteDirectoryState = async ({
   };
 
   await walkDirectory(watchDirectory);
-  return {
-    directories,
-    routeTopology: await getRouteTopology(),
-  };
+  return directories;
 };
 
 export const createRouteTopologyWatcher = async ({
@@ -154,10 +152,23 @@ export const createRouteTopologyWatcher = async ({
   onRouteTopologyChange?: () => void | Promise<void>;
   watchDirectoryEntry?: WatchDirectoryEntry;
 }): Promise<() => Promise<void>> => {
-  const discoveredState = await readRouteDirectoryState({
-    watchDirectory,
-    getRouteTopology,
-  });
+  const discoveredDirectories = await readRouteDirectories(watchDirectory);
+  let discoveredState: RouteDirectoryState;
+  try {
+    discoveredState = {
+      directories: discoveredDirectories,
+      routeTopology: await getRouteTopology(),
+    };
+  } catch (error) {
+    if (!initialRouteTopology) {
+      throw error;
+    }
+    onError(error);
+    discoveredState = {
+      directories: discoveredDirectories,
+      routeTopology: initialRouteTopology,
+    };
+  }
   let state = {
     ...discoveredState,
     routeTopology: initialRouteTopology ?? discoveredState.routeTopology,
@@ -209,39 +220,51 @@ export const createRouteTopologyWatcher = async ({
     watchNewDirectories(nextDirectories);
   };
 
+  const applyNextState = async (nextState: RouteDirectoryState) => {
+    if (closed) {
+      return;
+    }
+    syncDirectoryWatchers(nextState.directories);
+    if (!areSetsEqual(state.routeTopology, nextState.routeTopology)) {
+      if (onRouteTopologyChange) {
+        // This is a notification boundary, not part of the rescan
+        // transaction. A custom-server callback may close this watcher while
+        // replacing its compiler, so awaiting it here would deadlock close().
+        const notification = onRouteTopologyChange();
+        state = nextState;
+        void Promise.resolve(notification).catch(onError);
+        return;
+      } else {
+        await touchRestartMarker();
+      }
+      if (closed) {
+        return;
+      }
+      state = nextState;
+      return;
+    }
+    state = nextState;
+  };
+
   const runRescan = async (): Promise<void> => {
     if (closed) {
       return;
     }
+    let nextDirectories: Set<string> | undefined;
     try {
-      const nextState = await readRouteDirectoryState({
-        watchDirectory,
-        getRouteTopology,
-      });
+      nextDirectories = await readRouteDirectories(watchDirectory);
+      const nextState = {
+        directories: nextDirectories,
+        routeTopology: await getRouteTopology(),
+      };
       if (closed) {
         return;
       }
-      syncDirectoryWatchers(nextState.directories);
-      if (!areSetsEqual(state.routeTopology, nextState.routeTopology)) {
-        if (onRouteTopologyChange) {
-          // This is a notification boundary, not part of the rescan
-          // transaction. A custom-server callback may close this watcher while
-          // replacing its compiler, so awaiting it here would deadlock close().
-          const notification = onRouteTopologyChange();
-          state = nextState;
-          void Promise.resolve(notification).catch(onError);
-          return;
-        } else {
-          await touchRestartMarker();
-        }
-        if (closed) {
-          return;
-        }
-        state = nextState;
-        return;
-      }
-      state = nextState;
+      await applyNextState(nextState);
     } catch (error) {
+      if (nextDirectories && !closed) {
+        syncDirectoryWatchers(nextDirectories);
+      }
       onError(error);
     }
   };
@@ -261,9 +284,10 @@ export const createRouteTopologyWatcher = async ({
     }, 100);
   };
 
-  syncDirectoryWatchers(state.directories);
-  if (initialRouteTopology) {
-    await runRescan();
+  try {
+    await applyNextState(discoveredState);
+  } catch (error) {
+    onError(error);
   }
 
   return async () => {

--- a/src/route-watch.ts
+++ b/src/route-watch.ts
@@ -11,9 +11,13 @@ type RouteManifestSnapshotEntry = Pick<
   Route,
   'caseSensitive' | 'file' | 'id' | 'index' | 'parentId' | 'path'
 >;
+type RouteManifestSnapshotEntryPair = readonly [
+  string,
+  RouteManifestSnapshotEntry,
+];
 type RouteManifestSnapshotEntries =
   | Record<string, RouteManifestSnapshotEntry>
-  | Iterable<readonly [string, RouteManifestSnapshotEntry]>;
+  | ReadonlyArray<RouteManifestSnapshotEntryPair>;
 
 type WatchFilesConfig = NonNullable<
   NonNullable<RsbuildConfig['dev']>['watchFiles']
@@ -64,7 +68,7 @@ export const createRouteManifestSnapshot = (
   routes: RouteManifestSnapshotEntries
 ): Set<string> =>
   new Set(
-    (Symbol.iterator in routes ? Array.from(routes) : Object.entries(routes))
+    (Array.isArray(routes) ? routes : Object.entries(routes))
       // React Router uses sibling declaration order as a match tiebreaker, so
       // callers that have ordered route config should pass ordered entries
       // instead of a record with numeric-like keys.

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -96,6 +96,44 @@ describe('pluginReactRouter', () => {
     }
   });
 
+  it('lets custom route topology callbacks own route restart handling', async () => {
+    const rsbuild = await createStubRsbuild({
+      rsbuildConfig: {},
+    });
+
+    rsbuild.addPlugins([
+      pluginReactRouter({
+        onRouteTopologyChange: () => {},
+      }),
+    ]);
+    const config = await rsbuild.unwrapConfig();
+
+    expect(config.dev.watchFiles).toEqual(
+      expect.arrayContaining([
+        {
+          paths: expect.stringMatching(
+            /react-router\.config\.[cm]?[jt]sx?$/
+          ),
+          type: 'reload-server',
+        },
+      ])
+    );
+    expect(config.dev.watchFiles).not.toEqual(
+      expect.arrayContaining([
+        {
+          paths: expect.stringMatching(/app\/routes\.[cm]?[jt]sx?$/),
+          type: 'reload-server',
+        },
+        {
+          paths: expect.stringMatching(
+            /build\/client\/\.react-router\/route-watch$/
+          ),
+          type: 'reload-server',
+        },
+      ])
+    );
+  });
+
   it('should respect server output format', async () => {
     const rsbuild = await createStubRsbuild({
       rsbuildConfig: {},

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -124,6 +124,10 @@ describe('pluginReactRouter', () => {
           paths: expect.stringMatching(/app\/routes\.[cm]?[jt]sx?$/),
           type: 'reload-server',
         },
+      ])
+    );
+    expect(config.dev.watchFiles).not.toEqual(
+      expect.arrayContaining([
         {
           paths: expect.stringMatching(
             /build\/client\/\.react-router\/route-watch$/

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from '@rstest/core';
 import {
   createReactRouterManifestStats,
   configRoutesToRouteManifest,
+  configRoutesToRouteManifestEntries,
   generateReactRouterManifestForDev,
   getReactRouterManifestForDev,
   getReactRouterManifestChunkNames,
@@ -170,6 +171,25 @@ describe('manifest', () => {
       expect(result['routes/home'].id).toBe('routes/home');
       expect(result['routes/home'].path).toBe('/');
       expect(result['routes/home'].index).toBe(true);
+    });
+
+    it('preserves declaration order in route manifest entries', () => {
+      const routeConfig = [
+        {
+          id: '2',
+          file: 'routes/two.tsx',
+          path: ':value',
+        },
+        {
+          id: '1',
+          file: 'routes/one.tsx',
+          path: ':value',
+        },
+      ];
+
+      const result = configRoutesToRouteManifestEntries('app', routeConfig);
+
+      expect(result.map(([id]) => id)).toEqual(['2', '1']);
     });
 
     it('should handle nested routes with parentId', () => {

--- a/tests/route-watch.test.ts
+++ b/tests/route-watch.test.ts
@@ -143,6 +143,101 @@ describe('route watch restart marker', () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it('reuses discovered topology when initial topology is already current', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'rr-route-watch-'));
+    const markerPath = join(root, 'build/.react-router-route-watch');
+    const watchedDirectory = join(root, 'app');
+    mkdirSync(watchedDirectory, { recursive: true });
+    let topologyReads = 0;
+
+    try {
+      const close = await createRouteTopologyWatcher({
+        watchDirectory: watchedDirectory,
+        restartMarkerPath: markerPath,
+        initialRouteTopology: new Set(['current']),
+        getRouteTopology: async () => {
+          topologyReads += 1;
+          return new Set(['current']);
+        },
+        onError: error => {
+          throw error;
+        },
+        watchDirectoryEntry: () => ({ close: () => {} }),
+      });
+      await close();
+
+      expect(topologyReads).toBe(1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('uses discovered topology to notify when initial topology is stale', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'rr-route-watch-'));
+    const markerPath = join(root, 'build/.react-router-route-watch');
+    const watchedDirectory = join(root, 'app');
+    mkdirSync(watchedDirectory, { recursive: true });
+    let topologyReads = 0;
+    const onRouteTopologyChange = rstest.fn();
+
+    try {
+      const close = await createRouteTopologyWatcher({
+        watchDirectory: watchedDirectory,
+        restartMarkerPath: markerPath,
+        initialRouteTopology: new Set(['stale']),
+        getRouteTopology: async () => {
+          topologyReads += 1;
+          return new Set(['current']);
+        },
+        onRouteTopologyChange,
+        onError: error => {
+          throw error;
+        },
+        watchDirectoryEntry: () => ({ close: () => {} }),
+      });
+      await close();
+
+      expect(topologyReads).toBe(1);
+      expect(onRouteTopologyChange).toHaveBeenCalledTimes(1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('retains discovered recovery directories when startup topology evaluation fails', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'rr-route-watch-'));
+    const markerPath = join(root, 'build/.react-router-route-watch');
+    const watchedDirectory = join(root, 'app');
+    const helperDirectory = join(watchedDirectory, 'helpers');
+    mkdirSync(helperDirectory, { recursive: true });
+    const watchedDirectories: string[] = [];
+    const onError = rstest.fn();
+
+    try {
+      const close = await createRouteTopologyWatcher({
+        watchDirectory: watchedDirectory,
+        restartMarkerPath: markerPath,
+        initialRouteTopology: new Set(['last-good']),
+        getRouteTopology: async () => {
+          throw new Error('route config failed');
+        },
+        onError,
+        watchDirectoryEntry: directory => {
+          watchedDirectories.push(directory);
+          return { close: () => {} };
+        },
+      });
+      await close();
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(watchedDirectories).toEqual(
+        expect.arrayContaining([watchedDirectory, helperDirectory])
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('route watch topology snapshot', () => {
@@ -202,6 +297,54 @@ describe('route watch topology snapshot', () => {
         file: 'routes/a.tsx',
       },
     });
+
+    expect(second).not.toEqual(first);
+  });
+
+  it('preserves ordered entries for numeric-like route IDs', () => {
+    const first = createRouteManifestSnapshot([
+      ['root', { id: 'root', path: '', file: 'root.tsx' }],
+      [
+        '2',
+        {
+          id: '2',
+          parentId: 'root',
+          path: ':value',
+          file: 'routes/two.tsx',
+        },
+      ],
+      [
+        '1',
+        {
+          id: '1',
+          parentId: 'root',
+          path: ':value',
+          file: 'routes/one.tsx',
+        },
+      ],
+    ]);
+
+    const second = createRouteManifestSnapshot([
+      ['root', { id: 'root', path: '', file: 'root.tsx' }],
+      [
+        '1',
+        {
+          id: '1',
+          parentId: 'root',
+          path: ':value',
+          file: 'routes/one.tsx',
+        },
+      ],
+      [
+        '2',
+        {
+          id: '2',
+          parentId: 'root',
+          path: ':value',
+          file: 'routes/two.tsx',
+        },
+      ],
+    ]);
 
     expect(second).not.toEqual(first);
   });


### PR DESCRIPTION
## Summary
- avoid re-evaluating route topology during watcher startup when discovered state is already available
- preserve ordered route config entries for topology snapshots, including numeric-like route IDs
- retain discovered directories as recovery watches when topology evaluation fails with a last-good snapshot
- let custom onRouteTopologyChange callbacks own topology restart handling by omitting route reload-server watches
- align benchmark README with the current default of disabled performance instrumentation

## Context
Follow-up from /home/zack/Downloads/react_router_request.md. Multiple explorers checked route-watch lifecycle, publication/custom-server behavior, and dynamic-entry/generated-asset scope. This PR implements the remaining small in-repo route-topology fixes; larger generation-tagged publication, private entry namespace, and last-good SSR helper work remain separate follow-ups.

## Verification
- pnpm test:core -- tests/route-watch.test.ts tests/index.test.ts tests/manifest.test.ts
- pnpm build
- pnpm format:check
- git diff --check