### PR TITLE
Coordinate React Router dev generations

### DIFF
--- a/src/dev-generation-coordinator.ts
+++ b/src/dev-generation-coordinator.ts
@@ -1,0 +1,289 @@
+import type { Rspack } from '@rsbuild/core';
+import type { ServerBuild } from 'react-router';
+import type { RouteManifestModuleExports } from './manifest.js';
+
+export type ReactRouterDevManifest = {
+  version?: string;
+  routes?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+export type ReactRouterServerBuild = ServerBuild & {
+  assets?: ReactRouterDevManifest;
+  routes?: Record<string, { module?: Record<string, unknown> }>;
+};
+
+export type ReactRouterWebStage = {
+  id: number;
+  stats?: Rspack.Stats;
+  compilation?: Rspack.Compilation;
+  browserManifest: ReactRouterDevManifest;
+  serverManifest: ReactRouterDevManifest;
+  serverManifestsByBundleId: Readonly<Record<string, ReactRouterDevManifest>>;
+  moduleExportsByRouteId: RouteManifestModuleExports;
+};
+
+export type ReactRouterNodeStage = {
+  id: number;
+  stats?: Rspack.Stats;
+  buildsByEntryName: Readonly<Record<string, ReactRouterServerBuild>>;
+};
+
+export type ReactRouterDevGeneration = {
+  id: number;
+  web: ReactRouterWebStage;
+  node: ReactRouterNodeStage;
+};
+
+export class ReactRouterDevGenerationCoordinator {
+  private nextStageId = 1;
+  private nextGenerationId = 1;
+  private latestWebStage: ReactRouterWebStage | null = null;
+  private latestNodeStage: ReactRouterNodeStage | null = null;
+  private committed: ReactRouterDevGeneration | null = null;
+  private lastError: unknown;
+  private initialWaiters = new Set<{
+    resolve: (generation: ReactRouterDevGeneration) => void;
+    reject: (error: unknown) => void;
+  }>();
+
+  stageWeb(stage: Omit<ReactRouterWebStage, 'id'>): ReactRouterWebStage {
+    const next = {
+      ...stage,
+      id: this.nextStageId++,
+    };
+    this.latestWebStage = next;
+    return next;
+  }
+
+  stageNode(stage: Omit<ReactRouterNodeStage, 'id'>): ReactRouterNodeStage {
+    const next = {
+      ...stage,
+      id: this.nextStageId++,
+    };
+    this.latestNodeStage = next;
+    return next;
+  }
+
+  getLatestWebStage(): ReactRouterWebStage | null {
+    return this.latestWebStage;
+  }
+
+  getLatestNodeStage(): ReactRouterNodeStage | null {
+    return this.latestNodeStage;
+  }
+
+  getCommitted(): ReactRouterDevGeneration | null {
+    return this.committed;
+  }
+
+  getLastError(): unknown {
+    return this.lastError;
+  }
+
+  reject(error: unknown): void {
+    this.lastError = error;
+  }
+
+  commit(
+    web: ReactRouterWebStage | null = this.latestWebStage,
+    node: ReactRouterNodeStage | null = this.latestNodeStage
+  ): ReactRouterDevGeneration {
+    if (!web) {
+      throw new Error(
+        '[rsbuild-plugin-react-router] Cannot commit dev generation before the web manifest is staged.'
+      );
+    }
+    if (!node) {
+      throw new Error(
+        '[rsbuild-plugin-react-router] Cannot commit dev generation before the node server build is staged.'
+      );
+    }
+
+    this.validateNodeStage(web, node);
+
+    const generation = {
+      id: this.nextGenerationId++,
+      web,
+      node,
+    };
+    this.committed = generation;
+    this.lastError = undefined;
+    this.resolveInitialWaiters(generation);
+    return generation;
+  }
+
+  waitForInitialCommitted(): Promise<ReactRouterDevGeneration> {
+    if (this.committed) {
+      return Promise.resolve(this.committed);
+    }
+
+    return new Promise((resolve, reject) => {
+      this.initialWaiters.add({ resolve, reject });
+    });
+  }
+
+  close(): void {
+    const error = new Error(
+      '[rsbuild-plugin-react-router] Dev server closed before a React Router server build was committed.'
+    );
+    for (const waiter of this.initialWaiters) {
+      waiter.reject(error);
+    }
+    this.initialWaiters.clear();
+  }
+
+  private resolveInitialWaiters(generation: ReactRouterDevGeneration): void {
+    for (const waiter of this.initialWaiters) {
+      waiter.resolve(generation);
+    }
+    this.initialWaiters.clear();
+  }
+
+  private validateNodeStage(
+    web: ReactRouterWebStage,
+    node: ReactRouterNodeStage
+  ): void {
+    for (const [entryName, build] of Object.entries(node.buildsByEntryName)) {
+      const expectedManifest = getExpectedManifestForEntry(web, entryName);
+      const actualManifest = build.assets;
+      if (!actualManifest) {
+        throw new Error(
+          `[rsbuild-plugin-react-router] Server build "${entryName}" does not expose a React Router assets manifest.`
+        );
+      }
+      if (!manifestsMatch(expectedManifest, actualManifest)) {
+        throw new Error(
+          `[rsbuild-plugin-react-router] Server build "${entryName}" does not match the staged web manifest.`
+        );
+      }
+      assertBuildMatchesManifest(entryName, build, actualManifest);
+    }
+  }
+}
+
+const getExpectedManifestForEntry = (
+  web: ReactRouterWebStage,
+  entryName: string
+): ReactRouterDevManifest => {
+  const bundleId = entryName.includes('/')
+    ? entryName.slice(0, entryName.lastIndexOf('/'))
+    : undefined;
+  return (
+    (bundleId ? web.serverManifestsByBundleId[bundleId] : undefined) ??
+    web.serverManifest
+  );
+};
+
+const stableStringify = (value: unknown): string =>
+  JSON.stringify(sortObject(value));
+
+const sortObject = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(sortObject);
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, nextValue]) => [key, sortObject(nextValue)])
+  );
+};
+
+const manifestsMatch = (
+  expected: ReactRouterDevManifest,
+  actual: ReactRouterDevManifest
+): boolean => stableStringify(expected) === stableStringify(actual);
+
+const assertBuildMatchesManifest = (
+  entryName: string,
+  build: ReactRouterServerBuild,
+  manifest: ReactRouterDevManifest
+): void => {
+  const manifestRoutes = manifest.routes;
+  if (!manifestRoutes || !build.routes) {
+    return;
+  }
+
+  for (const [routeId, manifestRoute] of Object.entries(manifestRoutes)) {
+    if (!manifestRoute || typeof manifestRoute !== 'object') {
+      continue;
+    }
+    const routeModule = build.routes[routeId]?.module;
+    if (!routeModule) {
+      continue;
+    }
+    const hasLoader = Boolean(
+      (manifestRoute as { hasLoader?: unknown }).hasLoader
+    );
+    const hasAction = Boolean(
+      (manifestRoute as { hasAction?: unknown }).hasAction
+    );
+    if (hasLoader !== (typeof routeModule.loader === 'function')) {
+      throw new Error(
+        `[rsbuild-plugin-react-router] Server build "${entryName}" route "${routeId}" loader export does not match the staged web manifest.`
+      );
+    }
+    if (hasAction !== (typeof routeModule.action === 'function')) {
+      throw new Error(
+        `[rsbuild-plugin-react-router] Server build "${entryName}" route "${routeId}" action export does not match the staged web manifest.`
+      );
+    }
+  }
+};
+
+const devServerCoordinators = new WeakMap<
+  object,
+  ReactRouterDevGenerationCoordinator
+>();
+
+export const registerReactRouterDevServer = (
+  devServer: object,
+  coordinator: ReactRouterDevGenerationCoordinator
+): void => {
+  devServerCoordinators.set(devServer, coordinator);
+};
+
+export const unregisterReactRouterDevServer = (devServer: object): void => {
+  devServerCoordinators.delete(devServer);
+};
+
+export const loadReactRouterServerBuild = async (
+  devServer: object,
+  entryName?: string
+): Promise<ReactRouterServerBuild> => {
+  const coordinator = devServerCoordinators.get(devServer);
+  if (!coordinator) {
+    throw new Error(
+      '[rsbuild-plugin-react-router] No React Router dev generation coordinator is registered for this Rsbuild dev server.'
+    );
+  }
+
+  const generation =
+    coordinator.getCommitted() ?? (await coordinator.waitForInitialCommitted());
+  const build = selectServerBuild(generation, entryName);
+  if (!build) {
+    throw new Error(
+      entryName
+        ? `[rsbuild-plugin-react-router] Committed React Router server build "${entryName}" was not found.`
+        : '[rsbuild-plugin-react-router] No committed React Router server build was found.'
+    );
+  }
+  return build;
+};
+
+const selectServerBuild = (
+  generation: ReactRouterDevGeneration,
+  entryName?: string
+): ReactRouterServerBuild | undefined => {
+  if (entryName) {
+    return generation.node.buildsByEntryName[entryName];
+  }
+  return (
+    generation.node.buildsByEntryName['static/js/app'] ??
+    generation.node.buildsByEntryName.app ??
+    Object.values(generation.node.buildsByEntryName)[0]
+  );
+};

--- a/src/dev-server.ts
+++ b/src/dev-server.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import { loadReactRouterServerBuild } from './dev-generation-coordinator.js';
 import { normalizeBuildModule, resolveBuildExports } from './server-utils.js';
 
 export type DevServerMiddleware = (
@@ -14,22 +15,7 @@ export const createDevServerMiddleware = (server: any): DevServerMiddleware => {
     next: (err?: any) => void
   ): Promise<void> => {
     try {
-      const tryLoadBundle = async (entryName: string) => {
-        try {
-          return await server.environments.node.loadBundle(entryName);
-        } catch (error) {
-          if (
-            error instanceof Error &&
-            error.message.includes("Can't find entry")
-          ) {
-            return null;
-          }
-          throw error;
-        }
-      };
-
-      const bundle =
-        (await tryLoadBundle('static/js/app')) ?? (await tryLoadBundle('app'));
+      const bundle = await loadReactRouterServerBuild(server);
 
       if (!bundle || !bundle.routes) {
         throw new Error('Server bundle not found or invalid');

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,14 @@ import {
 } from './plugin-utils.js';
 import type { PluginOptions } from './types.js';
 import {
+  ReactRouterDevGenerationCoordinator,
+  registerReactRouterDevServer,
+  unregisterReactRouterDevServer,
+  loadReactRouterServerBuild,
+  type ReactRouterDevManifest,
+  type ReactRouterServerBuild,
+} from './dev-generation-coordinator.js';
+import {
   generateServerBuild,
   normalizeBuildModule,
   resolveBuildExports,
@@ -89,6 +97,8 @@ import {
 import { mapVirtualModules } from './virtual-modules.js';
 
 const redirectStatusCodes = new Set([301, 302, 303, 307, 308]);
+
+export { loadReactRouterServerBuild };
 
 type ModuleFederationPluginLike = {
   name?: string;
@@ -538,6 +548,19 @@ export const pluginReactRouter = (
     type ReactRouterManifest = Awaited<
       ReturnType<typeof getReactRouterManifestForDev>
     >;
+    const devGenerationCoordinator = new ReactRouterDevGenerationCoordinator();
+    let currentDevServer: object | undefined;
+    api.onBeforeStartDevServer(({ server }) => {
+      currentDevServer = server as object;
+      registerReactRouterDevServer(currentDevServer, devGenerationCoordinator);
+    });
+    api.onCloseDevServer(() => {
+      if (currentDevServer) {
+        unregisterReactRouterDevServer(currentDevServer);
+        currentDevServer = undefined;
+      }
+      devGenerationCoordinator.close();
+    });
     let latestBrowserManifest: ReactRouterManifest | null = null;
     let latestBrowserManifestModuleExports: RouteManifestModuleExports = {};
     let latestServerManifest: ReactRouterManifest | null = null;
@@ -587,14 +610,125 @@ export const pluginReactRouter = (
       rootDirectory: process.cwd(),
     });
     const routesByServerBundleId = getRoutesByServerBundleId(buildManifest);
+    const serverBuildFileBase = (serverBuildFile || 'index.js').replace(
+      /\.js$/,
+      ''
+    );
+    const serverBuildEntryNames = [
+      'static/js/app',
+      ...Object.entries(routesByServerBundleId)
+        .filter(([, bundleRoutes]) => {
+          return bundleRoutes && Object.keys(bundleRoutes).length > 0;
+        })
+        .map(([bundleId]) => `${bundleId}/${serverBuildFileBase}`),
+    ];
 
     let clientStats: ReactRouterManifestStats | undefined;
-    api.onAfterEnvironmentCompile(({ stats, environment }) => {
+    const statsHasErrors = (stats: Rspack.Stats | undefined): boolean => {
+      return Boolean(
+        stats && typeof stats.hasErrors === 'function'
+          ? stats.hasErrors()
+          : false
+      );
+    };
+    const loadDevServerBuild = async (
+      entryName: string
+    ): Promise<ReactRouterServerBuild | null> => {
+      if (!currentDevServer) {
+        throw new Error(
+          `[${PLUGIN_NAME}] Cannot evaluate React Router server build before the Rsbuild dev server is registered.`
+        );
+      }
+      const devServer = currentDevServer as {
+        environments?: {
+          node?: {
+            loadBundle?: (entryName: string) => Promise<unknown>;
+          };
+        };
+      };
+      const loadBundle = devServer.environments?.node?.loadBundle;
+      if (typeof loadBundle !== 'function') {
+        throw new Error(
+          `[${PLUGIN_NAME}] Rsbuild dev server does not expose node.loadBundle().`
+        );
+      }
+
+      try {
+        const bundle = await loadBundle(entryName);
+        const normalizedBuild = normalizeBuildModule(
+          bundle as Record<string, any>
+        );
+        const build = await resolveBuildExports(normalizedBuild);
+        if (!build || !build.routes) {
+          throw new Error(
+            `[${PLUGIN_NAME}] Server build "${entryName}" is missing React Router routes.`
+          );
+        }
+        return build as ReactRouterServerBuild;
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message.includes("Can't find entry")
+        ) {
+          return null;
+        }
+        throw error;
+      }
+    };
+    const stageNodeServerBuilds = async (
+      stats: Rspack.Stats | undefined
+    ): Promise<void> => {
+      const buildsByEntryName: Record<string, ReactRouterServerBuild> = {};
+      for (const entryName of serverBuildEntryNames) {
+        const build = await loadDevServerBuild(entryName);
+        if (build) {
+          buildsByEntryName[entryName] = build;
+        }
+      }
+
+      if (Object.keys(buildsByEntryName).length === 0) {
+        throw new Error(
+          `[${PLUGIN_NAME}] React Router server build not found.`
+        );
+      }
+
+      const nodeStage = devGenerationCoordinator.stageNode({
+        stats,
+        buildsByEntryName,
+      });
+      devGenerationCoordinator.commit(
+        devGenerationCoordinator.getLatestWebStage(),
+        nodeStage
+      );
+    };
+
+    api.onAfterEnvironmentCompile(async ({ stats, environment }) => {
       if (environment.name === 'web') {
         clientStats = createReactRouterManifestStats(
           stats?.compilation,
           manifestChunkNames
         );
+        if (!isBuild && statsHasErrors(stats)) {
+          devGenerationCoordinator.reject(
+            new Error(`[${PLUGIN_NAME}] Web compilation has errors.`)
+          );
+        }
+      }
+      if (!isBuild && environment.name === 'node') {
+        if (statsHasErrors(stats)) {
+          devGenerationCoordinator.reject(
+            new Error(`[${PLUGIN_NAME}] Node compilation has errors.`)
+          );
+        } else {
+          try {
+            await stageNodeServerBuilds(stats);
+          } catch (error) {
+            devGenerationCoordinator.reject(error);
+            api.logger.error(
+              error instanceof Error ? error.message : String(error)
+            );
+          }
+        }
       }
       if (pluginOptions.federation && ssr) {
         const serverBuildDir = resolve(buildDirectory, 'server');
@@ -1232,11 +1366,6 @@ export const pluginReactRouter = (
           : useAsyncNodeChunkLoading
             ? 'async-node'
             : 'require';
-      const serverBuildFileBase = (serverBuildFile || 'index.js').replace(
-        /\.js$/,
-        ''
-      );
-
       const nodeEntries: Record<string, string> = {
         ...(hasServerApp
           ? {
@@ -1429,7 +1558,12 @@ export const pluginReactRouter = (
                     {
                       future,
                       manifestChunkNames,
-                      onManifest: (manifest, sri, moduleExportsByRouteId) => {
+                      onManifest: (
+                        manifest,
+                        sri,
+                        moduleExportsByRouteId,
+                        manifestContext
+                      ) => {
                         performanceProfiler.recordSync(
                           'web',
                           'manifest:stage',
@@ -1443,6 +1577,10 @@ export const pluginReactRouter = (
                               sri,
                             };
                             latestServerManifest = baseServerManifest;
+                            const nextServerManifestsByBundleId: Record<
+                              string,
+                              ReactRouterManifest
+                            > = {};
                             for (const [
                               bundleId,
                               bundleRoutes,
@@ -1458,10 +1596,29 @@ export const pluginReactRouter = (
                                   ([routeId]) => routeIds.has(routeId)
                                 )
                               );
-                              latestServerManifestsByBundleId[bundleId] = {
+                              nextServerManifestsByBundleId[bundleId] = {
                                 ...baseServerManifest,
                                 routes: filteredRoutes,
                               };
+                            }
+                            Object.assign(
+                              latestServerManifestsByBundleId,
+                              nextServerManifestsByBundleId
+                            );
+                            if (!isBuild) {
+                              devGenerationCoordinator.stageWeb({
+                                compilation: manifestContext.compilation,
+                                browserManifest:
+                                  manifest as ReactRouterDevManifest,
+                                serverManifest:
+                                  baseServerManifest as ReactRouterDevManifest,
+                                serverManifestsByBundleId:
+                                  nextServerManifestsByBundleId as Record<
+                                    string,
+                                    ReactRouterDevManifest
+                                  >,
+                                moduleExportsByRouteId,
+                              });
                             }
                           }
                         );
@@ -1513,8 +1670,16 @@ export const pluginReactRouter = (
               /virtual\/react-router\/server-manifest(?:-([^?]+))?/
             );
             const bundleId = bundleMatch?.[1]?.replace(/\.js$/, '');
+            const stagedWeb = !isBuild
+              ? devGenerationCoordinator.getLatestWebStage()
+              : null;
 
             const manifest =
+              (!isBuild && stagedWeb
+                ? bundleId && stagedWeb.serverManifestsByBundleId[bundleId]
+                  ? stagedWeb.serverManifestsByBundleId[bundleId]
+                  : stagedWeb.serverManifest
+                : null) ??
               (isBuild && latestServerManifest
                 ? bundleId && latestServerManifestsByBundleId[bundleId]
                   ? latestServerManifestsByBundleId[bundleId]

--- a/src/modify-browser-manifest.ts
+++ b/src/modify-browser-manifest.ts
@@ -33,7 +33,11 @@ export function createModifyBrowserManifestPlugin(
       sri: Record<string, string> | undefined,
       moduleExportsByRouteId: Awaited<
         ReturnType<typeof generateReactRouterManifestForDev>
-      >['moduleExportsByRouteId']
+      >['moduleExportsByRouteId'],
+      context: {
+        compilation: Rspack.Compilation;
+        manifestStats: ReturnType<typeof createReactRouterManifestStats>;
+      }
     ) => void;
   }
 ) {
@@ -141,7 +145,10 @@ export function createModifyBrowserManifestPlugin(
             }
           }
 
-          options?.onManifest?.(manifest, sri, moduleExportsByRouteId);
+          options?.onManifest?.(manifest, sri, moduleExportsByRouteId, {
+            compilation,
+            manifestStats: stats,
+          });
         }
       );
     },

--- a/tests/dev-generation-coordinator.test.ts
+++ b/tests/dev-generation-coordinator.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from '@rstest/core';
+import {
+  ReactRouterDevGenerationCoordinator,
+  loadReactRouterServerBuild,
+  registerReactRouterDevServer,
+} from '../src/dev-generation-coordinator';
+
+const createManifest = (hasLoader: boolean) =>
+  ({
+    version: hasLoader ? 'with-loader' : 'without-loader',
+    url: '/static/js/manifest.js',
+    hmr: undefined,
+    routes: {
+      'routes/page': {
+        id: 'routes/page',
+        module: '/app/routes/page.tsx',
+        hasLoader,
+      },
+    },
+  }) as any;
+
+const createBuild = (assets: any, loader?: () => unknown) =>
+  ({
+    assets,
+    routes: {
+      'routes/page': {
+        id: 'routes/page',
+        module: loader ? { loader } : {},
+      },
+    },
+  }) as any;
+
+describe('ReactRouterDevGenerationCoordinator', () => {
+  it('rejects a server build whose embedded manifest does not match the staged web candidate', () => {
+    const coordinator = new ReactRouterDevGenerationCoordinator();
+    const firstManifest = createManifest(false);
+    const firstWeb = coordinator.stageWeb({
+      browserManifest: firstManifest,
+      serverManifest: firstManifest,
+      serverManifestsByBundleId: {},
+      moduleExportsByRouteId: {},
+    });
+    const firstNode = coordinator.stageNode({
+      buildsByEntryName: {
+        'static/js/app': createBuild(firstManifest),
+      },
+    });
+    const firstGeneration = coordinator.commit(firstWeb, firstNode);
+
+    const nextManifest = createManifest(true);
+    const nextWeb = coordinator.stageWeb({
+      browserManifest: nextManifest,
+      serverManifest: nextManifest,
+      serverManifestsByBundleId: {},
+      moduleExportsByRouteId: {},
+    });
+    const mismatchedNode = coordinator.stageNode({
+      buildsByEntryName: {
+        'static/js/app': createBuild(firstManifest, () => 'data'),
+      },
+    });
+
+    expect(() => coordinator.commit(nextWeb, mismatchedNode)).toThrow(
+      'does not match the staged web manifest'
+    );
+    expect(coordinator.getCommitted()).toBe(firstGeneration);
+  });
+
+  it('keeps serving the last committed build after a rejected candidate', async () => {
+    const coordinator = new ReactRouterDevGenerationCoordinator();
+    const server = {};
+    const manifest = createManifest(false);
+    const build = createBuild(manifest);
+
+    registerReactRouterDevServer(server, coordinator);
+    coordinator.commit(
+      coordinator.stageWeb({
+        browserManifest: manifest,
+        serverManifest: manifest,
+        serverManifestsByBundleId: {},
+        moduleExportsByRouteId: {},
+      }),
+      coordinator.stageNode({
+        buildsByEntryName: {
+          'static/js/app': build,
+        },
+      })
+    );
+    coordinator.reject(new Error('candidate failed'));
+
+    await expect(loadReactRouterServerBuild(server)).resolves.toBe(build);
+  });
+
+  it('rejects node-new web-old route export mismatches even when the embedded manifest is old-coherent', () => {
+    const coordinator = new ReactRouterDevGenerationCoordinator();
+    const manifest = createManifest(false);
+    const web = coordinator.stageWeb({
+      browserManifest: manifest,
+      serverManifest: manifest,
+      serverManifestsByBundleId: {},
+      moduleExportsByRouteId: {},
+    });
+    const node = coordinator.stageNode({
+      buildsByEntryName: {
+        'static/js/app': createBuild(manifest, () => 'data'),
+      },
+    });
+
+    expect(() => coordinator.commit(web, node)).toThrow(
+      'loader export does not match the staged web manifest'
+    );
+    expect(coordinator.getCommitted()).toBeNull();
+  });
+
+  it('custom server helper waits for the initial committed generation', async () => {
+    const coordinator = new ReactRouterDevGenerationCoordinator();
+    const server = {};
+    const manifest = createManifest(false);
+    const build = createBuild(manifest);
+    registerReactRouterDevServer(server, coordinator);
+
+    const pendingBuild = loadReactRouterServerBuild(server);
+    let resolved = false;
+    pendingBuild.then(() => {
+      resolved = true;
+    });
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    coordinator.commit(
+      coordinator.stageWeb({
+        browserManifest: manifest,
+        serverManifest: manifest,
+        serverManifestsByBundleId: {},
+        moduleExportsByRouteId: {},
+      }),
+      coordinator.stageNode({
+        buildsByEntryName: {
+          'static/js/app': build,
+        },
+      })
+    );
+
+    await expect(pendingBuild).resolves.toBe(build);
+  });
+});


### PR DESCRIPTION
## Summary

- add a React Router dev generation coordinator that stages web/node candidates and commits only coherent server-build/manifest pairs
- switch built-in dev middleware and the exported custom-server helper to consume the committed generation instead of raw per-request `node.loadBundle()`
- stage browser/server manifests with compilation identity and eagerly evaluate node server builds after node compile

## Notes

This implements the plugin-side framework/control-plane coherence pieces. The Rsbuild graph-settled lifecycle hook and pre-success socket publication gate are still required in Rsbuild core for the full multi-repo guarantee.

TraceDecay requested for exploration, but `tracedecay init` currently fails locally with `UNIQUE constraint failed: index 'idx_edges_unique'`, so this was completed with targeted source inspection.

## Validation

- `pnpm test:core tests/dev-generation-coordinator.test.ts`
- `pnpm build`
- `pnpm format:check`
- `pnpm test:core`
