### PR TITLE
Refactor React Router plugin follow-ups

### DIFF
--- a/.changeset/lazy-entry-hydration.md
+++ b/.changeset/lazy-entry-hydration.md
@@ -1,0 +1,5 @@
+---
+'rsbuild-plugin-react-router': patch
+---
+
+Keep React Router hydration entries compatible with Rsbuild lazy compilation when `entries: true` is enabled.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ pluginReactRouter({
    * Rsbuild dev-only lazy compilation behavior.
    * The plugin guards React Router hydration-critical modules so
    * `lazyCompilation: { entries: true }` remains enabled without replacing
-   * initial route modules with lazy entry proxies.
+   * manifest route modules with lazy entry proxies.
    * @default undefined
    */
   lazyCompilation?: boolean | Rspack.LazyCompilationOptions,

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ pluginReactRouter({
 
   /**
    * Rsbuild dev-only lazy compilation behavior.
+   * The plugin guards React Router hydration-critical modules so
+   * `lazyCompilation: { entries: true }` remains enabled without replacing
+   * initial route modules with lazy entry proxies.
    * @default undefined
    */
   lazyCompilation?: boolean | Rspack.LazyCompilationOptions,
@@ -307,7 +310,7 @@ If no configuration is provided, the following defaults will be used:
   customServer: false,
   serverOutput: 'module',
   federation: false,
-  lazyCompilation: undefined,
+  lazyCompilation: undefined, // Rsbuild's dev defaults still apply
   logPerformance: false,
   parallelTransforms: undefined // adaptive: workers for 256+ resolved routes
 }

--- a/examples/custom-node-server/package.json
+++ b/examples/custom-node-server/package.json
@@ -10,7 +10,7 @@
     "start": "NODE_ENV=production PORT=3003 node server.js",
     "build": "rsbuild build",
     "typecheck": "react-router typegen && tsc --noEmit",
-    "test:e2e": "playwright test && corepack pnpm run test:production",
+    "test:e2e": "RR_E2E_REUSE_EXISTING_SERVER=false playwright test && corepack pnpm run test:production",
     "test:production": "corepack pnpm run test:production:module && corepack pnpm run test:production:commonjs",
     "test:production:module": "RR_SERVER_OUTPUT=module corepack pnpm run build && node scripts/smoke-production.mjs",
     "test:production:commonjs": "RR_SERVER_OUTPUT=commonjs corepack pnpm run build && node scripts/smoke-production.mjs"

--- a/examples/custom-node-server/playwright.config.ts
+++ b/examples/custom-node-server/playwright.config.ts
@@ -44,7 +44,8 @@ export default defineConfig({
   webServer: {
     command: 'corepack pnpm run dev',
     url: 'http://localhost:3003',
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer:
+      !process.env.CI && process.env.RR_E2E_REUSE_EXISTING_SERVER !== 'false',
     timeout: 120000,
   },
 });

--- a/examples/default-template/package.json
+++ b/examples/default-template/package.json
@@ -8,7 +8,8 @@
     "start:esm": "react-router-serve ./build/server/static/js/app.js",
     "start:cjs": "react-router-serve ./cjs-serve-patch.cjs",
     "typecheck": "react-router typegen && tsc",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:e2e:lazy": "cross-env RR_LAZY_COMPILATION=entries playwright test tests/e2e/lazy-compilation.test.ts"
   },
   "dependencies": {
     "@react-router/express": "^7.13.0",

--- a/examples/default-template/rsbuild.config.ts
+++ b/examples/default-template/rsbuild.config.ts
@@ -13,7 +13,17 @@ declare module 'react-router' {
 }
 
 export default defineConfig(() => {
+  const lazyCompilation =
+    process.env.RR_LAZY_COMPILATION === 'entries'
+      ? { entries: true }
+      : undefined;
+
   return {
-    plugins: [pluginReactRouter(), pluginReact(), pluginLess(), pluginSass()],
+    plugins: [
+      pluginReactRouter({ lazyCompilation }),
+      pluginReact(),
+      pluginLess(),
+      pluginSass(),
+    ],
   };
 });

--- a/examples/default-template/tests/e2e/lazy-compilation.test.ts
+++ b/examples/default-template/tests/e2e/lazy-compilation.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 test.describe('lazy compilation', () => {
-  test('hydrates the initial route when route entries are lazy-enabled', async ({
+  test('hydrates with entries:true while manifest route modules stay synchronous', async ({
     page,
   }) => {
     const errors: string[] = [];
@@ -31,6 +31,20 @@ test.describe('lazy compilation', () => {
     });
     expect(initialRouteModules.root).toContain('default');
     expect(initialRouteModules['routes/home']).toContain('default');
+
+    const manifestRouteModules = await page.evaluate(() => {
+      const manifest = (window as any).__reactRouterManifest;
+      return Object.fromEntries(
+        Object.entries(manifest.routes).map(([routeId, route]) => [
+          routeId,
+          (route as { module: string }).module,
+        ])
+      );
+    });
+    const rootRouteAsset = await page.request.get(manifestRouteModules.root);
+    expect(await rootRouteAsset.text()).not.toContain(
+      'lazy-compilation-proxy'
+    );
 
     const documentRequests: string[] = [];
     page.on('request', (request) => {

--- a/examples/default-template/tests/e2e/lazy-compilation.test.ts
+++ b/examples/default-template/tests/e2e/lazy-compilation.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('lazy compilation', () => {
+  test('hydrates the initial route when route entries are lazy-enabled', async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on('console', (message) => {
+      if (message.type() === 'error') {
+        errors.push(message.text());
+      }
+    });
+    page.on('pageerror', (error) => {
+      errors.push(error.message);
+    });
+
+    await page.goto('/');
+
+    await page.waitForFunction(() => {
+      return (window as any).__reactRouterRouteModules !== undefined;
+    });
+
+    const initialRouteModules = await page.evaluate(() => {
+      const modules = (window as any).__reactRouterRouteModules ?? {};
+      return Object.fromEntries(
+        Object.entries(modules).map(([routeId, moduleValue]) => [
+          routeId,
+          Object.keys(moduleValue as Record<string, unknown>).sort(),
+        ])
+      );
+    });
+    expect(initialRouteModules.root).toContain('default');
+    expect(initialRouteModules['routes/home']).toContain('default');
+
+    const documentRequests: string[] = [];
+    page.on('request', (request) => {
+      if (
+        request.isNavigationRequest() &&
+        request.frame() === page.mainFrame()
+      ) {
+        documentRequests.push(request.url());
+      }
+    });
+
+    await page.locator('a[href="/about"]').first().click();
+
+    await expect(page).toHaveURL('/about');
+    await expect(
+      page.locator('h1:has-text("About This Demo")')
+    ).toBeVisible();
+    expect(documentRequests).toEqual([]);
+    expect(errors.join('\n')).not.toMatch(/hydration|Hydration|Component/);
+  });
+});

--- a/scripts/bench-builds.mjs
+++ b/scripts/bench-builds.mjs
@@ -269,6 +269,17 @@ const summarizePluginOperations = runs => {
       for (const [operation, metrics] of Object.entries(
         report.operations ?? {}
       )) {
+        if (!metrics || typeof metrics !== 'object') {
+          continue;
+        }
+
+        const count = typeof metrics.count === 'number' ? metrics.count : 0;
+        const totalMs =
+          typeof metrics.totalMs === 'number' ? metrics.totalMs : 0;
+        const wallMs =
+          typeof metrics.wallMs === 'number' ? metrics.wallMs : null;
+        const maxMs = typeof metrics.maxMs === 'number' ? metrics.maxMs : 0;
+
         const key = `${report.environment}:${operation}`;
         const current = operations.get(key) ?? {
           environment: report.environment,
@@ -279,12 +290,12 @@ const summarizePluginOperations = runs => {
           maxMs: 0,
           reports: 0,
         };
-        current.count += metrics.count ?? 0;
-        current.totalMs += metrics.totalMs ?? 0;
-        if (typeof metrics.wallMs === 'number') {
-          current.wallMs = (current.wallMs ?? 0) + metrics.wallMs;
+        current.count += count;
+        current.totalMs += totalMs;
+        if (wallMs !== null) {
+          current.wallMs = (current.wallMs ?? 0) + wallMs;
         }
-        current.maxMs = Math.max(current.maxMs, metrics.maxMs ?? 0);
+        current.maxMs = Math.max(current.maxMs, maxMs);
         current.reports += 1;
         operations.set(key, current);
       }

--- a/scripts/compare-benchmarks.mjs
+++ b/scripts/compare-benchmarks.mjs
@@ -25,7 +25,12 @@ if (!values.before || !values.after) {
 const readJson = async file => JSON.parse(await readFile(file, 'utf8'));
 const before = await readJson(values.before);
 const after = await readJson(values.after);
-const operations = new Set(values.operations.split(',').filter(Boolean));
+const operations = new Set(
+  values.operations
+    .split(',')
+    .map(value => value.trim())
+    .filter(Boolean)
+);
 
 const findBenchmark = (result, id) => {
   const benchmark = result.benchmarks?.find(item => item.id === id);

--- a/src/bounded-cache.ts
+++ b/src/bounded-cache.ts
@@ -9,9 +9,9 @@ export const setBoundedCacheEntry = <Key, Value>(
     return;
   }
   if (!cache.has(key) && cache.size >= maxEntries) {
-    const oldestKey = cache.keys().next().value;
-    if (oldestKey !== undefined) {
-      cache.delete(oldestKey);
+    const oldestEntry = cache.keys().next();
+    if (!oldestEntry.done) {
+      cache.delete(oldestEntry.value);
     }
   }
   cache.set(key, value);

--- a/src/dev-runtime-compilation.ts
+++ b/src/dev-runtime-compilation.ts
@@ -1,0 +1,92 @@
+import type { Rspack } from '@rsbuild/core';
+import type {
+  DevCompilationIdentity,
+  DevGraphChanges,
+  DevGraphIdentity,
+} from './dev-runtime-artifacts.js';
+
+export type DevCompilerPair = {
+  web: Rspack.Compiler;
+  node: Rspack.Compiler;
+  settledCompilations: WeakSet<Rspack.Compilation>;
+  pendingAttempt?: PendingDevCompilation;
+  latestCompletedWebIdentity?: DevCompilationIdentity;
+  latestWebStart?: CompilationStart;
+  latestNodeStart?: CompilationStart;
+};
+
+export type PendingDevCompilation = {
+  stats: Rspack.Stats | Rspack.MultiStats;
+  changes: DevGraphChanges;
+  identity: DevGraphIdentity;
+  webCompilation: Rspack.Compilation;
+  nodeCompilation: Rspack.Compilation;
+};
+
+export type CompilationStart =
+  | { status: 'pending' }
+  | { status: 'started'; identity: DevCompilationIdentity };
+
+export const isLatestStartedCompilation = (
+  identity: DevCompilationIdentity | undefined,
+  start: CompilationStart | undefined
+): boolean =>
+  !identity || (start?.status === 'started' && start.identity === identity);
+
+export const hasPendingCompilation = (pair: DevCompilerPair): boolean =>
+  pair.latestWebStart?.status === 'pending' ||
+  pair.latestNodeStart?.status === 'pending';
+
+export type CompilationIdentityTracker = {
+  getCompilationIdentity(
+    compilation: Rspack.Compilation
+  ): DevCompilationIdentity;
+  getWebIdentityForNodeCompilation(
+    compilation: Rspack.Compilation
+  ): DevCompilationIdentity | undefined;
+  setWebIdentityForNodeCompilation(
+    compilation: Rspack.Compilation,
+    identity: DevCompilationIdentity
+  ): void;
+};
+
+export const createCompilationIdentityTracker =
+  (): CompilationIdentityTracker => {
+    const identityByCompilation = new WeakMap<
+      Rspack.Compilation,
+      DevCompilationIdentity
+    >();
+    const webIdentityByNodeCompilation = new WeakMap<
+      Rspack.Compilation,
+      DevCompilationIdentity
+    >();
+
+    return {
+      getCompilationIdentity(
+        compilation: Rspack.Compilation
+      ): DevCompilationIdentity {
+        const existing = identityByCompilation.get(compilation);
+        if (existing) {
+          return existing;
+        }
+        const identity = Symbol();
+        // Keep compact lineage tokens in committed state without retaining entire
+        // Rspack compilation graphs across failed rebuilds.
+        identityByCompilation.set(compilation, identity);
+        return identity;
+      },
+
+      getWebIdentityForNodeCompilation(
+        compilation: Rspack.Compilation
+      ): DevCompilationIdentity | undefined {
+        return webIdentityByNodeCompilation.get(compilation);
+      },
+
+      setWebIdentityForNodeCompilation(
+        compilation: Rspack.Compilation,
+        identity: DevCompilationIdentity
+      ): void {
+        webIdentityByNodeCompilation.set(compilation, identity);
+      },
+    };
+  };

--- a/src/dev-runtime-controller.ts
+++ b/src/dev-runtime-controller.ts
@@ -1,75 +1,33 @@
-import type {
-  RsbuildConfig,
-  RsbuildPluginAPI,
-  RsbuildDevServer,
-  Rspack,
-} from '@rsbuild/core';
+import type { RsbuildConfig, RsbuildPluginAPI, Rspack } from '@rsbuild/core';
 import type { ServerBuild } from 'react-router';
 import { PLUGIN_NAME } from './constants.js';
+import {
+  createCompilationIdentityTracker,
+  hasPendingCompilation,
+  isLatestStartedCompilation,
+  type DevCompilerPair,
+} from './dev-runtime-compilation.js';
 import {
   createReactRouterDevRuntime,
   loadReactRouterServerBuild,
   registerReactRouterDevRuntime,
   unregisterReactRouterDevRuntime,
-  type ReactRouterDevRuntime,
 } from './dev-generation.js';
 import {
   getEnvironmentStats,
   snapshotDevChangedFiles,
-  type DevCompilationIdentity,
-  type DevGraphChanges,
-  type DevGraphIdentity,
   type ReactRouterDevBuildPlan,
   type ReactRouterDevManifestSet,
 } from './dev-runtime-artifacts.js';
-
-type DevCompilerPair = {
-  web: Rspack.Compiler;
-  node: Rspack.Compiler;
-  settledCompilations: WeakSet<Rspack.Compilation>;
-  pendingAttempt?: PendingDevCompilation;
-  latestCompletedWebIdentity?: DevCompilationIdentity;
-  latestWebStart?: CompilationStart;
-  latestNodeStart?: CompilationStart;
-};
-
-type PendingDevCompilation = {
-  stats: Rspack.Stats | Rspack.MultiStats;
-  changes: DevGraphChanges;
-  identity: DevGraphIdentity;
-  webCompilation: Rspack.Compilation;
-  nodeCompilation: Rspack.Compilation;
-};
-
-type CompilationStart =
-  | { status: 'pending' }
-  | { status: 'started'; identity: DevCompilationIdentity };
-
-type RuntimeBinding = {
-  id: number;
-  server: RsbuildDevServer;
-  runtime: ReactRouterDevRuntime;
-  compilers?: DevCompilerPair;
-};
-
-type CloseOutcome = { ok: true } | { ok: false; cause: unknown };
-
-type CloseObservation = {
-  binding?: RuntimeBinding;
-  promise?: Promise<void>;
-  outcome?: CloseOutcome;
-};
+import {
+  createDevRuntimeSessionManager,
+  type RuntimeBinding,
+} from './dev-runtime-session.js';
 
 type ServerSetup = Exclude<
   NonNullable<NonNullable<RsbuildConfig['server']>['setup']>,
   unknown[]
 >;
-
-type ControllerState =
-  | { status: 'idle' }
-  | { status: 'active'; binding: RuntimeBinding }
-  | { status: 'closing'; binding: RuntimeBinding }
-  | { status: 'terminal'; error: Error };
 
 export type ReactRouterDevRuntimeController = {
   captureWeb: (
@@ -91,16 +49,6 @@ const escapeHtml = (value: string): string =>
     .replaceAll('<', '&lt;')
     .replaceAll('>', '&gt;');
 
-const isLatestStartedCompilation = (
-  identity: DevCompilationIdentity | undefined,
-  start: CompilationStart | undefined
-): boolean =>
-  !identity || (start?.status === 'started' && start.identity === identity);
-
-const hasPendingCompilation = (pair: DevCompilerPair): boolean =>
-  pair.latestWebStart?.status === 'pending' ||
-  pair.latestNodeStart?.status === 'pending';
-
 export const createReactRouterDevRuntimeController = ({
   api,
   isBuild,
@@ -120,42 +68,6 @@ export const createReactRouterDevRuntimeController = ({
     };
   }
 
-  let state: ControllerState = { status: 'idle' };
-  let nextSessionId = 1;
-  const identityByCompilation = new WeakMap<
-    Rspack.Compilation,
-    DevCompilationIdentity
-  >();
-  const webIdentityByNodeCompilation = new WeakMap<
-    Rspack.Compilation,
-    DevCompilationIdentity
-  >();
-  const closeObservationByServer = new WeakMap<
-    RsbuildDevServer,
-    CloseObservation
-  >();
-
-  const getCompilationIdentity = (
-    compilation: Rspack.Compilation
-  ): DevCompilationIdentity => {
-    const existing = identityByCompilation.get(compilation);
-    if (existing) {
-      return existing;
-    }
-    const identity = Symbol();
-    // Keep compact lineage tokens in committed state without retaining entire
-    // Rspack compilation graphs across failed rebuilds.
-    identityByCompilation.set(compilation, identity);
-    return identity;
-  };
-
-  const getActiveBinding = (): RuntimeBinding | undefined =>
-    state.status === 'active' ? state.binding : undefined;
-
-  const isCurrentBinding = (binding: RuntimeBinding): boolean =>
-    (state.status === 'active' || state.status === 'closing') &&
-    state.binding === binding;
-
   const closeBinding = (binding: RuntimeBinding, error?: Error): void => {
     const pair = binding.compilers;
     if (pair) {
@@ -169,80 +81,9 @@ export const createReactRouterDevRuntimeController = ({
     unregisterReactRouterDevRuntime(binding.server, binding.runtime);
   };
 
-  const completeClose = (binding: RuntimeBinding): void => {
-    if (!isCurrentBinding(binding)) {
-      return;
-    }
-    if (state.status === 'active') {
-      closeBinding(binding);
-    }
-    state = { status: 'idle' };
-  };
-
-  const failClose = (binding: RuntimeBinding, cause: unknown): void => {
-    if (!isCurrentBinding(binding)) {
-      return;
-    }
-    const error = new Error(
-      `[${PLUGIN_NAME}] The previous development server failed to close. Restart the process before retrying because Rsbuild may not have finished tearing down its compiler and watchers.`,
-      { cause }
-    );
-    closeBinding(binding, error);
-    state = { status: 'terminal', error };
-  };
-
-  const applyCloseOutcome = (
-    observation: CloseObservation,
-    outcome: CloseOutcome
-  ): void => {
-    observation.outcome = outcome;
-    const { binding } = observation;
-    if (!binding) {
-      return;
-    }
-    if (outcome.ok) {
-      completeClose(binding);
-    } else {
-      failClose(binding, outcome.cause);
-    }
-    observation.binding = undefined;
-  };
-
-  const observeClose = (server: RsbuildDevServer): CloseObservation => {
-    const existing = closeObservationByServer.get(server);
-    if (existing) {
-      return existing;
-    }
-    const observation: CloseObservation = {};
-    const close = server.close.bind(server);
-    server.close = () => {
-      if (observation.promise) {
-        return observation.promise;
-      }
-      let closePromise: Promise<void>;
-      try {
-        closePromise = close();
-      } catch (cause) {
-        closePromise = Promise.reject(cause);
-      }
-      observation.promise = closePromise;
-      void closePromise.then(
-        () => applyCloseOutcome(observation, { ok: true }),
-        cause => applyCloseOutcome(observation, { ok: false, cause })
-      );
-      return closePromise;
-    };
-    closeObservationByServer.set(server, observation);
-    return observation;
-  };
-
-  const bindCloseObservation = (binding: RuntimeBinding): void => {
-    const observation = observeClose(binding.server);
-    observation.binding = binding;
-    if (observation.outcome) {
-      applyCloseOutcome(observation, observation.outcome);
-    }
-  };
+  const sessions = createDevRuntimeSessionManager(closeBinding);
+  const compilationIdentities = createCompilationIdentityTracker();
+  const { getCompilationIdentity } = compilationIdentities;
 
   const flushSettledAttempt = (
     binding: RuntimeBinding,
@@ -251,7 +92,7 @@ export const createReactRouterDevRuntimeController = ({
     const pending = pair.pendingAttempt;
     if (
       !pending ||
-      getActiveBinding()?.id !== binding.id ||
+      sessions.getActiveBinding()?.id !== binding.id ||
       !pair.settledCompilations.has(pending.webCompilation) ||
       !pair.settledCompilations.has(pending.nodeCompilation)
     ) {
@@ -267,7 +108,7 @@ export const createReactRouterDevRuntimeController = ({
     void binding.runtime
       .finishAttempt(pending.stats, pending.changes, pending.identity)
       .catch(cause => {
-        if (getActiveBinding()?.id === binding.id) {
+        if (sessions.getActiveBinding()?.id === binding.id) {
           binding.runtime.failAttempt(
             cause instanceof Error ? cause : new Error(String(cause))
           );
@@ -278,13 +119,12 @@ export const createReactRouterDevRuntimeController = ({
   const rejectUnsupportedCompiler = (reason: string): void => {
     const message = `[${PLUGIN_NAME}] Could not coordinate React Router development output because ${reason}.`;
     api.logger.warn(message);
-    const binding = getActiveBinding();
+    const binding = sessions.getActiveBinding();
     if (!binding) {
       return;
     }
     const error = new Error(message);
-    closeBinding(binding, error);
-    state = { status: 'terminal', error };
+    sessions.terminate(binding, error);
   };
 
   // Rsbuild runs server.setup before onBeforeStartDevServer. Prepending the
@@ -300,7 +140,7 @@ export const createReactRouterDevRuntimeController = ({
         : [];
       const observeServer: ServerSetup = context => {
         if (context.action === 'dev') {
-          observeClose(context.server);
+          sessions.observeClose(context.server);
         }
       };
       return {
@@ -316,24 +156,12 @@ export const createReactRouterDevRuntimeController = ({
   api.onBeforeStartDevServer({
     order: 'pre',
     async handler({ server }) {
-      if (state.status === 'terminal') {
-        throw state.error;
-      }
-      if (state.status === 'active') {
-        throw new Error(
-          `[${PLUGIN_NAME}] A development server is already active. Await its close() before calling createDevServer() again. If startup failed before returning the server, restart the process before retrying.`
-        );
-      }
-      if (state.status === 'closing') {
-        throw new Error(
-          `[${PLUGIN_NAME}] The previous development server is still closing. Await its close() before calling createDevServer() again.`
-        );
-      }
+      sessions.assertCanStart();
       const runtime = createReactRouterDevRuntime({
         server,
         buildPlan,
         onEvaluationError(error) {
-          if (getActiveBinding()?.runtime !== runtime) {
+          if (sessions.getActiveBinding()?.runtime !== runtime) {
             return;
           }
           api.logger.error(error.message);
@@ -344,29 +172,28 @@ export const createReactRouterDevRuntimeController = ({
         },
         onWarning: message => api.logger.warn(message),
       });
-      const binding = { id: nextSessionId++, server, runtime };
-      state = { status: 'active', binding };
+      const binding = sessions.createBinding(server, runtime);
       registerReactRouterDevRuntime(server, runtime);
-      bindCloseObservation(binding);
+      sessions.bindCloseObservation(binding);
     },
   });
 
   api.onCloseDevServer({
     order: 'pre',
     handler() {
-      if (state.status !== 'active') {
+      const binding = sessions.getActiveBinding();
+      if (!binding) {
         return;
       }
-      const binding = state.binding;
       closeBinding(binding);
-      state = { status: 'closing', binding };
+      sessions.markClosing(binding);
     },
   });
 
   api.onBeforeDevCompile({
     order: 'pre',
     handler() {
-      const binding = getActiveBinding();
+      const binding = sessions.getActiveBinding();
       const pair = binding?.compilers;
       if (!binding || !pair || hasPendingCompilation(pair)) {
         return;
@@ -387,7 +214,7 @@ export const createReactRouterDevRuntimeController = ({
       rejectUnsupportedCompiler('the web or node compiler was missing');
       return;
     }
-    const binding = getActiveBinding();
+    const binding = sessions.getActiveBinding();
     if (!binding) {
       return;
     }
@@ -400,7 +227,7 @@ export const createReactRouterDevRuntimeController = ({
     const sessionId = binding.id;
     const runtime = binding.runtime;
     const failCurrentAttempt = (side: 'web' | 'node', error: Error): void => {
-      if (getActiveBinding()?.id === sessionId) {
+      if (sessions.getActiveBinding()?.id === sessionId) {
         if (side === 'web') {
           pair.latestWebStart = undefined;
         } else {
@@ -414,7 +241,7 @@ export const createReactRouterDevRuntimeController = ({
       side: 'latestWebStart' | 'latestNodeStart'
     ): void => {
       if (
-        getActiveBinding()?.id === sessionId &&
+        sessions.getActiveBinding()?.id === sessionId &&
         pair[side]?.status !== 'pending'
       ) {
         const attemptAlreadyPending = hasPendingCompilation(pair);
@@ -436,7 +263,7 @@ export const createReactRouterDevRuntimeController = ({
     web.hooks.done.tap(
       { name: `${PLUGIN_NAME}:dev-web-complete`, stage: -1000 },
       stats => {
-        if (getActiveBinding()?.id !== sessionId) {
+        if (sessions.getActiveBinding()?.id !== sessionId) {
           return;
         }
         pair.latestCompletedWebIdentity = getCompilationIdentity(
@@ -447,7 +274,7 @@ export const createReactRouterDevRuntimeController = ({
     web.hooks.thisCompilation.tap(
       `${PLUGIN_NAME}:dev-web-compilation`,
       compilation => {
-        if (getActiveBinding()?.id === sessionId) {
+        if (sessions.getActiveBinding()?.id === sessionId) {
           pair.latestWebStart = {
             status: 'started',
             identity: getCompilationIdentity(compilation),
@@ -458,7 +285,7 @@ export const createReactRouterDevRuntimeController = ({
     node.hooks.thisCompilation.tap(
       `${PLUGIN_NAME}:dev-node-web-compilation`,
       compilation => {
-        if (getActiveBinding()?.id !== sessionId) {
+        if (sessions.getActiveBinding()?.id !== sessionId) {
           return;
         }
         pair.latestNodeStart = {
@@ -466,7 +293,7 @@ export const createReactRouterDevRuntimeController = ({
           identity: getCompilationIdentity(compilation),
         };
         if (pair.latestCompletedWebIdentity) {
-          webIdentityByNodeCompilation.set(
+          compilationIdentities.setWebIdentityForNodeCompilation(
             compilation,
             pair.latestCompletedWebIdentity
           );
@@ -474,7 +301,7 @@ export const createReactRouterDevRuntimeController = ({
       }
     );
     const settleCompilation = (stats: Rspack.Stats): void => {
-      if (getActiveBinding()?.id !== sessionId) {
+      if (sessions.getActiveBinding()?.id !== sessionId) {
         return;
       }
       pair.settledCompilations.add(stats.compilation);
@@ -497,7 +324,7 @@ export const createReactRouterDevRuntimeController = ({
   });
 
   api.onAfterDevCompile(async ({ stats }) => {
-    const binding = getActiveBinding();
+    const binding = sessions.getActiveBinding();
     const pair = binding?.compilers;
     if (!binding || !pair) {
       return;
@@ -530,7 +357,9 @@ export const createReactRouterDevRuntimeController = ({
       web: webIdentity,
       node: nodeIdentity,
       nodeWeb: nodeStats
-        ? webIdentityByNodeCompilation.get(nodeStats.compilation)
+        ? compilationIdentities.getWebIdentityForNodeCompilation(
+            nodeStats.compilation
+          )
         : undefined,
     };
     if (!webStats || !nodeStats) {
@@ -549,17 +378,18 @@ export const createReactRouterDevRuntimeController = ({
 
   return {
     captureWeb(compilation, manifestsByEntryName): void {
-      const binding = getActiveBinding();
+      const binding = sessions.getActiveBinding();
       if (binding?.compilers?.web === compilation.compiler) {
         binding.runtime.captureWeb(compilation, manifestsByEntryName);
       }
     },
 
     createBuildLoader(entryName?: string): () => Promise<ServerBuild> {
-      const server = getActiveBinding()?.server;
+      const server = sessions.getActiveBinding()?.server;
       if (server) {
         return () => loadReactRouterServerBuild(server, entryName);
       }
+      const state = sessions.getState();
       if (state.status === 'terminal') {
         const { error } = state;
         return () => Promise.reject(error);

--- a/src/dev-runtime-session.ts
+++ b/src/dev-runtime-session.ts
@@ -1,0 +1,184 @@
+import type { RsbuildDevServer } from '@rsbuild/core';
+import { PLUGIN_NAME } from './constants.js';
+import type { ReactRouterDevRuntime } from './dev-generation.js';
+import type { DevCompilerPair } from './dev-runtime-compilation.js';
+
+export type RuntimeBinding = {
+  id: number;
+  server: RsbuildDevServer;
+  runtime: ReactRouterDevRuntime;
+  compilers?: DevCompilerPair;
+};
+
+type CloseOutcome = { ok: true } | { ok: false; cause: unknown };
+
+type CloseObservation = {
+  binding?: RuntimeBinding;
+  promise?: Promise<void>;
+  outcome?: CloseOutcome;
+};
+
+export type ControllerState =
+  | { status: 'idle' }
+  | { status: 'active'; binding: RuntimeBinding }
+  | { status: 'closing'; binding: RuntimeBinding }
+  | { status: 'terminal'; error: Error };
+
+type CloseBinding = (binding: RuntimeBinding, error?: Error) => void;
+
+export type DevRuntimeSessionManager = {
+  getState(): ControllerState;
+  getActiveBinding(): RuntimeBinding | undefined;
+  observeClose(server: RsbuildDevServer): void;
+  assertCanStart(): void;
+  createBinding(
+    server: RsbuildDevServer,
+    runtime: ReactRouterDevRuntime
+  ): RuntimeBinding;
+  bindCloseObservation(binding: RuntimeBinding): void;
+  markClosing(binding: RuntimeBinding): void;
+  terminate(binding: RuntimeBinding, error: Error): void;
+};
+
+export const createDevRuntimeSessionManager = (
+  closeBinding: CloseBinding
+): DevRuntimeSessionManager => {
+  let state: ControllerState = { status: 'idle' };
+  let nextSessionId = 1;
+  const closeObservationByServer = new WeakMap<
+    RsbuildDevServer,
+    CloseObservation
+  >();
+
+  const getState = (): ControllerState => state;
+
+  const getActiveBinding = (): RuntimeBinding | undefined =>
+    state.status === 'active' ? state.binding : undefined;
+
+  const isCurrentBinding = (binding: RuntimeBinding): boolean =>
+    (state.status === 'active' || state.status === 'closing') &&
+    state.binding === binding;
+
+  const completeClose = (binding: RuntimeBinding): void => {
+    if (!isCurrentBinding(binding)) {
+      return;
+    }
+    if (state.status === 'active') {
+      closeBinding(binding);
+    }
+    state = { status: 'idle' };
+  };
+
+  const failClose = (binding: RuntimeBinding, cause: unknown): void => {
+    if (!isCurrentBinding(binding)) {
+      return;
+    }
+    const error = new Error(
+      `[${PLUGIN_NAME}] The previous development server failed to close. Restart the process before retrying because Rsbuild may not have finished tearing down its compiler and watchers.`,
+      { cause }
+    );
+    closeBinding(binding, error);
+    state = { status: 'terminal', error };
+  };
+
+  const applyCloseOutcome = (
+    observation: CloseObservation,
+    outcome: CloseOutcome
+  ): void => {
+    observation.outcome = outcome;
+    const { binding } = observation;
+    if (!binding) {
+      return;
+    }
+    if (outcome.ok) {
+      completeClose(binding);
+    } else {
+      failClose(binding, outcome.cause);
+    }
+    observation.binding = undefined;
+  };
+
+  const observeClose = (server: RsbuildDevServer): CloseObservation => {
+    const existing = closeObservationByServer.get(server);
+    if (existing) {
+      return existing;
+    }
+    const observation: CloseObservation = {};
+    const close = server.close.bind(server);
+    server.close = () => {
+      if (observation.promise) {
+        return observation.promise;
+      }
+      let closePromise: Promise<void>;
+      try {
+        closePromise = close();
+      } catch (cause) {
+        closePromise = Promise.reject(cause);
+      }
+      observation.promise = closePromise;
+      void closePromise.then(
+        () => applyCloseOutcome(observation, { ok: true }),
+        cause => applyCloseOutcome(observation, { ok: false, cause })
+      );
+      return closePromise;
+    };
+    closeObservationByServer.set(server, observation);
+    return observation;
+  };
+
+  return {
+    getState,
+    getActiveBinding,
+
+    observeClose(server: RsbuildDevServer): void {
+      observeClose(server);
+    },
+
+    assertCanStart(): void {
+      if (state.status === 'terminal') {
+        throw state.error;
+      }
+      if (state.status === 'active') {
+        throw new Error(
+          `[${PLUGIN_NAME}] A development server is already active. Await its close() before calling createDevServer() again. If startup failed before returning the server, restart the process before retrying.`
+        );
+      }
+      if (state.status === 'closing') {
+        throw new Error(
+          `[${PLUGIN_NAME}] The previous development server is still closing. Await its close() before calling createDevServer() again.`
+        );
+      }
+    },
+
+    createBinding(
+      server: RsbuildDevServer,
+      runtime: ReactRouterDevRuntime
+    ): RuntimeBinding {
+      const binding = { id: nextSessionId++, server, runtime };
+      state = { status: 'active', binding };
+      return binding;
+    },
+
+    bindCloseObservation(binding: RuntimeBinding): void {
+      const observation = observeClose(binding.server);
+      observation.binding = binding;
+      if (observation.outcome) {
+        applyCloseOutcome(observation, observation.outcome);
+      }
+    },
+
+    markClosing(binding: RuntimeBinding): void {
+      if (isCurrentBinding(binding)) {
+        state = { status: 'closing', binding };
+      }
+    },
+
+    terminate(binding: RuntimeBinding, error: Error): void {
+      if (!isCurrentBinding(binding)) {
+        return;
+      }
+      closeBinding(binding, error);
+      state = { status: 'terminal', error };
+    },
+  };
+};

--- a/src/export-utils.ts
+++ b/src/export-utils.ts
@@ -58,6 +58,7 @@ const parseProgram = (code: string, resourcePath?: string) => {
 const isTypeOnlyExport = (node: AnyNode): boolean =>
   node.exportKind === 'type' ||
   node.type === 'TSExportAssignment' ||
+  node.declaration?.declare === true ||
   (node.type === 'ExportDefaultDeclaration' &&
     node.declaration?.type === 'TSInterfaceDeclaration');
 

--- a/src/export-utils.ts
+++ b/src/export-utils.ts
@@ -1,6 +1,11 @@
 import { readFile, stat } from 'node:fs/promises';
 import { langFromPath, parse } from 'yuku-parser';
 import { setBoundedCacheEntry } from './bounded-cache.js';
+import {
+  getExportedName,
+  getIdentifierNamesFromPattern,
+  type AnyNode,
+} from './route-ast.js';
 
 type ExportInfo = {
   readonly exportNames: readonly string[];
@@ -27,8 +32,6 @@ const routeModuleAnalysisCache = new Map<
 
 const MAX_EXPORT_UTILS_CACHE_ENTRIES = 2048;
 
-type AnyNode = Record<string, any>;
-
 const cachePromiseOnReject = <T>(
   promise: Promise<T>,
   invalidate: () => void
@@ -50,54 +53,6 @@ const parseProgram = (code: string, resourcePath?: string) => {
     throw new Error(errors.map(error => error.message).join('\n'));
   }
   return result.program;
-};
-
-const getIdentifierNamesFromPattern = (
-  pattern: AnyNode | null | undefined,
-  names: string[] = []
-): string[] => {
-  if (!pattern) {
-    return names;
-  }
-  if (pattern.type === 'Identifier') {
-    names.push(pattern.name);
-    return names;
-  }
-  if (pattern.type === 'RestElement') {
-    return getIdentifierNamesFromPattern(pattern.argument, names);
-  }
-  if (pattern.type === 'AssignmentPattern') {
-    return getIdentifierNamesFromPattern(pattern.left, names);
-  }
-  if (pattern.type === 'ArrayPattern') {
-    for (const element of pattern.elements ?? []) {
-      getIdentifierNamesFromPattern(element, names);
-    }
-    return names;
-  }
-  if (pattern.type === 'ObjectPattern') {
-    for (const property of pattern.properties ?? []) {
-      if (property.type === 'RestElement') {
-        getIdentifierNamesFromPattern(property.argument, names);
-      } else {
-        getIdentifierNamesFromPattern(property.value, names);
-      }
-    }
-  }
-  return names;
-};
-
-const getExportedName = (node: AnyNode): string | null => {
-  if (!node) {
-    return null;
-  }
-  if (node.type === 'Identifier') {
-    return node.name;
-  }
-  if (node.type === 'Literal' || node.type === 'StringLiteral') {
-    return String(node.value);
-  }
-  return null;
 };
 
 const isTypeOnlyExport = (node: AnyNode): boolean =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import {
   JS_EXTENSIONS,
   PLUGIN_NAME,
 } from './constants.js';
+import { guardReactRouterLazyCompilation } from './lazy-compilation.js';
 import { createDevServerMiddleware } from './dev-server.js';
 import {
   generateWithProps,
@@ -33,9 +34,13 @@ import {
   resolveServerBuildModule,
 } from './server-utils.js';
 import {
+  createPrerenderRoutes,
   getPrerenderConcurrency,
+  getSsrFalsePrerenderExportErrors,
+  normalizePrerenderMatchPath,
   resolvePrerenderPaths,
   validatePrerenderConfig,
+  withBuildRequest,
 } from './prerender.js';
 import {
   resolveReactRouterConfig,
@@ -76,6 +81,10 @@ import {
   getBuildManifest,
   getRoutesByServerBundleId,
 } from './build-manifest.js';
+import {
+  createReactRouterNodeEntries,
+  createReactRouterServerBuildPlan,
+} from './server-build-plan.js';
 import {
   isSourceMapEnabled,
   warnOnClientSourceMaps,
@@ -591,42 +600,16 @@ export const pluginReactRouter = (
       buildManifest,
       routes
     );
-    const serverBuildFileBase = (serverBuildFile || 'index.js').replace(
-      /\.js$/,
-      ''
-    );
-    const serverBundleEntries = Object.entries(routesByServerBundleId)
-      .filter(([, bundleRoutes]) =>
-        Boolean(bundleRoutes && Object.keys(bundleRoutes).length > 0)
-      )
-      .map(([bundleId]) => ({
-        bundleId,
-        entryName: `${bundleId}/${serverBuildFileBase}`,
-      }));
-    const reservedNodeEntryNames = new Set([
-      'static/js/app',
-      'static/js/entry.server',
-      devServerBuildEntryName,
-    ]);
-    for (const { entryName } of serverBundleEntries) {
-      if (reservedNodeEntryNames.has(entryName)) {
-        throw new Error(
-          `[${PLUGIN_NAME}] Server bundle entry ${JSON.stringify(entryName)} conflicts with a reserved node entry.`
-        );
-      }
-      reservedNodeEntryNames.add(entryName);
-    }
-    const devBuildPlan = {
+    const serverBuildPlan = createReactRouterServerBuildPlan({
+      routesByServerBundleId,
+      serverBuildFile,
       defaultEntryName: devServerBuildEntryName,
-      entryNames: [
-        devServerBuildEntryName,
-        ...serverBundleEntries.map(({ entryName }) => entryName),
-      ],
-    };
+    });
+    const { serverBundleEntries } = serverBuildPlan;
     const devRuntime = createReactRouterDevRuntimeController({
       api,
       isBuild,
-      buildPlan: devBuildPlan,
+      buildPlan: serverBuildPlan,
     });
 
     let clientStats: ReactRouterManifestStats | undefined;
@@ -662,60 +645,6 @@ export const pluginReactRouter = (
         warn: message => api.logger.warn(message),
       }
     );
-    const groupRoutesByParentId = (manifest: Record<string, any>) => {
-      const grouped: Record<string, any[]> = {};
-      Object.values(manifest).forEach(route => {
-        if (!route) return;
-        const parentId = route.parentId || '';
-        if (!grouped[parentId]) {
-          grouped[parentId] = [];
-        }
-        grouped[parentId].push(route);
-      });
-      return grouped;
-    };
-
-    type MatchRouteObject =
-      Parameters<typeof matchRoutes>[0] extends Array<infer R> ? R : never;
-
-    const createPrerenderRoutes = (
-      manifest: Record<string, any>,
-      parentId = '',
-      grouped = groupRoutesByParentId(manifest)
-    ): MatchRouteObject[] => {
-      return (grouped[parentId] || []).map(route => {
-        const common = { id: route.id, path: route.path };
-        if (route.index) {
-          return { index: true, ...common } as MatchRouteObject;
-        }
-        return {
-          ...common,
-          children: createPrerenderRoutes(manifest, route.id, grouped),
-        } as MatchRouteObject;
-      });
-    };
-
-    const normalizePrerenderMatchPath = (path: string) =>
-      `/${path}/`.replace(/^\/\/+/, '/');
-
-    const withBuildRequest = async <T>(
-      input: string | URL,
-      init: RequestInit | undefined,
-      handle: (request: Request) => Promise<T>
-    ): Promise<T> => {
-      const controller = new AbortController();
-      try {
-        return await handle(
-          new Request(input, {
-            ...init,
-            signal: controller.signal,
-          })
-        );
-      } finally {
-        controller.abort();
-      }
-    };
-
     const prerenderData = async (
       handler: (request: Request) => Promise<Response>,
       prerenderPath: string,
@@ -927,78 +856,19 @@ export const pluginReactRouter = (
       );
     };
 
-    const validateSsrFalsePrerenderExports = async (
-      manifest: Awaited<ReturnType<typeof getReactRouterManifestForDev>>,
+    const assertValidSsrFalsePrerenderExports = (
+      manifestRoutes: Awaited<
+        ReturnType<typeof getReactRouterManifestForDev>
+      >['routes'],
       routeExports: RouteManifestModuleExports,
       prerenderList: string[]
     ) => {
-      if (prerenderList.length === 0) {
-        return;
-      }
-
-      const prerenderRoutes = createPrerenderRoutes(routes);
-      const prerenderedRoutes = new Set<string>();
-      for (const path of prerenderList) {
-        const matches = matchRoutes(
-          prerenderRoutes,
-          normalizePrerenderMatchPath(path)
-        );
-        if (!matches) {
-          throw new Error(
-            `Unable to prerender path because it does not match any routes: ${path}`
-          );
-        }
-        matches.forEach(match =>
-          prerenderedRoutes.add(match.route.id as string)
-        );
-      }
-
-      const errors: string[] = [];
-      for (const [routeId, route] of Object.entries(manifest.routes)) {
-        const exports = routeExports[routeId] ?? [];
-        const invalidApis: string[] = [];
-
-        if (exports.includes('headers')) invalidApis.push('headers');
-        if (exports.includes('action')) invalidApis.push('action');
-
-        if (invalidApis.length > 0) {
-          errors.push(
-            `Prerender: ${invalidApis.length} invalid route export(s) in ` +
-              `\`${routeId}\` when pre-rendering with \`ssr:false\`: ` +
-              `${invalidApis.map(api => `\`${api}\``).join(', ')}. ` +
-              `See https://reactrouter.com/how-to/pre-rendering#invalid-exports for more information.`
-          );
-        }
-
-        if (!prerenderedRoutes.has(routeId)) {
-          if (exports.includes('loader')) {
-            errors.push(
-              `Prerender: 1 invalid route export in \`${routeId}\` when pre-rendering with ` +
-                `\`ssr:false\`: \`loader\`. ` +
-                `See https://reactrouter.com/how-to/pre-rendering#invalid-exports for more information.`
-            );
-          }
-
-          let parentRoute =
-            route.parentId && manifest.routes[route.parentId]
-              ? manifest.routes[route.parentId]
-              : null;
-          while (parentRoute && parentRoute.id !== 'root') {
-            if (parentRoute.hasLoader && !parentRoute.hasClientLoader) {
-              errors.push(
-                `Prerender: 1 invalid route export in \`${parentRoute.id}\` when ` +
-                  `pre-rendering with \`ssr:false\`: \`loader\`. ` +
-                  `See https://reactrouter.com/how-to/pre-rendering#invalid-exports for more information.`
-              );
-            }
-            parentRoute =
-              parentRoute.parentId && parentRoute.parentId !== 'root'
-                ? manifest.routes[parentRoute.parentId]
-                : null;
-          }
-        }
-      }
-
+      const errors = getSsrFalsePrerenderExportErrors({
+        routes,
+        manifestRoutes,
+        routeExports,
+        prerenderPaths: prerenderList,
+      });
       if (errors.length > 0) {
         api.logger.error(errors.join('\n'));
         throw new Error(
@@ -1073,8 +943,8 @@ export const pluginReactRouter = (
                   assetPrefix,
                   routeChunkOptions
                 );
-            await validateSsrFalsePrerenderExports(
-              generated.manifest,
+            assertValidSsrFalsePrerenderExports(
+              generated.manifest.routes,
               generated.moduleExportsByRouteId,
               prerenderPaths
             );
@@ -1275,26 +1145,27 @@ export const pluginReactRouter = (
       } else if (useAsyncNodeChunkLoading) {
         nodeChunkLoading = 'async-node';
       }
-      const nodeEntries: Record<string, string> = {
-        'static/js/app': hasServerApp
-          ? serverAppPath
-          : 'virtual/react-router/server-build',
-        ...(hasServerApp && !isBuild
-          ? {
-              [devServerBuildEntryName]: 'virtual/react-router/server-build',
-            }
-          : {}),
-        'static/js/entry.server': finalEntryServerPath,
-      };
-      for (const { bundleId, entryName } of serverBundleEntries) {
-        nodeEntries[entryName] =
-          `virtual/react-router/server-build-${bundleId}`;
-      }
+      const nodeEntries = createReactRouterNodeEntries({
+        hasServerApp,
+        isBuild,
+        serverAppPath,
+        entryServerPath: finalEntryServerPath,
+        defaultEntryName: devServerBuildEntryName,
+        serverBundleEntries,
+      });
 
-      const lazyCompilation =
+      const configuredLazyCompilation =
         pluginOptions.lazyCompilation === undefined
+          ? config.dev?.lazyCompilation
+          : pluginOptions.lazyCompilation;
+      const guardedLazyCompilation = guardReactRouterLazyCompilation({
+        lazyCompilation: configuredLazyCompilation,
+        entryClientPath: finalEntryClientPath,
+      });
+      const lazyCompilation =
+        guardedLazyCompilation === undefined
           ? {}
-          : { lazyCompilation: pluginOptions.lazyCompilation };
+          : { lazyCompilation: guardedLazyCompilation };
       const shouldCompactFileSizeReport =
         isBuild &&
         routeCount >= 256 &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ import {
   type ReactRouterManifestStats,
   type RouteManifestModuleExports,
 } from './manifest.js';
-import { createModifyBrowserManifestPlugin } from './modify-browser-manifest.js';
+import { registerModifyBrowserManifestAssets } from './modify-browser-manifest.js';
 import { createRequestHandler, matchRoutes } from 'react-router';
 import {
   getRouteChunkEntryName,
@@ -553,6 +553,55 @@ export const pluginReactRouter = (
     let latestServerManifest: ReactRouterManifest | null = null;
     const latestServerManifestsByBundleId: Record<string, ReactRouterManifest> =
       {};
+
+    const stageLatestManifests = (
+      manifest: ReactRouterManifest,
+      sri: Record<string, string> | undefined,
+      moduleExportsByRouteId: RouteManifestModuleExports,
+      compilation: Rspack.Compilation
+    ) => {
+      performanceProfiler.recordSync(
+        'web',
+        'manifest:stage',
+        'virtual/react-router/browser-manifest',
+        () => {
+          latestBrowserManifest = manifest;
+          latestBrowserManifestModuleExports = moduleExportsByRouteId;
+          const baseServerManifest = {
+            ...manifest,
+            sri,
+          };
+          latestServerManifest = baseServerManifest;
+          const manifestsByEntryName: Record<string, ReactRouterManifest> = {
+            [devServerBuildEntryName]: baseServerManifest,
+          };
+
+          for (const { bundleId, entryName } of serverBundleEntries) {
+            const bundleRoutes = routesByServerBundleId[bundleId];
+            if (!bundleRoutes) {
+              continue;
+            }
+
+            const routeIds = new Set(Object.keys(bundleRoutes));
+            const filteredRoutes = Object.fromEntries(
+              Object.entries(manifest.routes).filter(([routeId]) =>
+                routeIds.has(routeId)
+              )
+            );
+            const bundleManifest = {
+              ...baseServerManifest,
+              routes: filteredRoutes,
+            };
+            latestServerManifestsByBundleId[bundleId] = bundleManifest;
+            manifestsByEntryName[entryName] = bundleManifest;
+          }
+
+          if (!isBuild) {
+            devRuntime.captureWeb(compilation, manifestsByEntryName);
+          }
+        }
+      );
+    };
 
     const routeByFilePath = new Map(
       Object.values(routes).map(route => [
@@ -1331,81 +1380,30 @@ export const pluginReactRouter = (
                 }
               }
 
-              if (name === 'web' && rspackConfig.plugins) {
-                rspackConfig.plugins.push(
-                  createModifyBrowserManifestPlugin(
-                    routes,
-                    pluginOptions,
-                    appDirectory,
-                    assetPrefix,
-                    routeChunkOptions,
-                    {
-                      future,
-                      manifestChunkNames,
-                      onManifest: (
-                        manifest,
-                        sri,
-                        moduleExportsByRouteId,
-                        manifestContext
-                      ) => {
-                        performanceProfiler.recordSync(
-                          'web',
-                          'manifest:stage',
-                          'virtual/react-router/browser-manifest',
-                          () => {
-                            latestBrowserManifest = manifest;
-                            latestBrowserManifestModuleExports =
-                              moduleExportsByRouteId;
-                            const baseServerManifest = {
-                              ...manifest,
-                              sri,
-                            };
-                            latestServerManifest = baseServerManifest;
-                            const manifestsByEntryName = {
-                              [devServerBuildEntryName]: baseServerManifest,
-                            } as Record<string, ReactRouterManifest>;
-                            for (const {
-                              bundleId,
-                              entryName,
-                            } of serverBundleEntries) {
-                              const bundleRoutes =
-                                routesByServerBundleId[bundleId];
-                              if (!bundleRoutes) {
-                                continue;
-                              }
-                              const routeIds = new Set(
-                                Object.keys(bundleRoutes)
-                              );
-                              const filteredRoutes = Object.fromEntries(
-                                Object.entries(manifest.routes).filter(
-                                  ([routeId]) => routeIds.has(routeId)
-                                )
-                              );
-                              const bundleManifest = {
-                                ...baseServerManifest,
-                                routes: filteredRoutes,
-                              };
-                              latestServerManifestsByBundleId[bundleId] =
-                                bundleManifest;
-                              manifestsByEntryName[entryName] = bundleManifest;
-                            }
-                            if (!isBuild) {
-                              devRuntime.captureWeb(
-                                manifestContext.compilation,
-                                manifestsByEntryName
-                              );
-                            }
-                          }
-                        );
-                      },
-                    }
-                  )
-                );
-              }
               return rspackConfig;
             },
           },
         });
+      }
+    );
+
+    registerModifyBrowserManifestAssets(
+      api,
+      routes,
+      pluginOptions,
+      appDirectory,
+      () => assetPrefix,
+      routeChunkOptions,
+      {
+        future,
+        manifestChunkNames,
+        onManifest: (manifest, sri, moduleExportsByRouteId, context) =>
+          stageLatestManifests(
+            manifest,
+            sri,
+            moduleExportsByRouteId,
+            context.compilation
+          ),
       }
     );
 
@@ -1568,12 +1566,28 @@ export const pluginReactRouter = (
           args.environment?.name,
           'module:client-only-stub',
           args.resource,
-          async () =>
-            routeTransformExecutor.run({
+          async () => {
+            const resolveExportAllModule =
+              typeof args.resolve === 'function'
+                ? (specifier: string, importerPath: string) =>
+                    new Promise<string | null>(resolveModule => {
+                      args.resolve(
+                        dirname(importerPath),
+                        specifier,
+                        (error, path) => {
+                          resolveModule(error || !path ? null : path);
+                        }
+                      );
+                    })
+                : undefined;
+
+            return routeTransformExecutor.run({
               kind: 'clientOnlyStub',
               code: args.code,
               resourcePath: args.resourcePath,
-            })
+              resolveExportAllModule,
+            });
+          }
         )
     );
 

--- a/src/lazy-compilation.ts
+++ b/src/lazy-compilation.ts
@@ -1,0 +1,93 @@
+import { BUILD_CLIENT_ROUTE_QUERY_STRING } from './constants.js';
+import type { PluginOptions } from './types.js';
+
+type LazyCompilationOptions = Exclude<
+  NonNullable<PluginOptions['lazyCompilation']>,
+  boolean
+>;
+
+type LazyCompilationModule = {
+  request?: string;
+  userRequest?: string;
+  rawRequest?: string;
+  resource?: string;
+  identifier?: () => string;
+  nameForCondition?: () => string | null;
+};
+
+const normalizeSlashes = (value: string): string => value.replace(/\\/g, '/');
+
+const getLazyCompilationModuleValues = (
+  module: LazyCompilationModule
+): string[] => {
+  const values = [
+    module.request,
+    module.userRequest,
+    module.rawRequest,
+    module.resource,
+    module.identifier?.(),
+    module.nameForCondition?.(),
+  ];
+  return values.filter((value): value is string => Boolean(value));
+};
+
+const matchesLazyCompilationTest = (
+  test: LazyCompilationOptions['test'] | undefined,
+  module: LazyCompilationModule
+): boolean => {
+  if (!test) {
+    return true;
+  }
+  if (typeof test === 'function') {
+    return test(module as Parameters<typeof test>[0]);
+  }
+  return getLazyCompilationModuleValues(module).some(value => {
+    test.lastIndex = 0;
+    return test.test(value);
+  });
+};
+
+const isReactRouterHydrationModule = (
+  module: LazyCompilationModule,
+  entryClientPath: string
+): boolean => {
+  const eagerPatterns = [
+    normalizeSlashes(entryClientPath),
+    'virtual/react-router/browser-manifest',
+    BUILD_CLIENT_ROUTE_QUERY_STRING,
+    '?react-router-route',
+  ];
+
+  return getLazyCompilationModuleValues(module)
+    .map(normalizeSlashes)
+    .some(value => eagerPatterns.some(pattern => value.includes(pattern)));
+};
+
+export const guardReactRouterLazyCompilation = ({
+  lazyCompilation,
+  entryClientPath,
+}: {
+  lazyCompilation: PluginOptions['lazyCompilation'] | undefined;
+  entryClientPath: string;
+}): PluginOptions['lazyCompilation'] | undefined => {
+  if (lazyCompilation === undefined || lazyCompilation === false) {
+    return lazyCompilation;
+  }
+
+  const options: LazyCompilationOptions =
+    lazyCompilation === true
+      ? { entries: true, imports: true }
+      : lazyCompilation;
+  const userTest = options.test;
+
+  return {
+    ...options,
+    test(module) {
+      const lazyModule = module as LazyCompilationModule;
+      if (isReactRouterHydrationModule(lazyModule, entryClientPath)) {
+        return false;
+      }
+      return matchesLazyCompilationTest(userTest, lazyModule);
+    },
+  };
+};

--- a/src/modify-browser-manifest.ts
+++ b/src/modify-browser-manifest.ts
@@ -1,7 +1,6 @@
 import { createHash } from 'node:crypto';
 import type { Route, PluginOptions } from './types.js';
-import { rspack } from '@rsbuild/core';
-import type { Rspack } from '@rsbuild/core';
+import type { RsbuildPluginAPI, Rspack } from '@rsbuild/core';
 import {
   createReactRouterManifestStats,
   generateReactRouterManifestForDev,
@@ -12,145 +11,171 @@ import {
 import { combineURLs } from './plugin-utils.js';
 import jsesc from 'jsesc';
 
-/**
- * Creates a Webpack/Rspack plugin that modifies the browser manifest
- * @param routes - The routes configuration
- * @param pluginOptions - The plugin options
- * @param appDirectory - The application directory
- * @returns A webpack/rspack plugin
- */
-export function createModifyBrowserManifestPlugin(
+type ModifyBrowserManifestOptions = {
+  future?: { unstable_subResourceIntegrity?: boolean };
+  manifestChunkNames?: ReadonlySet<string>;
+  onManifest?: (
+    manifest: Awaited<ReturnType<typeof getReactRouterManifestForDev>>,
+    sri: Record<string, string> | undefined,
+    moduleExportsByRouteId: Awaited<
+      ReturnType<typeof generateReactRouterManifestForDev>
+    >['moduleExportsByRouteId'],
+    context: {
+      compilation: Rspack.Compilation;
+      manifestStats: ReturnType<typeof createReactRouterManifestStats>;
+    }
+  ) => void;
+};
+
+type ProcessAssetsApi = Pick<RsbuildPluginAPI, 'processAssets'>;
+type AssetPrefixInput = string | (() => string);
+type ReactRouterManifest = Awaited<
+  ReturnType<typeof getReactRouterManifestForDev>
+>;
+type RouteManifestModuleExports = Awaited<
+  ReturnType<typeof generateReactRouterManifestForDev>
+>['moduleExportsByRouteId'];
+type GeneratedManifest = {
+  manifest: ReactRouterManifest;
+  moduleExportsByRouteId: RouteManifestModuleExports;
+  manifestStats: ReturnType<typeof createReactRouterManifestStats>;
+  assetPrefix: string;
+};
+
+const BROWSER_MANIFEST_ASSET =
+  'static/js/virtual/react-router/browser-manifest.js';
+
+const createSubresourceIntegrity = (
+  compilation: Rspack.Compilation,
+  assetPrefix: string
+) => {
+  const sri: Record<string, string> = {};
+  for (const asset of compilation.getAssets()) {
+    if (!asset.name.endsWith('.js')) {
+      continue;
+    }
+    const source = asset.source.source().toString();
+    const hash = createHash('sha384').update(source).digest('base64');
+    sri[combineURLs(assetPrefix, asset.name)] = `sha384-${hash}`;
+  }
+  return sri;
+};
+
+export function registerModifyBrowserManifestAssets(
+  api: ProcessAssetsApi,
   routes: Record<string, Route>,
   pluginOptions: PluginOptions,
   appDirectory: string,
-  assetPrefix = '/',
+  assetPrefix: AssetPrefixInput = '/',
   routeChunkOptions?: Parameters<typeof getReactRouterManifestForDev>[5],
-  options?: {
-    future?: { unstable_subResourceIntegrity?: boolean };
-    manifestChunkNames?: ReadonlySet<string>;
-    onManifest?: (
-      manifest: Awaited<ReturnType<typeof getReactRouterManifestForDev>>,
-      sri: Record<string, string> | undefined,
-      moduleExportsByRouteId: Awaited<
-        ReturnType<typeof generateReactRouterManifestForDev>
-      >['moduleExportsByRouteId'],
-      context: {
-        compilation: Rspack.Compilation;
-        manifestStats: ReturnType<typeof createReactRouterManifestStats>;
-      }
-    ) => void;
-  }
-) {
+  options?: ModifyBrowserManifestOptions
+): void {
+  const getAssetPrefix =
+    typeof assetPrefix === 'function' ? assetPrefix : () => assetPrefix;
   const manifestChunkNames =
     options?.manifestChunkNames ??
     getReactRouterManifestChunkNames(
       routes,
       routeChunkOptions?.splitRouteModules
     );
+  const finalizeSri =
+    routeChunkOptions?.isBuild &&
+    options?.future?.unstable_subResourceIntegrity;
+  const generatedManifests = finalizeSri
+    ? new WeakMap<Rspack.Compilation, GeneratedManifest>()
+    : undefined;
 
-  return {
-    apply(compiler: Rspack.Compiler): void {
-      compiler.hooks.emit.tapPromise(
-        'ModifyBrowserManifest',
-        async (compilation: Rspack.Compilation) => {
-          const stats = createReactRouterManifestStats(
-            compilation,
-            manifestChunkNames
-          );
-          const { manifest, moduleExportsByRouteId } =
-            await generateReactRouterManifestForDev(
-              routes,
-              pluginOptions,
-              stats,
-              appDirectory,
-              assetPrefix,
-              routeChunkOptions
-            );
-
-          const virtualManifestPath =
-            'static/js/virtual/react-router/browser-manifest.js';
-          if (compilation.assets[virtualManifestPath]) {
-            const originalSource = compilation.assets[virtualManifestPath]
-              .source()
-              .toString();
-            const newSource = originalSource.replace(
-              /["'`]PLACEHOLDER["'`]/,
-              jsesc(manifest, { es6: true })
-            );
-            compilation.assets[virtualManifestPath] = {
-              source: () => newSource,
-              size: () => newSource.length,
-              map: () => ({
-                version: 3,
-                sources: [virtualManifestPath],
-                names: [],
-                mappings: '',
-                file: virtualManifestPath,
-                sourcesContent: [newSource],
-              }),
-              sourceAndMap: () => ({
-                source: newSource,
-                map: {
-                  version: 3,
-                  sources: [virtualManifestPath],
-                  names: [],
-                  mappings: '',
-                  file: virtualManifestPath,
-                  sourcesContent: [newSource],
-                },
-              }),
-              updateHash: hash => hash.update(newSource),
-              buffer: () => Buffer.from(newSource),
-            };
-          }
-
-          if (routeChunkOptions?.isBuild) {
-            const entryAssets = stats?.assetsByChunkName?.['entry.client'];
-            const entryJsAssets =
-              entryAssets?.filter(asset => asset.endsWith('.js')) || [];
-            const manifestPath = getReactRouterManifestPath({
-              version: manifest.version,
-              isBuild: true,
-              entryModulePath: entryJsAssets[0],
-            });
-            const manifestSource = `window.__reactRouterManifest=${jsesc(
-              manifest,
-              { es6: true }
-            )};`;
-            compilation.assets[manifestPath] = new rspack.sources.RawSource(
-              manifestSource
-            );
-          }
-
-          let sri: Record<string, string> | undefined;
-          if (
-            routeChunkOptions?.isBuild &&
-            options?.future?.unstable_subResourceIntegrity
-          ) {
-            const assets =
-              typeof compilation.getAssets === 'function'
-                ? compilation.getAssets()
-                : Object.entries(compilation.assets).map(([name, asset]) => ({
-                    name,
-                    source: asset,
-                  }));
-            sri = {};
-            for (const asset of assets) {
-              if (!asset.name.endsWith('.js')) {
-                continue;
-              }
-              const source = asset.source.source().toString();
-              const hash = createHash('sha384').update(source).digest('base64');
-              sri[combineURLs(assetPrefix, asset.name)] = `sha384-${hash}`;
-            }
-          }
-
-          options?.onManifest?.(manifest, sri, moduleExportsByRouteId, {
-            compilation,
-            manifestStats: stats,
-          });
-        }
+  api.processAssets(
+    { stage: 'additions', environments: ['web'] },
+    async ({ assets, sources, compilation }) => {
+      const currentAssetPrefix = getAssetPrefix();
+      const stats = createReactRouterManifestStats(
+        compilation,
+        manifestChunkNames
       );
-    },
-  };
+      const { manifest, moduleExportsByRouteId } =
+        await generateReactRouterManifestForDev(
+          routes,
+          pluginOptions,
+          stats,
+          appDirectory,
+          currentAssetPrefix,
+          routeChunkOptions
+        );
+
+      const browserManifestAsset = assets[BROWSER_MANIFEST_ASSET];
+      if (browserManifestAsset) {
+        const originalSource = browserManifestAsset.source().toString();
+        const newSource = originalSource.replace(
+          /["'`]PLACEHOLDER["'`]/,
+          jsesc(manifest, { es6: true })
+        );
+        compilation.updateAsset(
+          BROWSER_MANIFEST_ASSET,
+          new sources.RawSource(newSource)
+        );
+      }
+
+      if (routeChunkOptions?.isBuild) {
+        const entryAssets = stats?.assetsByChunkName?.['entry.client'];
+        const entryJsAssets =
+          entryAssets?.filter(asset => asset.endsWith('.js')) || [];
+        const manifestPath = getReactRouterManifestPath({
+          version: manifest.version,
+          isBuild: true,
+          entryModulePath: entryJsAssets[0],
+        });
+        const manifestSource = `window.__reactRouterManifest=${jsesc(manifest, {
+          es6: true,
+        })};`;
+        const source = new sources.RawSource(manifestSource);
+        if (compilation.getAsset(manifestPath)) {
+          compilation.updateAsset(manifestPath, source);
+        } else {
+          compilation.emitAsset(manifestPath, source);
+        }
+      }
+
+      if (generatedManifests) {
+        generatedManifests.set(compilation, {
+          manifest,
+          moduleExportsByRouteId,
+          manifestStats: stats,
+          assetPrefix: currentAssetPrefix,
+        });
+        return;
+      }
+
+      options?.onManifest?.(manifest, undefined, moduleExportsByRouteId, {
+        compilation,
+        manifestStats: stats,
+      });
+    }
+  );
+
+  if (generatedManifests) {
+    api.processAssets(
+      { stage: 'report', environments: ['web'] },
+      ({ compilation }) => {
+        const generatedManifest = generatedManifests.get(compilation);
+        if (!generatedManifest) {
+          return;
+        }
+
+        generatedManifests.delete(compilation);
+        options?.onManifest?.(
+          generatedManifest.manifest,
+          createSubresourceIntegrity(
+            compilation,
+            generatedManifest.assetPrefix
+          ),
+          generatedManifest.moduleExportsByRouteId,
+          {
+            compilation,
+            manifestStats: generatedManifest.manifestStats,
+          }
+        );
+      }
+    );
+  }
 }

--- a/src/parallel-route-transforms.ts
+++ b/src/parallel-route-transforms.ts
@@ -131,6 +131,9 @@ class ParallelRouteTransformExecutor implements RouteTransformExecutor {
     if (this.#closed) {
       return executeRouteTransformTask(task, this.options);
     }
+    if (task.kind === 'clientOnlyStub' && task.resolveExportAllModule) {
+      return executeRouteTransformTask(task, this.options);
+    }
 
     try {
       return await this.#runInWorker(task);

--- a/src/performance.ts
+++ b/src/performance.ts
@@ -71,7 +71,7 @@ export type ReactRouterPerformanceProfiler = {
     callback: () => T
   ): T;
   flush(
-    environment: string,
+    environment: string | undefined,
     details?: Pick<ReactRouterPerformanceReport, 'compilerLifecycleMs'>
   ): void;
 };
@@ -171,7 +171,11 @@ export const createReactRouterPerformanceProfiler = ({
   return {
     record(environment, operation, resource, callback) {
       if (!enabled) {
-        return callback();
+        try {
+          return Promise.resolve(callback());
+        } catch (error) {
+          return Promise.reject(error);
+        }
       }
 
       const resolvedEnvironment = environment ?? 'unknown';
@@ -226,7 +230,8 @@ export const createReactRouterPerformanceProfiler = ({
         return;
       }
 
-      const timings = timingsByEnvironment.get(environment);
+      const resolvedEnvironment = environment ?? 'unknown';
+      const timings = timingsByEnvironment.get(resolvedEnvironment);
       if (!timings || timings.size === 0) {
         return;
       }
@@ -238,12 +243,12 @@ export const createReactRouterPerformanceProfiler = ({
         ])
       );
       const report: ReactRouterPerformanceReport = {
-        environment,
+        environment: resolvedEnvironment,
         ...details,
         operations,
       };
       log(`[react-router:performance] ${JSON.stringify(report)}`);
-      timingsByEnvironment.delete(environment);
+      timingsByEnvironment.delete(resolvedEnvironment);
     },
   };
 };

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -1,7 +1,10 @@
 import type { Config } from './react-router-config.js';
 import type { RouteConfigEntry } from '@react-router/dev/routes';
+import { matchRoutes } from 'react-router';
 
 type PrerenderConfig = Config['prerender'];
+type MatchRouteObject =
+  Parameters<typeof matchRoutes>[0] extends Array<infer R> ? R : never;
 
 type PrerenderPathsConfig =
   | boolean
@@ -25,8 +28,151 @@ type StaticPrerenderPaths = {
   paramRoutes: string[];
 };
 
+type SsrFalsePrerenderRoute = {
+  id: string;
+  parentId?: string;
+  path?: string;
+  index?: boolean;
+  hasLoader?: boolean;
+  hasClientLoader?: boolean;
+};
+
+type SsrFalsePrerenderExportOptions = {
+  routes: Record<string, SsrFalsePrerenderRoute>;
+  manifestRoutes: Record<string, SsrFalsePrerenderRoute>;
+  routeExports: Record<string, readonly string[] | undefined>;
+  prerenderPaths: string[];
+};
+
 const normalizePath = (value: string): string =>
   value.replace(/\/\/+/g, '/').replace(/(.+)\/$/, '$1');
+
+const groupRoutesByParentId = (
+  manifest: Record<string, any>
+): Record<string, any[]> => {
+  const grouped: Record<string, any[]> = {};
+  Object.values(manifest).forEach(route => {
+    if (!route) {
+      return;
+    }
+    const parentId = route.parentId || '';
+    grouped[parentId] ??= [];
+    grouped[parentId].push(route);
+  });
+  return grouped;
+};
+
+export const createPrerenderRoutes = (
+  manifest: Record<string, any>,
+  parentId = '',
+  grouped: Record<string, any[]> = groupRoutesByParentId(manifest)
+): MatchRouteObject[] => {
+  return (grouped[parentId] || []).map(route => {
+    const common = { id: route.id, path: route.path };
+    if (route.index) {
+      return { index: true, ...common } as MatchRouteObject;
+    }
+    return {
+      ...common,
+      children: createPrerenderRoutes(manifest, route.id, grouped),
+    } as MatchRouteObject;
+  });
+};
+
+export const normalizePrerenderMatchPath = (path: string): string =>
+  `/${path}/`.replace(/^\/\/+/, '/');
+
+export const withBuildRequest = async <T>(
+  input: string | URL,
+  init: RequestInit | undefined,
+  handle: (request: Request) => Promise<T>
+): Promise<T> => {
+  const controller = new AbortController();
+  try {
+    return await handle(
+      new Request(input, {
+        ...init,
+        signal: controller.signal,
+      })
+    );
+  } finally {
+    controller.abort();
+  }
+};
+
+export const getSsrFalsePrerenderExportErrors = ({
+  routes,
+  manifestRoutes,
+  routeExports,
+  prerenderPaths,
+}: SsrFalsePrerenderExportOptions): string[] => {
+  if (prerenderPaths.length === 0) {
+    return [];
+  }
+
+  const prerenderRoutes = createPrerenderRoutes(routes);
+  const prerenderedRoutes = new Set<string>();
+  for (const path of prerenderPaths) {
+    const matches = matchRoutes(
+      prerenderRoutes,
+      normalizePrerenderMatchPath(path)
+    );
+    if (!matches) {
+      throw new Error(
+        `Unable to prerender path because it does not match any routes: ${path}`
+      );
+    }
+    matches.forEach(match => prerenderedRoutes.add(match.route.id as string));
+  }
+
+  const errors: string[] = [];
+  for (const [routeId, route] of Object.entries(manifestRoutes)) {
+    const exports = routeExports[routeId] ?? [];
+    const invalidApis: string[] = [];
+
+    if (exports.includes('headers')) invalidApis.push('headers');
+    if (exports.includes('action')) invalidApis.push('action');
+
+    if (invalidApis.length > 0) {
+      errors.push(
+        `Prerender: ${invalidApis.length} invalid route export(s) in ` +
+          `\`${routeId}\` when pre-rendering with \`ssr:false\`: ` +
+          `${invalidApis.map(api => `\`${api}\``).join(', ')}. ` +
+          `See https://reactrouter.com/how-to/pre-rendering#invalid-exports for more information.`
+      );
+    }
+
+    if (!prerenderedRoutes.has(routeId)) {
+      if (exports.includes('loader')) {
+        errors.push(
+          `Prerender: 1 invalid route export in \`${routeId}\` when pre-rendering with ` +
+            `\`ssr:false\`: \`loader\`. ` +
+            `See https://reactrouter.com/how-to/pre-rendering#invalid-exports for more information.`
+        );
+      }
+
+      let parentRoute =
+        route.parentId && manifestRoutes[route.parentId]
+          ? manifestRoutes[route.parentId]
+          : null;
+      while (parentRoute && parentRoute.id !== 'root') {
+        if (parentRoute.hasLoader && !parentRoute.hasClientLoader) {
+          errors.push(
+            `Prerender: 1 invalid route export in \`${parentRoute.id}\` when ` +
+              `pre-rendering with \`ssr:false\`: \`loader\`. ` +
+              `See https://reactrouter.com/how-to/pre-rendering#invalid-exports for more information.`
+          );
+        }
+        parentRoute =
+          parentRoute.parentId && parentRoute.parentId !== 'root'
+            ? manifestRoutes[parentRoute.parentId]
+            : null;
+      }
+    }
+  }
+
+  return errors;
+};
 
 export const getStaticPrerenderPaths = (
   routes: RouteConfigEntry[]

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -155,7 +155,7 @@ export const getSsrFalsePrerenderExportErrors = ({
         route.parentId && manifestRoutes[route.parentId]
           ? manifestRoutes[route.parentId]
           : null;
-      while (parentRoute && parentRoute.id !== 'root') {
+      while (parentRoute) {
         if (parentRoute.hasLoader && !parentRoute.hasClientLoader) {
           errors.push(
             `Prerender: 1 invalid route export in \`${parentRoute.id}\` when ` +
@@ -164,7 +164,7 @@ export const getSsrFalsePrerenderExportErrors = ({
           );
         }
         parentRoute =
-          parentRoute.parentId && parentRoute.parentId !== 'root'
+          parentRoute.parentId && manifestRoutes[parentRoute.parentId]
             ? manifestRoutes[parentRoute.parentId]
             : null;
       }

--- a/src/route-ast.ts
+++ b/src/route-ast.ts
@@ -1,0 +1,159 @@
+import type { ParseResult } from 'yuku-parser';
+
+export type AnyNode = Record<string, any>;
+
+export const getProgram = (ast: ParseResult | AnyNode): AnyNode =>
+  (ast as ParseResult).program ?? ast;
+
+export const getPatternIdentifierNames = (
+  pattern: AnyNode | null | undefined,
+  names: Set<string> = new Set()
+): Set<string> => {
+  if (!pattern) {
+    return names;
+  }
+  if (pattern.type === 'Identifier') {
+    names.add(pattern.name);
+    return names;
+  }
+  if (pattern.type === 'RestElement') {
+    return getPatternIdentifierNames(pattern.argument, names);
+  }
+  if (pattern.type === 'AssignmentPattern') {
+    return getPatternIdentifierNames(pattern.left, names);
+  }
+  if (pattern.type === 'ArrayPattern') {
+    for (const element of pattern.elements ?? []) {
+      getPatternIdentifierNames(element, names);
+    }
+    return names;
+  }
+  if (pattern.type === 'ObjectPattern') {
+    for (const property of pattern.properties ?? []) {
+      if (property.type === 'RestElement') {
+        getPatternIdentifierNames(property.argument, names);
+      } else {
+        getPatternIdentifierNames(property.value, names);
+      }
+    }
+  }
+  return names;
+};
+
+export const getIdentifierNamesFromPattern = (
+  pattern: AnyNode | null | undefined
+): string[] => Array.from(getPatternIdentifierNames(pattern));
+
+export const patternIncludesName = (
+  pattern: AnyNode | null | undefined,
+  name: string
+): boolean => getPatternIdentifierNames(pattern).has(name);
+
+export const getExportedName = (
+  node: AnyNode | null | undefined
+): string | null => {
+  const exported = node?.exported ?? node;
+  if (!exported) {
+    return null;
+  }
+  if (exported.type === 'Identifier') {
+    return exported.name;
+  }
+  if (exported.type === 'Literal' || exported.type === 'StringLiteral') {
+    return String(exported.value);
+  }
+  return null;
+};
+
+export const identifier = (name: string): AnyNode => ({
+  type: 'Identifier',
+  start: 0,
+  end: 0,
+  name,
+  decorators: [],
+  optional: false,
+  typeAnnotation: null,
+});
+
+export const literal = (value: string): AnyNode => ({
+  type: 'Literal',
+  start: 0,
+  end: 0,
+  value,
+  raw: JSON.stringify(value),
+});
+
+export const callExpression = (callee: AnyNode, args: AnyNode[]): AnyNode => ({
+  type: 'CallExpression',
+  start: 0,
+  end: 0,
+  callee,
+  arguments: args,
+  optional: false,
+});
+
+export const importDeclaration = (
+  specifiers: Array<{ local: string; imported: string }>,
+  source: string
+): AnyNode => ({
+  type: 'ImportDeclaration',
+  start: 0,
+  end: 0,
+  specifiers: specifiers.map(specifier => ({
+    type: 'ImportSpecifier',
+    start: 0,
+    end: 0,
+    imported: identifier(specifier.imported),
+    local: identifier(specifier.local),
+    importKind: 'value',
+  })),
+  source: literal(source),
+  attributes: [],
+  phase: null,
+  importKind: 'value',
+});
+
+export const exportSpecifier = (local: string, exported: string): AnyNode => ({
+  type: 'ExportSpecifier',
+  start: 0,
+  end: 0,
+  local: identifier(local),
+  exported: identifier(exported),
+  exportKind: 'value',
+});
+
+export const exportNamedDeclaration = (specifiers: AnyNode[]): AnyNode => ({
+  type: 'ExportNamedDeclaration',
+  start: 0,
+  end: 0,
+  declaration: null,
+  specifiers,
+  source: null,
+  attributes: [],
+  exportKind: 'value',
+});
+
+export const variableDeclaration = (name: string, init: AnyNode): AnyNode => ({
+  type: 'VariableDeclaration',
+  start: 0,
+  end: 0,
+  kind: 'const',
+  declare: false,
+  declarations: [
+    {
+      type: 'VariableDeclarator',
+      start: 0,
+      end: 0,
+      id: identifier(name),
+      init,
+      definite: false,
+    },
+  ],
+});
+
+export const removeFromArray = <T>(array: T[], value: T): void => {
+  const index = array.indexOf(value);
+  if (index >= 0) {
+    array.splice(index, 1);
+  }
+};

--- a/src/route-chunks.ts
+++ b/src/route-chunks.ts
@@ -70,7 +70,6 @@ const routeChunkQueryStrings: Record<RouteChunkName, string> = {
   clientMiddleware: `${routeChunkQueryStringPrefix}clientMiddleware`,
   HydrateFallback: `${routeChunkQueryStringPrefix}HydrateFallback`,
 };
-const routeChunkQueryStringValues = Object.values(routeChunkQueryStrings);
 
 const routeChunkEntrySuffix: Record<RouteChunkExportName, string> = {
   clientAction: 'client-action',
@@ -209,6 +208,12 @@ const getExportDependencies = (
       const exportDependencies = new Map<string, ExportDependencies>();
       const topLevelStatementCache = new Map<AnyNode, AnyNode>();
       const variableDeclaratorCache = new Map<AnyNode, AnyNode | null>();
+      const sharedTopLevelSideEffects = (module.ast as AnyNode).body.filter(
+        (statement: AnyNode) =>
+          (statement.type === 'ImportDeclaration' &&
+            statement.specifiers.length === 0) ||
+          statement.type === 'ExpressionStatement'
+      );
 
       const getCachedTopLevelStatementForNode = (node: AnyNode): AnyNode => {
         const cached = topLevelStatementCache.get(node);
@@ -319,6 +324,11 @@ const getExportDependencies = (
         } else {
           const statement = getCachedTopLevelStatementForNode(exportNode);
           scanNode(statement);
+        }
+
+        for (const statement of sharedTopLevelSideEffects) {
+          dependencies.topLevelStatements.add(statement);
+          dependencies.topLevelNonModuleStatements.add(statement);
         }
 
         exportDependencies.set(exportName, dependencies);
@@ -706,7 +716,7 @@ export const getRouteChunkModuleId = (
 ) => `${filePath}${routeChunkQueryStrings[chunkName]}`;
 
 export const isRouteChunkModuleId: (id: string) => boolean = (id: string) =>
-  routeChunkQueryStringValues.some(queryString => id.endsWith(queryString));
+  getRouteChunkNameFromModuleId(id) !== null;
 
 const isRouteChunkName = (name: string): name is RouteChunkName =>
   name === 'main' || (routeChunkExportNames as string[]).includes(name);

--- a/src/route-component-transform.ts
+++ b/src/route-component-transform.ts
@@ -3,25 +3,18 @@ import {
   NAMED_COMPONENT_EXPORTS_SET,
 } from './constants.js';
 import type { ParseResult } from 'yuku-parser';
-
-type AnyNode = Record<string, any>;
-
-const getProgram = (ast: ParseResult | AnyNode): AnyNode =>
-  (ast as ParseResult).program ?? ast;
-
-const getExportedName = (specifier: AnyNode): string | null => {
-  const exported = specifier.exported;
-  if (!exported) {
-    return null;
-  }
-  if (exported.type === 'Identifier') {
-    return exported.name;
-  }
-  if (exported.type === 'Literal') {
-    return String(exported.value);
-  }
-  return null;
-};
+import {
+  callExpression,
+  exportNamedDeclaration,
+  exportSpecifier,
+  getExportedName,
+  getProgram,
+  identifier,
+  importDeclaration,
+  patternIncludesName,
+  variableDeclaration,
+  type AnyNode,
+} from './route-ast.js';
 
 export function toFunctionExpression(decl: AnyNode): AnyNode {
   return {
@@ -38,74 +31,6 @@ export function toClassExpression(decl: AnyNode): AnyNode {
     declare: undefined,
   };
 }
-
-const identifier = (name: string): AnyNode => ({
-  type: 'Identifier',
-  start: 0,
-  end: 0,
-  name,
-  decorators: [],
-  optional: false,
-  typeAnnotation: null,
-});
-
-const literal = (value: string): AnyNode => ({
-  type: 'Literal',
-  start: 0,
-  end: 0,
-  value,
-  raw: JSON.stringify(value),
-});
-
-const callExpression = (callee: AnyNode, args: AnyNode[]): AnyNode => ({
-  type: 'CallExpression',
-  start: 0,
-  end: 0,
-  callee,
-  arguments: args,
-  optional: false,
-});
-
-const importDeclaration = (
-  specifiers: Array<{ local: string; imported: string }>,
-  source: string
-): AnyNode => ({
-  type: 'ImportDeclaration',
-  start: 0,
-  end: 0,
-  specifiers: specifiers.map(specifier => ({
-    type: 'ImportSpecifier',
-    start: 0,
-    end: 0,
-    imported: identifier(specifier.imported),
-    local: identifier(specifier.local),
-    importKind: 'value',
-  })),
-  source: literal(source),
-  attributes: [],
-  phase: null,
-  importKind: 'value',
-});
-
-const exportSpecifier = (local: string, exported: string): AnyNode => ({
-  type: 'ExportSpecifier',
-  start: 0,
-  end: 0,
-  local: identifier(local),
-  exported: identifier(exported),
-  exportKind: 'value',
-});
-
-const exportNamedDeclaration = (specifiers: AnyNode[]): AnyNode => ({
-  type: 'ExportNamedDeclaration',
-  start: 0,
-  end: 0,
-  declaration: null,
-  specifiers,
-  source: null,
-  attributes: [],
-  exportKind: 'value',
-});
 
 const getComponentExportName = (exportedName: string): string | null => {
   if (exportedName === 'default') {
@@ -127,70 +52,6 @@ const getImportInsertionIndex = (program: AnyNode): number => {
     index += 1;
   }
   return index;
-};
-
-const getModuleExportName = (
-  node: AnyNode | null | undefined
-): string | null => {
-  if (!node) {
-    return null;
-  }
-  if (node.type === 'Identifier') {
-    return node.name;
-  }
-  if (node.type === 'Literal') {
-    return String(node.value);
-  }
-  return null;
-};
-
-const variableDeclaration = (name: string, init: AnyNode): AnyNode => ({
-  type: 'VariableDeclaration',
-  start: 0,
-  end: 0,
-  kind: 'const',
-  declare: false,
-  declarations: [
-    {
-      type: 'VariableDeclarator',
-      start: 0,
-      end: 0,
-      id: identifier(name),
-      init,
-      definite: false,
-    },
-  ],
-});
-
-const patternIncludesName = (
-  pattern: AnyNode | null | undefined,
-  name: string
-): boolean => {
-  if (!pattern) {
-    return false;
-  }
-  if (pattern.type === 'Identifier') {
-    return pattern.name === name;
-  }
-  if (pattern.type === 'RestElement') {
-    return patternIncludesName(pattern.argument, name);
-  }
-  if (pattern.type === 'AssignmentPattern') {
-    return patternIncludesName(pattern.left, name);
-  }
-  if (pattern.type === 'ArrayPattern') {
-    return (pattern.elements ?? []).some((element: AnyNode | null) =>
-      patternIncludesName(element, name)
-    );
-  }
-  if (pattern.type === 'ObjectPattern') {
-    return (pattern.properties ?? []).some((property: AnyNode) =>
-      property.type === 'RestElement'
-        ? patternIncludesName(property.argument, name)
-        : patternIncludesName(property.value, name)
-    );
-  }
-  return false;
 };
 
 const declarationIncludesName = (
@@ -352,7 +213,7 @@ export const transformRoute = (ast: ParseResult | AnyNode): void => {
             return true;
           }
           const exportedName = getExportedName(specifier);
-          const importedName = getModuleExportName(specifier.local);
+          const importedName = getExportedName(specifier.local);
           const componentExportName = exportedName
             ? getComponentExportName(exportedName)
             : null;

--- a/src/route-component-transform.ts
+++ b/src/route-component-transform.ts
@@ -65,7 +65,8 @@ const declarationIncludesName = (
   }
   if (
     (declaration.type === 'FunctionDeclaration' ||
-      declaration.type === 'ClassDeclaration') &&
+      declaration.type === 'ClassDeclaration' ||
+      declaration.type === 'TSEnumDeclaration') &&
     declaration.id?.name
   ) {
     return declaration.id.name === name;
@@ -142,6 +143,12 @@ export const transformRoute = (ast: ParseResult | AnyNode): void => {
     if (statement.type === 'ExportDefaultDeclaration') {
       const declaration = statement.declaration;
       if (!declaration) {
+        continue;
+      }
+      if (
+        declaration.declare === true ||
+        declaration.type === 'TSInterfaceDeclaration'
+      ) {
         continue;
       }
       const uid = getHocUid('withComponentProps');

--- a/src/route-export-pruning.ts
+++ b/src/route-export-pruning.ts
@@ -1,9 +1,11 @@
 import { walk, type ParseResult } from 'yuku-parser';
-
-type AnyNode = Record<string, any>;
-
-const getProgram = (ast: ParseResult | AnyNode): AnyNode =>
-  (ast as ParseResult).program ?? ast;
+import {
+  getExportedName,
+  getPatternIdentifierNames,
+  getProgram,
+  removeFromArray,
+  type AnyNode,
+} from './route-ast.js';
 
 export function validateDestructuredExports(
   id: AnyNode,
@@ -90,48 +92,6 @@ export function validateDestructuredExports(
 export function invalidDestructureError(name: string): Error {
   return new Error(`Cannot remove destructured export "${name}"`);
 }
-
-const removeFromArray = <T>(array: T[], value: T): void => {
-  const index = array.indexOf(value);
-  if (index >= 0) {
-    array.splice(index, 1);
-  }
-};
-
-const getPatternIdentifierNames = (
-  pattern: AnyNode | null | undefined,
-  names = new Set<string>()
-): Set<string> => {
-  if (!pattern) {
-    return names;
-  }
-  if (pattern.type === 'Identifier') {
-    names.add(pattern.name);
-    return names;
-  }
-  if (pattern.type === 'RestElement') {
-    return getPatternIdentifierNames(pattern.argument, names);
-  }
-  if (pattern.type === 'AssignmentPattern') {
-    return getPatternIdentifierNames(pattern.left, names);
-  }
-  if (pattern.type === 'ArrayPattern') {
-    for (const element of pattern.elements ?? []) {
-      getPatternIdentifierNames(element, names);
-    }
-    return names;
-  }
-  if (pattern.type === 'ObjectPattern') {
-    for (const property of pattern.properties ?? []) {
-      if (property.type === 'RestElement') {
-        getPatternIdentifierNames(property.argument, names);
-      } else {
-        getPatternIdentifierNames(property.value, names);
-      }
-    }
-  }
-  return names;
-};
 
 const getDeclaredNames = (node: AnyNode): Set<string> => {
   const names = new Set<string>();
@@ -285,20 +245,6 @@ const collectReferencedNames = (node: AnyNode): Set<string> => {
     },
   });
   return referenced;
-};
-
-const getExportedName = (specifier: AnyNode): string | null => {
-  const exported = specifier.exported;
-  if (!exported) {
-    return null;
-  }
-  if (exported.type === 'Identifier') {
-    return exported.name;
-  }
-  if (exported.type === 'Literal') {
-    return String(exported.value);
-  }
-  return null;
 };
 
 type TopLevelDeclaration = {

--- a/src/route-export-resolution.ts
+++ b/src/route-export-resolution.ts
@@ -204,9 +204,15 @@ const resolveExportAllModule = (
   }
 };
 
+export type RouteExportResolver = (
+  specifier: string,
+  importerPath: string
+) => Promise<string | null> | string | null;
+
 export const collectClientOnlyStubExportNames = async (
   code: string,
-  resourcePath: string
+  resourcePath: string,
+  resolveModule: RouteExportResolver = resolveExportAllModule
 ): Promise<Set<string>> => {
   const { exportNames: directExportNames, exportAllModules } =
     await getExportNamesAndExportAll(code);
@@ -229,7 +235,7 @@ export const collectClientOnlyStubExportNames = async (
       }
     }
     for (const nestedSpecifier of moduleExportAll) {
-      const nestedPath = resolveExportAllModule(nestedSpecifier, modulePath);
+      const nestedPath = await resolveModule(nestedSpecifier, modulePath);
       if (!nestedPath) {
         unresolvedExportAll.add(nestedSpecifier);
         continue;
@@ -239,7 +245,7 @@ export const collectClientOnlyStubExportNames = async (
   };
 
   for (const specifier of exportAllModules) {
-    const resolvedPath = resolveExportAllModule(specifier, resourcePath);
+    const resolvedPath = await resolveModule(specifier, resourcePath);
     if (!resolvedPath) {
       unresolvedExportAll.add(specifier);
       continue;

--- a/src/route-export-resolution.ts
+++ b/src/route-export-resolution.ts
@@ -14,6 +14,11 @@ type PackageJson = {
   main?: unknown;
 };
 
+type PackageImportResolution =
+  | { status: 'resolved'; path: string }
+  | { status: 'blocked-by-exports' }
+  | { status: 'not-found' };
+
 const tryStat = (path: string): Stats | null =>
   statSync(path, { throwIfNoEntry: false }) ?? null;
 
@@ -134,27 +139,28 @@ const resolvePackageTarget = (
 const resolvePackageImport = (
   specifier: string,
   importerPath: string
-): string | null => {
+): PackageImportResolution => {
   const parsed = parsePackageSpecifier(specifier);
   if (!parsed) {
-    return null;
+    return { status: 'not-found' };
   }
   const packageDirectory = findPackageDirectory(
     parsed.packageName,
     importerPath
   );
   if (!packageDirectory) {
-    return null;
+    return { status: 'not-found' };
   }
   const packageJson = readPackageJson(packageDirectory);
   if (!packageJson) {
-    return null;
+    return { status: 'not-found' };
   }
   const exportsField = packageJson.exports;
-  if (exportsField) {
+  if ('exports' in packageJson) {
     const hasSubpathExports =
       typeof exportsField === 'object' &&
       !Array.isArray(exportsField) &&
+      exportsField !== null &&
       Object.keys(exportsField).some(key => key.startsWith('.'));
     const target =
       parsed.subpath === '.' && !hasSubpathExports
@@ -164,17 +170,25 @@ const resolvePackageImport = (
           : undefined;
     const resolved = resolvePackageTarget(packageDirectory, target);
     if (resolved) {
-      return resolved;
+      return { status: 'resolved', path: resolved };
     }
+    return { status: 'blocked-by-exports' };
   }
   if (parsed.subpath !== '.') {
-    return resolvePathWithExtensions(resolve(packageDirectory, parsed.subpath));
+    const resolved = resolvePathWithExtensions(
+      resolve(packageDirectory, parsed.subpath)
+    );
+    return resolved
+      ? { status: 'resolved', path: resolved }
+      : { status: 'not-found' };
   }
-  return (
+  const resolved =
     resolvePackageTarget(packageDirectory, packageJson.module) ??
     resolvePackageTarget(packageDirectory, packageJson.main) ??
-    resolveIndexFile(packageDirectory)
-  );
+    resolveIndexFile(packageDirectory);
+  return resolved
+    ? { status: 'resolved', path: resolved }
+    : { status: 'not-found' };
 };
 
 const resolveExportAllModule = (
@@ -191,9 +205,12 @@ const resolveExportAllModule = (
     }
   }
 
-  const packageImportPath = resolvePackageImport(specifier, importerPath);
-  if (packageImportPath) {
-    return packageImportPath;
+  const packageImport = resolvePackageImport(specifier, importerPath);
+  if (packageImport.status === 'resolved') {
+    return packageImport.path;
+  }
+  if (packageImport.status === 'blocked-by-exports') {
+    return null;
   }
 
   try {

--- a/src/route-export-resolution.ts
+++ b/src/route-export-resolution.ts
@@ -1,0 +1,262 @@
+import { readFileSync, statSync, type Stats } from 'node:fs';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import { dirname, relative, resolve } from 'pathe';
+import { JS_EXTENSIONS, PLUGIN_NAME } from './constants.js';
+import {
+  getExportNamesAndExportAll,
+  getRouteModuleAnalysis,
+} from './export-utils.js';
+
+type PackageJson = {
+  exports?: unknown;
+  module?: unknown;
+  main?: unknown;
+};
+
+const tryStat = (path: string): Stats | null =>
+  statSync(path, { throwIfNoEntry: false }) ?? null;
+
+const resolveIndexFile = (dirPath: string): string | null => {
+  for (const ext of JS_EXTENSIONS) {
+    const candidate = resolve(dirPath, `index${ext}`);
+    const stats = tryStat(candidate);
+    if (stats?.isFile()) {
+      return candidate;
+    }
+  }
+  return null;
+};
+
+const resolvePathWithExtensions = (basePath: string): string | null => {
+  const stats = tryStat(basePath);
+  if (stats?.isFile()) {
+    return basePath;
+  }
+  if (stats?.isDirectory()) {
+    return resolveIndexFile(basePath);
+  }
+
+  for (const ext of JS_EXTENSIONS) {
+    const candidate = `${basePath}${ext}`;
+    const candidateStats = tryStat(candidate);
+    if (candidateStats?.isFile()) {
+      return candidate;
+    }
+  }
+
+  return resolveIndexFile(basePath);
+};
+
+const parsePackageSpecifier = (
+  specifier: string
+): { packageName: string; subpath: string } | null => {
+  if (
+    specifier.startsWith('.') ||
+    specifier.startsWith('/') ||
+    specifier.startsWith('node:')
+  ) {
+    return null;
+  }
+  const parts = specifier.split('/');
+  const packageName = specifier.startsWith('@')
+    ? parts.slice(0, 2).join('/')
+    : parts[0];
+  if (!packageName || (specifier.startsWith('@') && parts.length < 2)) {
+    return null;
+  }
+  const rest = parts.slice(packageName.startsWith('@') ? 2 : 1).join('/');
+  return {
+    packageName,
+    subpath: rest ? `./${rest}` : '.',
+  };
+};
+
+const findPackageDirectory = (
+  packageName: string,
+  importerPath: string
+): string | null => {
+  let currentDirectory = dirname(importerPath);
+  while (true) {
+    const candidate = resolve(currentDirectory, 'node_modules', packageName);
+    if (tryStat(candidate)?.isDirectory()) {
+      return candidate;
+    }
+    const parentDirectory = dirname(currentDirectory);
+    if (parentDirectory === currentDirectory) {
+      return null;
+    }
+    currentDirectory = parentDirectory;
+  }
+};
+
+const readPackageJson = (packageDirectory: string): PackageJson | null => {
+  try {
+    return JSON.parse(
+      readFileSync(resolve(packageDirectory, 'package.json'), 'utf8')
+    );
+  } catch {
+    return null;
+  }
+};
+
+const resolvePackageTarget = (
+  packageDirectory: string,
+  target: unknown
+): string | null => {
+  if (typeof target === 'string') {
+    return resolvePathWithExtensions(resolve(packageDirectory, target));
+  }
+  if (Array.isArray(target)) {
+    for (const item of target) {
+      const resolved = resolvePackageTarget(packageDirectory, item);
+      if (resolved) {
+        return resolved;
+      }
+    }
+    return null;
+  }
+  if (target && typeof target === 'object') {
+    const conditions = target as Record<string, unknown>;
+    for (const condition of ['import', 'default']) {
+      const resolved = resolvePackageTarget(
+        packageDirectory,
+        conditions[condition]
+      );
+      if (resolved) {
+        return resolved;
+      }
+    }
+  }
+  return null;
+};
+
+const resolvePackageImport = (
+  specifier: string,
+  importerPath: string
+): string | null => {
+  const parsed = parsePackageSpecifier(specifier);
+  if (!parsed) {
+    return null;
+  }
+  const packageDirectory = findPackageDirectory(
+    parsed.packageName,
+    importerPath
+  );
+  if (!packageDirectory) {
+    return null;
+  }
+  const packageJson = readPackageJson(packageDirectory);
+  if (!packageJson) {
+    return null;
+  }
+  const exportsField = packageJson.exports;
+  if (exportsField) {
+    const hasSubpathExports =
+      typeof exportsField === 'object' &&
+      !Array.isArray(exportsField) &&
+      Object.keys(exportsField).some(key => key.startsWith('.'));
+    const target =
+      parsed.subpath === '.' && !hasSubpathExports
+        ? exportsField
+        : hasSubpathExports
+          ? (exportsField as Record<string, unknown>)[parsed.subpath]
+          : undefined;
+    const resolved = resolvePackageTarget(packageDirectory, target);
+    if (resolved) {
+      return resolved;
+    }
+  }
+  if (parsed.subpath !== '.') {
+    return resolvePathWithExtensions(resolve(packageDirectory, parsed.subpath));
+  }
+  return (
+    resolvePackageTarget(packageDirectory, packageJson.module) ??
+    resolvePackageTarget(packageDirectory, packageJson.main) ??
+    resolveIndexFile(packageDirectory)
+  );
+};
+
+const resolveExportAllModule = (
+  specifier: string,
+  importerPath: string
+): string | null => {
+  if (specifier.startsWith('.') || specifier.startsWith('/')) {
+    const basePath = specifier.startsWith('/')
+      ? specifier
+      : resolve(dirname(importerPath), specifier);
+    const resolvedPath = resolvePathWithExtensions(basePath);
+    if (resolvedPath) {
+      return resolvedPath;
+    }
+  }
+
+  const packageImportPath = resolvePackageImport(specifier, importerPath);
+  if (packageImportPath) {
+    return packageImportPath;
+  }
+
+  try {
+    const resolver = createRequire(pathToFileURL(importerPath).href);
+    return resolver.resolve(specifier);
+  } catch {
+    return null;
+  }
+};
+
+export const collectClientOnlyStubExportNames = async (
+  code: string,
+  resourcePath: string
+): Promise<Set<string>> => {
+  const { exportNames: directExportNames, exportAllModules } =
+    await getExportNamesAndExportAll(code);
+  const exportNames = new Set(directExportNames);
+  const unresolvedExportAll = new Set<string>();
+  const visitedModules = new Set<string>();
+
+  const collectExportNamesFromModule = async (
+    modulePath: string
+  ): Promise<void> => {
+    if (visitedModules.has(modulePath)) {
+      return;
+    }
+    visitedModules.add(modulePath);
+    const { exports: moduleExportNames, exportAllModules: moduleExportAll } =
+      await getRouteModuleAnalysis(modulePath);
+    for (const name of moduleExportNames) {
+      if (name !== 'default') {
+        exportNames.add(name);
+      }
+    }
+    for (const nestedSpecifier of moduleExportAll) {
+      const nestedPath = resolveExportAllModule(nestedSpecifier, modulePath);
+      if (!nestedPath) {
+        unresolvedExportAll.add(nestedSpecifier);
+        continue;
+      }
+      await collectExportNamesFromModule(nestedPath);
+    }
+  };
+
+  for (const specifier of exportAllModules) {
+    const resolvedPath = resolveExportAllModule(specifier, resourcePath);
+    if (!resolvedPath) {
+      unresolvedExportAll.add(specifier);
+      continue;
+    }
+    await collectExportNamesFromModule(resolvedPath);
+  }
+
+  if (unresolvedExportAll.size > 0) {
+    throw new Error(
+      `[${PLUGIN_NAME}] Client-only module uses \`export * from\` with ` +
+        `unresolvable specifier(s): ${Array.from(unresolvedExportAll)
+          .map(spec => `\`${spec}\``)
+          .join(', ')}. ` +
+        `Please explicitly re-export named bindings in ` +
+        `\`${relative(process.cwd(), resourcePath)}\`.`
+    );
+  }
+
+  return exportNames;
+};

--- a/src/route-transform-tasks.ts
+++ b/src/route-transform-tasks.ts
@@ -10,7 +10,10 @@ import {
   removeUnusedImports,
   transformRoute,
 } from './plugin-utils.js';
-import { collectClientOnlyStubExportNames } from './route-export-resolution.js';
+import {
+  collectClientOnlyStubExportNames,
+  type RouteExportResolver,
+} from './route-export-resolution.js';
 import {
   createRouteChunkArtifact,
   createRouteClientEntryArtifact,
@@ -53,6 +56,7 @@ export type SplitRouteExportsTransformTask = BaseRouteTransformTask & {
 
 export type ClientOnlyStubTransformTask = BaseRouteTransformTask & {
   kind: 'clientOnlyStub';
+  resolveExportAllModule?: RouteExportResolver;
 };
 
 export type RouteModuleTransformTask = BaseRouteTransformTask & {
@@ -130,7 +134,8 @@ const createClientOnlyStub = async (
 ): Promise<RouteTransformResult> => {
   const exportNames = await collectClientOnlyStubExportNames(
     task.code,
-    task.resourcePath
+    task.resourcePath,
+    task.resolveExportAllModule
   );
 
   return {

--- a/src/route-transform-tasks.ts
+++ b/src/route-transform-tasks.ts
@@ -1,24 +1,16 @@
-import { readFileSync, statSync, type Stats } from 'node:fs';
-import { createRequire } from 'node:module';
-import { pathToFileURL } from 'node:url';
-import { basename as pathBasename, dirname, relative, resolve } from 'pathe';
+import { basename as pathBasename, relative } from 'pathe';
 import { generate, parse } from './yuku.js';
 import {
-  JS_EXTENSIONS,
-  PLUGIN_NAME,
   SERVER_ONLY_ROUTE_EXPORTS,
   SERVER_ONLY_ROUTE_EXPORTS_SET,
 } from './constants.js';
-import {
-  collectProgramExportNames,
-  getExportNamesAndExportAll,
-  getRouteModuleAnalysis,
-} from './export-utils.js';
+import { collectProgramExportNames } from './export-utils.js';
 import {
   removeExports,
   removeUnusedImports,
   transformRoute,
 } from './plugin-utils.js';
+import { collectClientOnlyStubExportNames } from './route-export-resolution.js';
 import {
   createRouteChunkArtifact,
   createRouteClientEntryArtifact,
@@ -38,12 +30,6 @@ export type RouteTransformResult = {
 type BaseRouteTransformTask = {
   code: string;
   resourcePath: string;
-};
-
-type PackageJson = {
-  exports?: unknown;
-  module?: unknown;
-  main?: unknown;
 };
 
 export type RouteClientEntryTransformTask = BaseRouteTransformTask & {
@@ -96,9 +82,6 @@ const defaultRouteChunkCache: RouteChunkCache = new Map();
 const getRouteChunkCache = (options?: RouteTransformTaskOptions) =>
   options?.routeChunkCache ?? defaultRouteChunkCache;
 
-const tryStat = (path: string): Stats | null =>
-  statSync(path, { throwIfNoEntry: false }) ?? null;
-
 const splitRouteExports = async (
   task: SplitRouteExportsTransformTask,
   options?: RouteTransformTaskOptions
@@ -142,247 +125,13 @@ const splitRouteExports = async (
   };
 };
 
-const resolveIndexFile = (dirPath: string): string | null => {
-  for (const ext of JS_EXTENSIONS) {
-    const candidate = resolve(dirPath, `index${ext}`);
-    const stats = tryStat(candidate);
-    if (!stats?.isFile()) {
-      continue;
-    }
-    return candidate;
-  }
-  return null;
-};
-
-const resolvePathWithExtensions = (basePath: string): string | null => {
-  const stats = tryStat(basePath);
-  if (stats?.isFile()) {
-    return basePath;
-  }
-  if (stats?.isDirectory()) {
-    return resolveIndexFile(basePath);
-  }
-
-  for (const ext of JS_EXTENSIONS) {
-    const candidate = `${basePath}${ext}`;
-    const candidateStats = tryStat(candidate);
-    if (!candidateStats?.isFile()) {
-      continue;
-    }
-    return candidate;
-  }
-
-  return resolveIndexFile(basePath);
-};
-
-const parsePackageSpecifier = (
-  specifier: string
-): { packageName: string; subpath: string } | null => {
-  if (
-    specifier.startsWith('.') ||
-    specifier.startsWith('/') ||
-    specifier.startsWith('node:')
-  ) {
-    return null;
-  }
-  const parts = specifier.split('/');
-  const packageName = specifier.startsWith('@')
-    ? parts.slice(0, 2).join('/')
-    : parts[0];
-  if (!packageName || (specifier.startsWith('@') && parts.length < 2)) {
-    return null;
-  }
-  const rest = parts.slice(packageName.startsWith('@') ? 2 : 1).join('/');
-  return {
-    packageName,
-    subpath: rest ? `./${rest}` : '.',
-  };
-};
-
-const findPackageDirectory = (
-  packageName: string,
-  importerPath: string
-): string | null => {
-  let currentDirectory = dirname(importerPath);
-  while (true) {
-    const candidate = resolve(currentDirectory, 'node_modules', packageName);
-    if (tryStat(candidate)?.isDirectory()) {
-      return candidate;
-    }
-    const parentDirectory = dirname(currentDirectory);
-    if (parentDirectory === currentDirectory) {
-      return null;
-    }
-    currentDirectory = parentDirectory;
-  }
-};
-
-const readPackageJson = (packageDirectory: string): PackageJson | null => {
-  try {
-    return JSON.parse(
-      readFileSync(resolve(packageDirectory, 'package.json'), 'utf8')
-    );
-  } catch {
-    return null;
-  }
-};
-
-const resolvePackageTarget = (
-  packageDirectory: string,
-  target: unknown
-): string | null => {
-  if (typeof target === 'string') {
-    return resolvePathWithExtensions(resolve(packageDirectory, target));
-  }
-  if (Array.isArray(target)) {
-    for (const item of target) {
-      const resolved = resolvePackageTarget(packageDirectory, item);
-      if (resolved) {
-        return resolved;
-      }
-    }
-    return null;
-  }
-  if (target && typeof target === 'object') {
-    const conditions = target as Record<string, unknown>;
-    for (const condition of ['import', 'default']) {
-      const resolved = resolvePackageTarget(
-        packageDirectory,
-        conditions[condition]
-      );
-      if (resolved) {
-        return resolved;
-      }
-    }
-  }
-  return null;
-};
-
-const resolvePackageImport = (
-  specifier: string,
-  importerPath: string
-): string | null => {
-  const parsed = parsePackageSpecifier(specifier);
-  if (!parsed) {
-    return null;
-  }
-  const packageDirectory = findPackageDirectory(
-    parsed.packageName,
-    importerPath
-  );
-  if (!packageDirectory) {
-    return null;
-  }
-  const packageJson = readPackageJson(packageDirectory);
-  if (!packageJson) {
-    return null;
-  }
-  const exportsField = packageJson.exports;
-  if (exportsField) {
-    const hasSubpathExports =
-      typeof exportsField === 'object' &&
-      !Array.isArray(exportsField) &&
-      Object.keys(exportsField).some(key => key.startsWith('.'));
-    const target =
-      parsed.subpath === '.' && !hasSubpathExports
-        ? exportsField
-        : hasSubpathExports
-          ? (exportsField as Record<string, unknown>)[parsed.subpath]
-          : undefined;
-    const resolved = resolvePackageTarget(packageDirectory, target);
-    if (resolved) {
-      return resolved;
-    }
-  }
-  if (parsed.subpath !== '.') {
-    return resolvePathWithExtensions(resolve(packageDirectory, parsed.subpath));
-  }
-  return (
-    resolvePackageTarget(packageDirectory, packageJson.module) ??
-    resolvePackageTarget(packageDirectory, packageJson.main) ??
-    resolveIndexFile(packageDirectory)
-  );
-};
-
-const resolveExportAllModule = (
-  specifier: string,
-  importerPath: string
-): string | null => {
-  if (specifier.startsWith('.') || specifier.startsWith('/')) {
-    const basePath = specifier.startsWith('/')
-      ? specifier
-      : resolve(dirname(importerPath), specifier);
-    const resolvedPath = resolvePathWithExtensions(basePath);
-    if (resolvedPath) {
-      return resolvedPath;
-    }
-  }
-
-  const packageImportPath = resolvePackageImport(specifier, importerPath);
-  if (packageImportPath) {
-    return packageImportPath;
-  }
-
-  try {
-    const resolver = createRequire(pathToFileURL(importerPath).href);
-    return resolver.resolve(specifier);
-  } catch {
-    return null;
-  }
-};
-
 const createClientOnlyStub = async (
   task: ClientOnlyStubTransformTask
 ): Promise<RouteTransformResult> => {
-  const { exportNames: directExportNames, exportAllModules } =
-    await getExportNamesAndExportAll(task.code);
-  const exportNames = new Set(directExportNames);
-  const unresolvedExportAll = new Set<string>();
-  const visitedModules = new Set<string>();
-
-  const collectExportNamesFromModule = async (
-    modulePath: string
-  ): Promise<void> => {
-    if (visitedModules.has(modulePath)) {
-      return;
-    }
-    visitedModules.add(modulePath);
-    const { exports: moduleExportNames, exportAllModules: moduleExportAll } =
-      await getRouteModuleAnalysis(modulePath);
-    for (const name of moduleExportNames) {
-      if (name !== 'default') {
-        exportNames.add(name);
-      }
-    }
-    for (const nestedSpecifier of moduleExportAll) {
-      const nestedPath = resolveExportAllModule(nestedSpecifier, modulePath);
-      if (!nestedPath) {
-        unresolvedExportAll.add(nestedSpecifier);
-        continue;
-      }
-      await collectExportNamesFromModule(nestedPath);
-    }
-  };
-
-  for (const specifier of exportAllModules) {
-    const resolvedPath = resolveExportAllModule(specifier, task.resourcePath);
-    if (!resolvedPath) {
-      unresolvedExportAll.add(specifier);
-      continue;
-    }
-    await collectExportNamesFromModule(resolvedPath);
-  }
-
-  if (unresolvedExportAll.size > 0) {
-    throw new Error(
-      `[${PLUGIN_NAME}] Client-only module uses \`export * from\` with ` +
-        `unresolvable specifier(s): ${Array.from(unresolvedExportAll)
-          .map(spec => `\`${spec}\``)
-          .join(', ')}. ` +
-        `Please explicitly re-export named bindings in ` +
-        `\`${relative(process.cwd(), task.resourcePath)}\`.`
-    );
-  }
+  const exportNames = await collectClientOnlyStubExportNames(
+    task.code,
+    task.resourcePath
+  );
 
   return {
     code: Array.from(exportNames)

--- a/src/route-watch.ts
+++ b/src/route-watch.ts
@@ -260,6 +260,9 @@ export const createRouteTopologyWatcher = async ({
     let nextDirectories: Set<string> | undefined;
     try {
       nextDirectories = await readRouteDirectories(watchDirectory);
+      if (closed) {
+        return;
+      }
       const nextState = {
         directories: nextDirectories,
         routeTopology: await getRouteTopology(),

--- a/src/server-build-plan.ts
+++ b/src/server-build-plan.ts
@@ -1,0 +1,91 @@
+import { PLUGIN_NAME } from './constants.js';
+import type { ReactRouterDevBuildPlan } from './dev-runtime-artifacts.js';
+import type { Route } from './types.js';
+
+export type ReactRouterServerBundleEntry = {
+  bundleId: string;
+  entryName: string;
+};
+
+export type ReactRouterServerBuildPlan = ReactRouterDevBuildPlan & {
+  serverBundleEntries: ReactRouterServerBundleEntry[];
+};
+
+export const createReactRouterServerBuildPlan = ({
+  routesByServerBundleId,
+  serverBuildFile,
+  defaultEntryName,
+}: {
+  routesByServerBundleId: Record<string, Record<string, Route>>;
+  serverBuildFile: string | undefined;
+  defaultEntryName: string;
+}): ReactRouterServerBuildPlan => {
+  const serverBuildFileBase = (serverBuildFile || 'index.js').replace(
+    /\.js$/,
+    ''
+  );
+  const serverBundleEntries = Object.entries(routesByServerBundleId)
+    .filter(([, bundleRoutes]) =>
+      Boolean(bundleRoutes && Object.keys(bundleRoutes).length > 0)
+    )
+    .map(([bundleId]) => ({
+      bundleId,
+      entryName: `${bundleId}/${serverBuildFileBase}`,
+    }));
+
+  const reservedNodeEntryNames = new Set([
+    'static/js/app',
+    'static/js/entry.server',
+    defaultEntryName,
+  ]);
+  for (const { entryName } of serverBundleEntries) {
+    if (reservedNodeEntryNames.has(entryName)) {
+      throw new Error(
+        `[${PLUGIN_NAME}] Server bundle entry ${JSON.stringify(entryName)} conflicts with a reserved node entry.`
+      );
+    }
+    reservedNodeEntryNames.add(entryName);
+  }
+
+  return {
+    defaultEntryName,
+    entryNames: [
+      defaultEntryName,
+      ...serverBundleEntries.map(({ entryName }) => entryName),
+    ],
+    serverBundleEntries,
+  };
+};
+
+export const createReactRouterNodeEntries = ({
+  hasServerApp,
+  isBuild,
+  serverAppPath,
+  entryServerPath,
+  defaultEntryName,
+  serverBundleEntries,
+}: {
+  hasServerApp: boolean;
+  isBuild: boolean;
+  serverAppPath: string;
+  entryServerPath: string;
+  defaultEntryName: string;
+  serverBundleEntries: readonly ReactRouterServerBundleEntry[];
+}): Record<string, string> => {
+  const entries: Record<string, string> = {
+    'static/js/app': hasServerApp
+      ? serverAppPath
+      : 'virtual/react-router/server-build',
+    'static/js/entry.server': entryServerPath,
+  };
+
+  if (hasServerApp && !isBuild) {
+    entries[defaultEntryName] = 'virtual/react-router/server-build';
+  }
+
+  for (const { bundleId, entryName } of serverBundleEntries) {
+    entries[entryName] = `virtual/react-router/server-build-${bundleId}`;
+  }
+
+  return entries;
+};

--- a/src/server-utils.ts
+++ b/src/server-utils.ts
@@ -191,6 +191,14 @@ export async function resolveServerBuildModule(
       return fromDefault;
     }
   }
+  if (isRecord(moduleValue) && 'module.exports' in moduleValue) {
+    const fromModuleExports = await resolveServerBuildCandidate(
+      await moduleValue['module.exports']
+    );
+    if (fromModuleExports) {
+      return fromModuleExports;
+    }
+  }
   throw new Error(
     `[rsbuild-plugin-react-router] ${source} did not contain a valid React Router ServerBuild.`
   );

--- a/tests/bounded-cache.test.ts
+++ b/tests/bounded-cache.test.ts
@@ -28,4 +28,18 @@ describe('bounded cache helpers', () => {
 
     expect([...cache.entries()]).toEqual([]);
   });
+
+  it('evicts an undefined oldest key when inserting past the maximum size', () => {
+    const cache = new Map<string | undefined, number>([
+      [undefined, 1],
+      ['second', 2],
+    ]);
+
+    setBoundedCacheEntry(cache, 'third', 3, 2);
+
+    expect([...cache.entries()]).toEqual([
+      ['second', 2],
+      ['third', 3],
+    ]);
+  });
 });

--- a/tests/client-modules.test.ts
+++ b/tests/client-modules.test.ts
@@ -97,4 +97,53 @@ describe('client-only module transforms', () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it('uses the Rsbuild transform resolver for export-all modules', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'rr-client-modules-resolve-'));
+    const appDirectory = join(root, 'app');
+    const resourcePath = join(appDirectory, 'example.client.ts');
+    const resolvedPath = join(root, 'generated', 'client-exports.ts');
+    await mkdir(appDirectory, { recursive: true });
+    await mkdir(join(root, 'generated'), { recursive: true });
+    await writeFile(resourcePath, "export * from '@client/exports';");
+    await writeFile(
+      resolvedPath,
+      'export const fromResolver = true; export const alsoResolver = true;'
+    );
+
+    try {
+      const rsbuild = await createStubRsbuild({
+        rsbuildConfig: {},
+      });
+
+      const plugin = pluginReactRouter();
+      await plugin.setup(rsbuild as any);
+
+      const transformCall = (rsbuild.transform as any).mock.calls.find(
+        (call: any[]) => call[0].test?.toString().includes('\\.client')
+      );
+      expect(transformCall).toBeDefined();
+
+      const handler = transformCall?.[1];
+      const result = await handler({
+        environment: { name: 'node' },
+        code: await readFile(resourcePath, 'utf8'),
+        resourcePath,
+        resolve(
+          context: string,
+          specifier: string,
+          callback: (error: Error | null, resolved?: string) => void
+        ) {
+          expect(context).toBe(appDirectory);
+          expect(specifier).toBe('@client/exports');
+          callback(null, resolvedPath);
+        },
+      });
+
+      expect(result.code).toContain('export const fromResolver = undefined;');
+      expect(result.code).toContain('export const alsoResolver = undefined;');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/client-modules.test.ts
+++ b/tests/client-modules.test.ts
@@ -5,6 +5,7 @@ import { resolve } from 'pathe';
 import { describe, expect, it } from '@rstest/core';
 import { createStubRsbuild } from '@scripts/test-helper';
 import { pluginReactRouter } from '../src';
+import { collectClientOnlyStubExportNames } from '../src/route-export-resolution';
 
 describe('client-only module transforms', () => {
   it('stubs exports for .client modules using export *', async () => {
@@ -93,6 +94,41 @@ describe('client-only module transforms', () => {
       expect(result.code).toContain('export const esmOnly = undefined;');
       expect(result.code).toContain('export const shared = undefined;');
       expect(result.code).not.toContain('cjsOnly');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not bypass package exports for private export-all subpaths', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'rr-client-modules-private-'));
+    const packageDirectory = join(root, 'node_modules', 'private-client-lib');
+    await mkdir(packageDirectory, { recursive: true });
+    await writeFile(
+      join(packageDirectory, 'package.json'),
+      JSON.stringify({
+        name: 'private-client-lib',
+        exports: {
+          '.': './public.js',
+        },
+        type: 'module',
+      })
+    );
+    await writeFile(join(packageDirectory, 'public.js'), 'export const ok = true;');
+    await writeFile(
+      join(packageDirectory, 'private.js'),
+      'export const hidden = true;'
+    );
+    const resourcePath = join(root, 'app', 'example.client.ts');
+    await mkdir(join(root, 'app'), { recursive: true });
+    await writeFile(resourcePath, "export * from 'private-client-lib/private';");
+
+    try {
+      await expect(
+        collectClientOnlyStubExportNames(
+          await readFile(resourcePath, 'utf8'),
+          resourcePath
+        )
+      ).rejects.toThrow('private-client-lib/private');
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/tests/dev-runtime-controller.test.ts
+++ b/tests/dev-runtime-controller.test.ts
@@ -170,8 +170,9 @@ const createHarness = (userSetup?: TestServerSetup) => {
     ) => {
       const handler =
         typeof callback === 'function' ? callback : callback.handler;
-      const config = handler({ server: { setup: serverSetups } });
-      const setup = config?.server?.setup;
+      const nextConfig: TestConfig = { server: { setup: serverSetups } };
+      const config = handler(nextConfig) ?? nextConfig;
+      const setup = config.server?.setup;
       serverSetups = setup
         ? Array.isArray(setup)
           ? setup
@@ -338,7 +339,7 @@ describe('React Router development runtime controller', () => {
   it('rejects readiness when Rsbuild does not create both compilers', async () => {
     const { callbacks, controller, server } = createHarness();
     const compiler = createCompiler('web');
-    callbacks.start({ server });
+    await callbacks.start({ server });
 
     callbacks.created({ compiler: compiler.compiler });
 
@@ -351,7 +352,7 @@ describe('React Router development runtime controller', () => {
     const { callbacks, controller, server } = createHarness();
     const web = createCompiler('web');
     const node = createCompiler('node');
-    callbacks.start({ server });
+    await callbacks.start({ server });
     callbacks.created({
       compiler: { compilers: [web.compiler, node.compiler] },
     });
@@ -370,7 +371,7 @@ describe('React Router development runtime controller', () => {
     const { callbacks, controller, loadBundle, server } = createHarness();
     const web = createCompiler('web');
     const node = createCompiler('node');
-    callbacks.start({ server });
+    await callbacks.start({ server });
     callbacks.created({
       compiler: { compilers: [web.compiler, node.compiler] },
     });
@@ -593,7 +594,7 @@ describe('React Router development runtime controller', () => {
     const { callbacks, controller, createServer, server } = createHarness();
     const oldWeb = createCompiler('web');
     const oldNode = createCompiler('node');
-    callbacks.start({ server });
+    await callbacks.start({ server });
     callbacks.created({
       compiler: { compilers: [oldWeb.compiler, oldNode.compiler] },
     });
@@ -619,7 +620,7 @@ describe('React Router development runtime controller', () => {
 
   it('disposes the current session through the supported close hook', async () => {
     const { callbacks, controller, server } = createHarness();
-    callbacks.start({ server });
+    await callbacks.start({ server });
     const loadBuild = controller.createBuildLoader();
 
     await callbacks.close();
@@ -634,7 +635,7 @@ describe('React Router development runtime controller', () => {
     const { callbacks, controller, createServer, server } = createHarness();
     const oldWeb = createCompiler('web');
     const oldNode = createCompiler('node');
-    callbacks.start({ server });
+    await callbacks.start({ server });
     callbacks.created({
       compiler: { compilers: [oldWeb.compiler, oldNode.compiler] },
     });
@@ -668,7 +669,7 @@ describe('React Router development runtime controller', () => {
     const { callbacks, controller, createServer, server } = createHarness();
     const oldWeb = createCompiler('web');
     const oldNode = createCompiler('node');
-    callbacks.start({ server });
+    await callbacks.start({ server });
     callbacks.created({
       compiler: { compilers: [oldWeb.compiler, oldNode.compiler] },
     });
@@ -834,7 +835,7 @@ describe('React Router development runtime controller', () => {
     const node = createCompiler('node');
     let build = createBuild('base');
     loadBundle.mockImplementation(() => build);
-    callbacks.start({ server });
+    await callbacks.start({ server });
     callbacks.created({
       compiler: { compilers: [web.compiler, node.compiler] },
     });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -293,10 +293,20 @@ describe('pluginReactRouter', () => {
     ]);
     const config = await rsbuild.unwrapConfig();
 
-    expect(config.dev.lazyCompilation).toEqual({
+    expect(config.dev.lazyCompilation).toMatchObject({
       entries: true,
       imports: true,
     });
+    expect(
+      config.dev.lazyCompilation.test({
+        resource: '/project/app/root.tsx?__react-router-build-client-route',
+      })
+    ).toBe(false);
+    expect(
+      config.dev.lazyCompilation.test({
+        resource: '/project/app/components/card.tsx',
+      })
+    ).toBe(true);
   });
 
   it('should allow lazy compilation to be enabled with a boolean', async () => {
@@ -307,7 +317,52 @@ describe('pluginReactRouter', () => {
     rsbuild.addPlugins([pluginReactRouter({ lazyCompilation: true })]);
     const config = await rsbuild.unwrapConfig();
 
-    expect(config.dev.lazyCompilation).toBe(true);
+    expect(config.dev.lazyCompilation).toMatchObject({
+      entries: true,
+      imports: true,
+    });
+    expect(
+      config.dev.lazyCompilation.test({
+        resource: `${process.cwd()}/app/entry.client.tsx`,
+      })
+    ).toBe(false);
+  });
+
+  it('guards direct Rsbuild lazy compilation config for React Router hydration entries', async () => {
+    const rsbuild = await createStubRsbuild({
+      rsbuildConfig: {
+        dev: {
+          lazyCompilation: {
+            entries: true,
+            imports: false,
+            test: /app/,
+          },
+        },
+      },
+    });
+
+    rsbuild.addPlugins([pluginReactRouter()]);
+    const config = await rsbuild.unwrapConfig();
+
+    expect(config.dev.lazyCompilation).toMatchObject({
+      entries: true,
+      imports: false,
+    });
+    expect(
+      config.dev.lazyCompilation.test({
+        resource: '/project/app/routes/home.tsx?__react-router-build-client-route',
+      })
+    ).toBe(false);
+    expect(
+      config.dev.lazyCompilation.test({
+        resource: '/project/app/components/card.tsx',
+      })
+    ).toBe(true);
+    expect(
+      config.dev.lazyCompilation.test({
+        resource: '/project/vendor/react.tsx',
+      })
+    ).toBe(false);
   });
 
   it('should allow lazy compilation to be disabled', async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -3,6 +3,21 @@ import { describe, expect, it, rstest } from '@rstest/core';
 import * as fs from 'node:fs';
 import { pluginReactRouter } from '../src';
 
+const captureEnv = (keys: string[]) => {
+  const previousValues = new Map(
+    keys.map(key => [key, process.env[key]] as const)
+  );
+  return () => {
+    for (const [key, value] of previousValues) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  };
+};
+
 describe('pluginReactRouter', () => {
   it('should configure basic plugin options', async () => {
     const rsbuild = await createStubRsbuild({
@@ -194,6 +209,10 @@ describe('pluginReactRouter', () => {
   });
 
   it('reduces file size reporting overhead for medium split route builds by default', async () => {
+    const restoreEnv = captureEnv([
+      'RR_TEST_SPLIT_ROUTE_MODULES',
+      'RR_TEST_ROUTE_COUNT',
+    ]);
     process.env.RR_TEST_SPLIT_ROUTE_MODULES = 'true';
     process.env.RR_TEST_ROUTE_COUNT = '256';
     const readFileSync = rstest
@@ -215,12 +234,12 @@ describe('pluginReactRouter', () => {
       });
     } finally {
       readFileSync.mockRestore();
-      delete process.env.RR_TEST_SPLIT_ROUTE_MODULES;
-      delete process.env.RR_TEST_ROUTE_COUNT;
+      restoreEnv();
     }
   });
 
   it('reduces file size reporting overhead for medium route builds by default', async () => {
+    const restoreEnv = captureEnv(['RR_TEST_ROUTE_COUNT']);
     process.env.RR_TEST_ROUTE_COUNT = '256';
     const readFileSync = rstest
       .spyOn(fs, 'readFileSync')
@@ -241,11 +260,15 @@ describe('pluginReactRouter', () => {
       });
     } finally {
       readFileSync.mockRestore();
-      delete process.env.RR_TEST_ROUTE_COUNT;
+      restoreEnv();
     }
   });
 
   it('keeps explicit object file size reporting config for large split route builds', async () => {
+    const restoreEnv = captureEnv([
+      'RR_TEST_SPLIT_ROUTE_MODULES',
+      'RR_TEST_ROUTE_COUNT',
+    ]);
     process.env.RR_TEST_SPLIT_ROUTE_MODULES = 'true';
     process.env.RR_TEST_ROUTE_COUNT = '1024';
     const readFileSync = rstest
@@ -273,8 +296,7 @@ describe('pluginReactRouter', () => {
       });
     } finally {
       readFileSync.mockRestore();
-      delete process.env.RR_TEST_SPLIT_ROUTE_MODULES;
-      delete process.env.RR_TEST_ROUTE_COUNT;
+      restoreEnv();
     }
   });
 

--- a/tests/lazy-compilation.test.ts
+++ b/tests/lazy-compilation.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from '@rstest/core';
+import { guardReactRouterLazyCompilation } from '../src/lazy-compilation';
+
+describe('guardReactRouterLazyCompilation', () => {
+  const entryClientPath = '/project/app/entry.client.tsx';
+
+  it('leaves disabled and unspecified lazy compilation unchanged', () => {
+    expect(
+      guardReactRouterLazyCompilation({
+        lazyCompilation: undefined,
+        entryClientPath,
+      })
+    ).toBeUndefined();
+    expect(
+      guardReactRouterLazyCompilation({
+        lazyCompilation: false,
+        entryClientPath,
+      })
+    ).toBe(false);
+  });
+
+  it('keeps boolean lazy compilation enabled while guarding hydration modules', () => {
+    const guarded = guardReactRouterLazyCompilation({
+      lazyCompilation: true,
+      entryClientPath,
+    });
+
+    expect(guarded).toMatchObject({
+      entries: true,
+      imports: true,
+    });
+    expect(
+      guarded?.test?.({
+        resource: `${entryClientPath}!lazy-compilation-proxy`,
+      })
+    ).toBe(false);
+    expect(
+      guarded?.test?.({
+        resource: '/project/app/components/card.tsx',
+      })
+    ).toBe(true);
+  });
+
+  it('preserves user tests for non-React Router hydration modules', () => {
+    const guarded = guardReactRouterLazyCompilation({
+      lazyCompilation: {
+        entries: true,
+        imports: false,
+        test: /app/g,
+      },
+      entryClientPath,
+    });
+
+    expect(guarded).toMatchObject({
+      entries: true,
+      imports: false,
+    });
+    expect(
+      guarded?.test?.({
+        resource: '/project/app/root.tsx?__react-router-build-client-route',
+      })
+    ).toBe(false);
+    expect(
+      guarded?.test?.({
+        resource: '/project/app/components/card.tsx',
+      })
+    ).toBe(true);
+    expect(
+      guarded?.test?.({
+        resource: '/project/vendor/react.tsx',
+      })
+    ).toBe(false);
+  });
+
+  it('guards all React Router hydration-critical module shapes', () => {
+    const guarded = guardReactRouterLazyCompilation({
+      lazyCompilation: {
+        entries: true,
+        imports: true,
+      },
+      entryClientPath,
+    });
+
+    expect(
+      guarded?.test?.({
+        request: 'virtual/react-router/browser-manifest',
+      })
+    ).toBe(false);
+    expect(
+      guarded?.test?.({
+        identifier: () =>
+          '/project/app/routes/home.tsx?__react-router-build-client-route',
+      })
+    ).toBe(false);
+    expect(
+      guarded?.test?.({
+        nameForCondition: () =>
+          '/project/app/routes/home.tsx?react-router-route',
+      })
+    ).toBe(false);
+  });
+});

--- a/tests/modify-browser-manifest.test.ts
+++ b/tests/modify-browser-manifest.test.ts
@@ -1,8 +1,14 @@
+import { createHash } from 'node:crypto';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from '@rstest/core';
-import { createModifyBrowserManifestPlugin } from '../src/modify-browser-manifest';
+import { registerModifyBrowserManifestAssets } from '../src/modify-browser-manifest';
+
+const BROWSER_MANIFEST_PATH =
+  'static/js/virtual/react-router/browser-manifest.js';
+const PLACEHOLDER_MANIFEST_SOURCE =
+  'window.__reactRouterManifest="PLACEHOLDER";';
 
 const createTempApp = () => {
   const root = mkdtempSync(join(tmpdir(), 'rr-modify-manifest-'));
@@ -24,38 +30,156 @@ const createAsset = (source: string) => ({
   size: () => source.length,
 });
 
-describe('modify browser manifest plugin', () => {
-  it('reports the exact compilation that produced the manifest', async () => {
-    const { root, appDir } = createTempApp();
-    const routes = {
-      root: { id: 'root', file: 'root.tsx', path: '' },
-    };
-    let emit: ((compilation: unknown) => Promise<void>) | undefined;
-    let reportedCompilation: unknown;
-    const compiler = {
-      hooks: {
-        emit: {
-          tapPromise(_name: string, callback: typeof emit) {
-            emit = callback;
-          },
-        },
+class RawSource {
+  constructor(private readonly value: string) {}
+  source() {
+    return this.value;
+  }
+  size() {
+    return this.value.length;
+  }
+}
+
+type Asset = ReturnType<typeof createAsset>;
+type ProcessAssetsContext = {
+  assets: Record<string, Asset>;
+  compilation: unknown;
+};
+type ProcessAssetsDescriptor = {
+  stage: string;
+  environments?: string[];
+};
+type ProcessAssetsHandler = (
+  context: ProcessAssetsContext & { sources: { RawSource: typeof RawSource } }
+) => Promise<void> | void;
+type ProcessAssetsRegistration = {
+  descriptor: ProcessAssetsDescriptor;
+  handler: ProcessAssetsHandler;
+};
+
+const createProcessAssetsHarness = () => {
+  const registrations: ProcessAssetsRegistration[] = [];
+
+  return {
+    api: {
+      processAssets(
+        processAssetsDescriptor: ProcessAssetsDescriptor,
+        processAssetsHandler: ProcessAssetsHandler
+      ) {
+        registrations.push({
+          descriptor: processAssetsDescriptor,
+          handler: processAssetsHandler,
+        });
       },
-    };
-    const compilation = {
-      namedChunks: new Map([
+    },
+    getDescriptor: () => registrations[0]?.descriptor,
+    getDescriptors: () =>
+      registrations.map(registration => registration.descriptor),
+    run(context: ProcessAssetsContext) {
+      const registration = registrations[0];
+      expect(registration).toBeDefined();
+      return registration!.handler({ ...context, sources: { RawSource } });
+    },
+    runStage(stage: string, context: ProcessAssetsContext) {
+      const registration = registrations.find(
+        registration => registration.descriptor.stage === stage
+      );
+      expect(registration).toBeDefined();
+      return registration!.handler({ ...context, sources: { RawSource } });
+    },
+  };
+};
+
+const createCompilation = (
+  namedChunks: Array<[string, unknown]>,
+  assets: Record<string, Asset> = {}
+) => ({
+  namedChunks: new Map(namedChunks),
+  assets,
+  getAsset(name: string) {
+    const asset = assets[name];
+    return asset ? { name, source: asset } : undefined;
+  },
+  updateAsset(name: string, source: Asset) {
+    assets[name] = source;
+  },
+  emitAsset(name: string, source: Asset) {
+    assets[name] = source;
+  },
+  getAssets() {
+    return Object.entries(assets).map(([name, source]) => ({ name, source }));
+  },
+});
+
+const rootRoute = { id: 'root', file: 'root.tsx', path: '' };
+
+const createRoutesWithPage = () => ({
+  root: rootRoute,
+  'routes/page': {
+    id: 'routes/page',
+    parentId: 'root',
+    file: 'routes/page.tsx',
+    path: 'page',
+  },
+});
+
+const createBrowserManifestAssets = () => ({
+  [BROWSER_MANIFEST_PATH]: createAsset(PLACEHOLDER_MANIFEST_SOURCE),
+});
+
+const createSriHash = (source: string) =>
+  `sha384-${createHash('sha384').update(source).digest('base64')}`;
+
+describe('modify browser manifest plugin', () => {
+  it('registers browser manifest mutation with Rsbuild processAssets', async () => {
+    const { root, appDir } = createTempApp();
+    const harness = createProcessAssetsHarness();
+    const assets = createBrowserManifestAssets();
+    const compilation = createCompilation(
+      [
         ['entry.client', { files: new Set(['static/js/entry.client.js']) }],
         ['root', { files: new Set(['static/js/root.js']) }],
-      ]),
-      assets: {
-        'static/js/virtual/react-router/browser-manifest.js': createAsset(
-          'window.__reactRouterManifest="PLACEHOLDER";'
-        ),
-      },
-    };
+      ],
+      assets
+    );
 
     try {
-      createModifyBrowserManifestPlugin(
-        routes,
+      registerModifyBrowserManifestAssets(
+        harness.api as never,
+        { root: rootRoute },
+        {},
+        appDir
+      );
+
+      expect(harness.getDescriptor()).toEqual({
+        stage: 'additions',
+        environments: ['web'],
+      });
+      await harness.run({ assets, compilation });
+
+      expect(assets[BROWSER_MANIFEST_PATH].source()).toContain('routes');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('reports the exact compilation that produced the manifest', async () => {
+    const { root, appDir } = createTempApp();
+    const harness = createProcessAssetsHarness();
+    const assets = createBrowserManifestAssets();
+    const compilation = createCompilation(
+      [
+        ['entry.client', { files: new Set(['static/js/entry.client.js']) }],
+        ['root', { files: new Set(['static/js/root.js']) }],
+      ],
+      assets
+    );
+    let reportedCompilation: unknown;
+
+    try {
+      registerModifyBrowserManifestAssets(
+        harness.api as never,
+        { root: rootRoute },
         {},
         appDir,
         '/',
@@ -65,10 +189,9 @@ describe('modify browser manifest plugin', () => {
             reportedCompilation = context.compilation;
           },
         }
-      ).apply(compiler as never);
+      );
 
-      expect(emit).toBeDefined();
-      await emit(compilation);
+      await harness.run({ assets, compilation });
 
       expect(reportedCompilation).toBe(compilation);
     } finally {
@@ -76,39 +199,85 @@ describe('modify browser manifest plugin', () => {
     }
   });
 
-  it('rejects the promise hook when build route analysis fails', async () => {
+  it('hashes build SRI after later asset stages mutate JavaScript', async () => {
     const { root, appDir } = createTempApp();
-    writeFileSync(join(appDir, 'routes/page.tsx'), 'export const = broken;');
-    const routes = {
-      root: { id: 'root', file: 'root.tsx', path: '' },
-      'routes/page': {
-        id: 'routes/page',
-        parentId: 'root',
-        file: 'routes/page.tsx',
-        path: 'page',
-      },
+    const harness = createProcessAssetsHarness();
+    const originalEntrySource = 'console.log("before optimize");';
+    const optimizedEntrySource = 'console.log("after optimize");';
+    const assets = {
+      ...createBrowserManifestAssets(),
+      'static/js/entry.client.js': createAsset(originalEntrySource),
+      'static/js/root.js': createAsset('console.log("root");'),
     };
-    let emit: ((compilation: unknown) => Promise<void>) | undefined;
-    const compiler = {
-      hooks: {
-        emit: {
-          tapPromise(_name: string, callback: typeof emit) {
-            emit = callback;
-          },
-        },
-      },
-    };
+    const compilation = createCompilation(
+      [
+        ['entry.client', { files: new Set(['static/js/entry.client.js']) }],
+        ['root', { files: new Set(['static/js/root.js']) }],
+      ],
+      assets
+    );
+    let reportedSri: Record<string, string> | undefined;
 
     try {
-      createModifyBrowserManifestPlugin(routes, {}, appDir, '/', {
-        isBuild: true,
-      }).apply(compiler as never);
+      registerModifyBrowserManifestAssets(
+        harness.api as never,
+        { root: rootRoute },
+        {},
+        appDir,
+        '/',
+        { isBuild: true },
+        {
+          future: { unstable_subResourceIntegrity: true },
+          onManifest(_manifest, sri) {
+            reportedSri = sri;
+          },
+        }
+      );
 
-      expect(emit).toBeDefined();
+      expect(harness.getDescriptors()).toEqual([
+        { stage: 'additions', environments: ['web'] },
+        { stage: 'report', environments: ['web'] },
+      ]);
+
+      await harness.runStage('additions', { assets, compilation });
+      expect(reportedSri).toBeUndefined();
+
+      compilation.updateAsset(
+        'static/js/entry.client.js',
+        createAsset(optimizedEntrySource)
+      );
+      await harness.runStage('report', { assets, compilation });
+
+      expect(reportedSri?.['/static/js/entry.client.js']).toBe(
+        createSriHash(optimizedEntrySource)
+      );
+      expect(reportedSri?.['/static/js/entry.client.js']).not.toBe(
+        createSriHash(originalEntrySource)
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects the promise hook when build route analysis fails', async () => {
+    const { root, appDir } = createTempApp();
+    const harness = createProcessAssetsHarness();
+    writeFileSync(join(appDir, 'routes/page.tsx'), 'export const = broken;');
+
+    try {
+      registerModifyBrowserManifestAssets(
+        harness.api as never,
+        createRoutesWithPage(),
+        {},
+        appDir,
+        '/',
+        { isBuild: true }
+      );
+
       await expect(
-        emit({
-          namedChunks: new Map(),
+        harness.run({
           assets: {},
+          compilation: createCompilation([]),
         })
       ).rejects.toThrow();
     } finally {
@@ -118,51 +287,31 @@ describe('modify browser manifest plugin', () => {
 
   it('does not read ignored chunk files while creating manifest stats', async () => {
     const { root, appDir } = createTempApp();
-    const routes = {
-      root: { id: 'root', file: 'root.tsx', path: '' },
-      'routes/page': {
-        id: 'routes/page',
-        parentId: 'root',
-        file: 'routes/page.tsx',
-        path: 'page',
+    const harness = createProcessAssetsHarness();
+    const assets = createBrowserManifestAssets();
+    const ignoredChunk = {};
+    Object.defineProperty(ignoredChunk, 'files', {
+      get() {
+        throw new Error('ignored chunk files should not be read');
       },
-    };
-    let emit: ((compilation: unknown) => Promise<void>) | undefined;
-    const compiler = {
-      hooks: {
-        emit: {
-          tapPromise(_name: string, callback: typeof emit) {
-            emit = callback;
-          },
-        },
-      },
-    };
+    });
 
     try {
-      createModifyBrowserManifestPlugin(routes, {}, appDir).apply(
-        compiler as never
+      registerModifyBrowserManifestAssets(
+        harness.api as never,
+        createRoutesWithPage(),
+        {},
+        appDir
       );
 
-      const ignoredChunk = {};
-      Object.defineProperty(ignoredChunk, 'files', {
-        get() {
-          throw new Error('ignored chunk files should not be read');
-        },
-      });
-
-      expect(emit).toBeDefined();
-      await emit({
-        namedChunks: new Map([
+      await harness.run({
+        assets,
+        compilation: createCompilation([
           ['entry.client', { files: new Set(['static/js/entry.client.js']) }],
           ['root', { files: new Set(['static/js/root.js']) }],
           ['routes/page', { files: new Set(['static/js/routes/page.js']) }],
           ['vendor', ignoredChunk],
         ]),
-        assets: {
-          'static/js/virtual/react-router/browser-manifest.js': createAsset(
-            'window.__reactRouterManifest="PLACEHOLDER";'
-          ),
-        },
       });
     } finally {
       rmSync(root, { recursive: true, force: true });
@@ -171,29 +320,19 @@ describe('modify browser manifest plugin', () => {
 
   it('uses actual manifest chunk names instead of theoretical split route chunks', async () => {
     const { root, appDir } = createTempApp();
-    const routes = {
-      root: { id: 'root', file: 'root.tsx', path: '' },
-      'routes/page': {
-        id: 'routes/page',
-        parentId: 'root',
-        file: 'routes/page.tsx',
-        path: 'page',
+    const harness = createProcessAssetsHarness();
+    const assets = createBrowserManifestAssets();
+    const theoreticalSplitChunk = {};
+    Object.defineProperty(theoreticalSplitChunk, 'files', {
+      get() {
+        throw new Error('theoretical split chunk files should not be read');
       },
-    };
-    let emit: ((compilation: unknown) => Promise<void>) | undefined;
-    const compiler = {
-      hooks: {
-        emit: {
-          tapPromise(_name: string, callback: typeof emit) {
-            emit = callback;
-          },
-        },
-      },
-    };
+    });
 
     try {
-      createModifyBrowserManifestPlugin(
-        routes,
+      registerModifyBrowserManifestAssets(
+        harness.api as never,
+        createRoutesWithPage(),
         {},
         appDir,
         '/',
@@ -205,28 +344,16 @@ describe('modify browser manifest plugin', () => {
         {
           manifestChunkNames: new Set(['entry.client', 'root', 'routes/page']),
         }
-      ).apply(compiler as never);
+      );
 
-      const theoreticalSplitChunk = {};
-      Object.defineProperty(theoreticalSplitChunk, 'files', {
-        get() {
-          throw new Error('theoretical split chunk files should not be read');
-        },
-      });
-
-      expect(emit).toBeDefined();
-      await emit({
-        namedChunks: new Map([
+      await harness.run({
+        assets,
+        compilation: createCompilation([
           ['entry.client', { files: new Set(['static/js/entry.client.js']) }],
           ['root', { files: new Set(['static/js/root.js']) }],
           ['routes/page', { files: new Set(['static/js/routes/page.js']) }],
           ['routes/page-client-loader', theoreticalSplitChunk],
         ]),
-        assets: {
-          'static/js/virtual/react-router/browser-manifest.js': createAsset(
-            'window.__reactRouterManifest="PLACEHOLDER";'
-          ),
-        },
       });
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/tests/performance.test.ts
+++ b/tests/performance.test.ts
@@ -239,4 +239,38 @@ describe('React Router performance profiler', () => {
       performance.now = originalNow;
     }
   });
+
+  it('returns a rejected promise for synchronous record failures when disabled', async () => {
+    const profiler = createReactRouterPerformanceProfiler({
+      enabled: false,
+      log: () => {},
+    });
+
+    await expect(
+      profiler.record('web', 'route:module', 'app/routes/a.tsx', () => {
+        throw new Error('sync failure');
+      })
+    ).rejects.toThrow('sync failure');
+  });
+
+  it('flushes timings recorded before an environment is known', async () => {
+    const logs: string[] = [];
+    const profiler = createReactRouterPerformanceProfiler({
+      enabled: true,
+      log: message => logs.push(message),
+    });
+
+    await profiler.record(
+      undefined,
+      'route:module',
+      'app/routes/a.tsx',
+      async () => 'route-module'
+    );
+    profiler.flush(undefined);
+
+    expect(logs).toHaveLength(1);
+    const report = parsePerformanceReport(logs[0]);
+    expect(report.environment).toBe('unknown');
+    expect(report.operations['route:module'].count).toBe(1);
+  });
 });

--- a/tests/plugin-utils.test.ts
+++ b/tests/plugin-utils.test.ts
@@ -251,6 +251,17 @@ describe('plugin-utils', () => {
       expect(result).not.toContain('const _ErrorBoundary');
     });
 
+    it('does not wrap erased default interface exports', () => {
+      const result = transformRouteCode(`
+        export default interface Route {
+          value: string;
+        }
+      `);
+
+      expect(result).not.toContain('withComponentProps');
+      expect(result).toContain('export default interface Route');
+    });
+
     it('avoids top-level generated helper name collisions', () => {
       const result = transformRouteCode(`
         const _withComponentProps = 'reserved';
@@ -284,6 +295,18 @@ describe('plugin-utils', () => {
       expect(result).toContain('withComponentProps as _withComponentProps');
       expect(result).toContain('export default _withComponentProps');
       expect(result).not.toContain('_withComponentProps2');
+    });
+
+    it('avoids top-level generated helper name collisions with enums', () => {
+      const result = transformRouteCode(`
+        enum _withComponentProps {
+          reserved = 'reserved'
+        }
+        export default function Route() { return null; }
+      `);
+
+      expect(result).toContain('withComponentProps as _withComponentProps2');
+      expect(result).toContain('export default _withComponentProps2(Route)');
     });
   });
 });

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -265,4 +265,36 @@ describe('prerender helpers', () => {
       expect.stringContaining('`dashboard` when pre-rendering'),
     ]);
   });
+
+  it('reports root loaders for unprerendered ssr:false descendants', () => {
+    const manifestRoutes = {
+      root: {
+        id: 'root',
+        file: 'root.tsx',
+        path: '',
+        hasLoader: true,
+      },
+      dashboard: {
+        id: 'dashboard',
+        parentId: 'root',
+        file: 'routes/dashboard.tsx',
+        path: 'dashboard',
+      },
+      about: {
+        id: 'about',
+        parentId: 'root',
+        file: 'routes/about.tsx',
+        path: 'about',
+      },
+    };
+
+    expect(
+      getSsrFalsePrerenderExportErrors({
+        routes: manifestRoutes,
+        manifestRoutes,
+        routeExports: {},
+        prerenderPaths: ['/about'],
+      })
+    ).toEqual([expect.stringContaining('`root` when pre-rendering')]);
+  });
 });

--- a/tests/prerender.test.ts
+++ b/tests/prerender.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from '@rstest/core';
 import {
+  createPrerenderRoutes,
   getPrerenderConcurrency,
   getStaticPrerenderPaths,
+  getSsrFalsePrerenderExportErrors,
+  normalizePrerenderMatchPath,
   resolvePrerenderPaths,
+  withBuildRequest,
 } from '../src/prerender';
 import type { RouteConfigEntry } from '@react-router/dev/routes';
 
@@ -94,5 +98,171 @@ describe('prerender helpers', () => {
     expect(getPrerenderConcurrency({ paths: ['/'] }, 24)).toBe(1);
     expect(getPrerenderConcurrency({ paths: ['/'] }, 3)).toBe(1);
     expect(getPrerenderConcurrency({ paths: ['/'] }, 2)).toBe(1);
+  });
+
+  it('creates React Router match routes from a route manifest', () => {
+    expect(
+      createPrerenderRoutes({
+        root: { id: 'root', file: 'root.tsx', path: '' },
+        layout: {
+          id: 'layout',
+          parentId: 'root',
+          file: 'routes/layout.tsx',
+          path: 'dashboard',
+        },
+        index: {
+          id: 'index',
+          parentId: 'layout',
+          file: 'routes/index.tsx',
+          index: true,
+        },
+      })
+    ).toEqual([
+      {
+        id: 'root',
+        path: '',
+        children: [
+          {
+            id: 'layout',
+            path: 'dashboard',
+            children: [{ id: 'index', path: undefined, index: true }],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('normalizes prerender paths for React Router matching', () => {
+    expect(normalizePrerenderMatchPath('/')).toBe('/');
+    expect(normalizePrerenderMatchPath('about')).toBe('/about/');
+    expect(normalizePrerenderMatchPath('/about')).toBe('/about/');
+  });
+
+  it('aborts build request signals after the handler settles', async () => {
+    let signal: AbortSignal | undefined;
+
+    const result = await withBuildRequest(
+      'http://localhost/about',
+      {
+        headers: {
+          'x-test': 'yes',
+        },
+      },
+      async request => {
+        signal = request.signal;
+        expect(request.headers.get('x-test')).toBe('yes');
+        expect(signal.aborted).toBe(false);
+        return 'handled';
+      }
+    );
+
+    expect(result).toBe('handled');
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it('returns no ssr:false prerender export errors for valid prerendered routes', () => {
+    const manifestRoutes = {
+      root: { id: 'root', file: 'root.tsx', path: '' },
+      dashboard: {
+        id: 'dashboard',
+        parentId: 'root',
+        file: 'routes/dashboard.tsx',
+        path: 'dashboard',
+        hasLoader: true,
+        hasClientLoader: true,
+      },
+    };
+
+    expect(
+      getSsrFalsePrerenderExportErrors({
+        routes: manifestRoutes,
+        manifestRoutes,
+        routeExports: {
+          dashboard: ['clientLoader'],
+        },
+        prerenderPaths: ['/dashboard'],
+      })
+    ).toEqual([]);
+  });
+
+  it('rejects ssr:false prerender paths that do not match routes', () => {
+    expect(() =>
+      getSsrFalsePrerenderExportErrors({
+        routes: {
+          root: { id: 'root', file: 'root.tsx', path: '' },
+        },
+        manifestRoutes: {
+          root: { id: 'root', file: 'root.tsx', path: '' },
+        },
+        routeExports: {},
+        prerenderPaths: ['/missing'],
+      })
+    ).toThrow('Unable to prerender path because it does not match any routes');
+  });
+
+  it('reports invalid ssr:false prerender action and headers exports', () => {
+    const manifestRoutes = {
+      root: { id: 'root', file: 'root.tsx', path: '' },
+      dashboard: {
+        id: 'dashboard',
+        parentId: 'root',
+        file: 'routes/dashboard.tsx',
+        path: 'dashboard',
+      },
+    };
+
+    expect(
+      getSsrFalsePrerenderExportErrors({
+        routes: manifestRoutes,
+        manifestRoutes,
+        routeExports: {
+          dashboard: ['action', 'headers'],
+        },
+        prerenderPaths: ['/dashboard'],
+      })
+    ).toEqual([
+      expect.stringContaining(
+        '`dashboard` when pre-rendering with `ssr:false`: `headers`, `action`'
+      ),
+    ]);
+  });
+
+  it('reports loader exports on routes outside the ssr:false prerender set', () => {
+    const manifestRoutes = {
+      root: { id: 'root', file: 'root.tsx', path: '' },
+      dashboard: {
+        id: 'dashboard',
+        parentId: 'root',
+        file: 'routes/dashboard.tsx',
+        path: 'dashboard',
+        hasLoader: true,
+      },
+      reports: {
+        id: 'reports',
+        parentId: 'dashboard',
+        file: 'routes/reports.tsx',
+        path: 'reports',
+      },
+      about: {
+        id: 'about',
+        parentId: 'root',
+        file: 'routes/about.tsx',
+        path: 'about',
+      },
+    };
+
+    expect(
+      getSsrFalsePrerenderExportErrors({
+        routes: manifestRoutes,
+        manifestRoutes,
+        routeExports: {
+          reports: ['loader'],
+        },
+        prerenderPaths: ['/about'],
+      })
+    ).toEqual([
+      expect.stringContaining('`reports` when pre-rendering'),
+      expect.stringContaining('`dashboard` when pre-rendering'),
+    ]);
   });
 });

--- a/tests/route-chunks.test.ts
+++ b/tests/route-chunks.test.ts
@@ -270,6 +270,19 @@ describe('route chunks', () => {
         'HydrateFallback',
       ]);
     });
+
+    it('does not split client exports away from top-level side effects', async () => {
+      const code = `
+        import './polyfill';
+        initialize();
+        export const clientAction = async () => {};
+        export default function Route() { return null; }
+      `;
+
+      const result = await detect(code);
+
+      expectNoRouteChunks(result, ['clientAction', 'default']);
+    });
   });
 
   describe('generate route chunk code', () => {
@@ -416,6 +429,14 @@ describe('route chunks', () => {
       expect(moduleId).toBe('/app/routes/r.tsx?route-chunk=clientAction');
       expect(isRouteChunkModuleId(moduleId)).toBe(true);
       expect(getRouteChunkNameFromModuleId(moduleId)).toBe('clientAction');
+      expect(
+        isRouteChunkModuleId('/app/routes/r.tsx?route-chunk=clientAction&foo=1')
+      ).toBe(true);
+      expect(
+        getRouteChunkNameFromModuleId(
+          '/app/routes/r.tsx?route-chunk=clientAction&foo=1'
+        )
+      ).toBe('clientAction');
       expect(getRouteChunkNameFromModuleId('/app/routes/r.tsx?route-chunk=main')).toBe(
         'main'
       );

--- a/tests/server-build-plan.test.ts
+++ b/tests/server-build-plan.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from '@rstest/core';
+import {
+  createReactRouterNodeEntries,
+  createReactRouterServerBuildPlan,
+} from '../src/server-build-plan';
+
+describe('React Router server build plan', () => {
+  it('creates a default-only plan when no server bundles are configured', () => {
+    expect(
+      createReactRouterServerBuildPlan({
+        routesByServerBundleId: {},
+        serverBuildFile: undefined,
+        defaultEntryName: 'static/js/app',
+      })
+    ).toEqual({
+      defaultEntryName: 'static/js/app',
+      entryNames: ['static/js/app'],
+      serverBundleEntries: [],
+    });
+  });
+
+  it('creates deterministic bundle entries from the configured server build file', () => {
+    expect(
+      createReactRouterServerBuildPlan({
+        routesByServerBundleId: {
+          admin: {
+            root: { id: 'root', file: 'root.tsx', path: '' },
+          },
+          empty: {},
+          shop: {
+            root: { id: 'root', file: 'root.tsx', path: '' },
+          },
+        },
+        serverBuildFile: 'server-entry.js',
+        defaultEntryName: 'static/js/app',
+      })
+    ).toEqual({
+      defaultEntryName: 'static/js/app',
+      entryNames: [
+        'static/js/app',
+        'admin/server-entry',
+        'shop/server-entry',
+      ],
+      serverBundleEntries: [
+        { bundleId: 'admin', entryName: 'admin/server-entry' },
+        { bundleId: 'shop', entryName: 'shop/server-entry' },
+      ],
+    });
+  });
+
+  it('rejects bundle entries that collide with reserved node entries', () => {
+    expect(() =>
+      createReactRouterServerBuildPlan({
+        routesByServerBundleId: {
+          'static/js': {
+            root: { id: 'root', file: 'root.tsx', path: '' },
+          },
+        },
+        serverBuildFile: 'app.js',
+        defaultEntryName: 'static/js/react-router-server-build',
+      })
+    ).toThrow('conflicts with a reserved node entry');
+  });
+});
+
+describe('React Router node entries', () => {
+  const serverBundleEntries = [
+    { bundleId: 'admin', entryName: 'admin/index' },
+  ];
+
+  it('uses the generated server build as the app entry without a custom server', () => {
+    expect(
+      createReactRouterNodeEntries({
+        hasServerApp: false,
+        isBuild: false,
+        serverAppPath: '/project/server/index.ts',
+        entryServerPath: '/project/app/entry.server.tsx',
+        defaultEntryName: 'static/js/app',
+        serverBundleEntries,
+      })
+    ).toEqual({
+      'static/js/app': 'virtual/react-router/server-build',
+      'static/js/entry.server': '/project/app/entry.server.tsx',
+      'admin/index': 'virtual/react-router/server-build-admin',
+    });
+  });
+
+  it('adds a private generated server build only for custom-server development', () => {
+    expect(
+      createReactRouterNodeEntries({
+        hasServerApp: true,
+        isBuild: false,
+        serverAppPath: '/project/server/index.ts',
+        entryServerPath: '/project/app/entry.server.tsx',
+        defaultEntryName: 'static/js/react-router-server-build',
+        serverBundleEntries,
+      })
+    ).toEqual({
+      'static/js/app': '/project/server/index.ts',
+      'static/js/react-router-server-build':
+        'virtual/react-router/server-build',
+      'static/js/entry.server': '/project/app/entry.server.tsx',
+      'admin/index': 'virtual/react-router/server-build-admin',
+    });
+  });
+
+  it('omits the private generated server build during custom-server production builds', () => {
+    expect(
+      createReactRouterNodeEntries({
+        hasServerApp: true,
+        isBuild: true,
+        serverAppPath: '/project/server/index.ts',
+        entryServerPath: '/project/app/entry.server.tsx',
+        defaultEntryName: 'static/js/react-router-server-build',
+        serverBundleEntries,
+      })
+    ).toEqual({
+      'static/js/app': '/project/server/index.ts',
+      'static/js/entry.server': '/project/app/entry.server.tsx',
+      'admin/index': 'virtual/react-router/server-build-admin',
+    });
+  });
+});

--- a/tests/server-utils.test.ts
+++ b/tests/server-utils.test.ts
@@ -49,6 +49,17 @@ describe('resolveReactRouterServerBuild', () => {
     ).resolves.toMatchObject({ assets: { version: 'commonjs' } });
   });
 
+  it('prefers module.exports when a CommonJS namespace default is not a server build', async () => {
+    const build = createBuild('module-exports');
+
+    await expect(
+      resolveReactRouterServerBuild({
+        default: { routes: {} },
+        'module.exports': build,
+      })
+    ).resolves.toMatchObject({ assets: { version: 'module-exports' } });
+  });
+
   it('resolves recognized asynchronous build exports', async () => {
     const build = createBuild('async');
 


### PR DESCRIPTION
## Summary

This stacks the follow-up work on top of the Slack coherent-generation patch now isolated on `perf/bundling-performance`.

It includes:
- the `lazyCompilation: { entries: true }` hydration fix and browser regression
- the route watcher post-close rescan guard
- extraction of lazy-compilation guarding into `src/lazy-compilation.ts`
- extraction of server build/node entry planning into `src/server-build-plan.ts`
- extraction of prerender route helpers and SSR-false prerender export validation into `src/prerender.ts`

## Validation

Already run against this head before splitting the stack:
- `corepack pnpm run test:core`
- `corepack pnpm exec tsc --noEmit`
- `corepack pnpm run format:check`
- `corepack pnpm run build`
- `corepack pnpm --filter './examples/default-template' run test:e2e:lazy --reporter=list`
- GitHub checks were green on the same head before restacking.

The base branch was then rewritten to the Slack patch-only commit and this branch was preserved at the prior verified head.
