### PR TITLE
[codex] Align manifest and export resolution APIs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ import {
   type ReactRouterManifestStats,
   type RouteManifestModuleExports,
 } from './manifest.js';
-import { createModifyBrowserManifestPlugin } from './modify-browser-manifest.js';
+import { registerModifyBrowserManifestAssets } from './modify-browser-manifest.js';
 import { createRequestHandler, matchRoutes } from 'react-router';
 import {
   getRouteChunkEntryName,
@@ -553,6 +553,55 @@ export const pluginReactRouter = (
     let latestServerManifest: ReactRouterManifest | null = null;
     const latestServerManifestsByBundleId: Record<string, ReactRouterManifest> =
       {};
+
+    const stageLatestManifests = (
+      manifest: ReactRouterManifest,
+      sri: Record<string, string> | undefined,
+      moduleExportsByRouteId: RouteManifestModuleExports,
+      compilation: Rspack.Compilation
+    ) => {
+      performanceProfiler.recordSync(
+        'web',
+        'manifest:stage',
+        'virtual/react-router/browser-manifest',
+        () => {
+          latestBrowserManifest = manifest;
+          latestBrowserManifestModuleExports = moduleExportsByRouteId;
+          const baseServerManifest = {
+            ...manifest,
+            sri,
+          };
+          latestServerManifest = baseServerManifest;
+          const manifestsByEntryName: Record<string, ReactRouterManifest> = {
+            [devServerBuildEntryName]: baseServerManifest,
+          };
+
+          for (const { bundleId, entryName } of serverBundleEntries) {
+            const bundleRoutes = routesByServerBundleId[bundleId];
+            if (!bundleRoutes) {
+              continue;
+            }
+
+            const routeIds = new Set(Object.keys(bundleRoutes));
+            const filteredRoutes = Object.fromEntries(
+              Object.entries(manifest.routes).filter(([routeId]) =>
+                routeIds.has(routeId)
+              )
+            );
+            const bundleManifest = {
+              ...baseServerManifest,
+              routes: filteredRoutes,
+            };
+            latestServerManifestsByBundleId[bundleId] = bundleManifest;
+            manifestsByEntryName[entryName] = bundleManifest;
+          }
+
+          if (!isBuild) {
+            devRuntime.captureWeb(compilation, manifestsByEntryName);
+          }
+        }
+      );
+    };
 
     const routeByFilePath = new Map(
       Object.values(routes).map(route => [
@@ -1331,81 +1380,30 @@ export const pluginReactRouter = (
                 }
               }
 
-              if (name === 'web' && rspackConfig.plugins) {
-                rspackConfig.plugins.push(
-                  createModifyBrowserManifestPlugin(
-                    routes,
-                    pluginOptions,
-                    appDirectory,
-                    assetPrefix,
-                    routeChunkOptions,
-                    {
-                      future,
-                      manifestChunkNames,
-                      onManifest: (
-                        manifest,
-                        sri,
-                        moduleExportsByRouteId,
-                        manifestContext
-                      ) => {
-                        performanceProfiler.recordSync(
-                          'web',
-                          'manifest:stage',
-                          'virtual/react-router/browser-manifest',
-                          () => {
-                            latestBrowserManifest = manifest;
-                            latestBrowserManifestModuleExports =
-                              moduleExportsByRouteId;
-                            const baseServerManifest = {
-                              ...manifest,
-                              sri,
-                            };
-                            latestServerManifest = baseServerManifest;
-                            const manifestsByEntryName = {
-                              [devServerBuildEntryName]: baseServerManifest,
-                            } as Record<string, ReactRouterManifest>;
-                            for (const {
-                              bundleId,
-                              entryName,
-                            } of serverBundleEntries) {
-                              const bundleRoutes =
-                                routesByServerBundleId[bundleId];
-                              if (!bundleRoutes) {
-                                continue;
-                              }
-                              const routeIds = new Set(
-                                Object.keys(bundleRoutes)
-                              );
-                              const filteredRoutes = Object.fromEntries(
-                                Object.entries(manifest.routes).filter(
-                                  ([routeId]) => routeIds.has(routeId)
-                                )
-                              );
-                              const bundleManifest = {
-                                ...baseServerManifest,
-                                routes: filteredRoutes,
-                              };
-                              latestServerManifestsByBundleId[bundleId] =
-                                bundleManifest;
-                              manifestsByEntryName[entryName] = bundleManifest;
-                            }
-                            if (!isBuild) {
-                              devRuntime.captureWeb(
-                                manifestContext.compilation,
-                                manifestsByEntryName
-                              );
-                            }
-                          }
-                        );
-                      },
-                    }
-                  )
-                );
-              }
               return rspackConfig;
             },
           },
         });
+      }
+    );
+
+    registerModifyBrowserManifestAssets(
+      api,
+      routes,
+      pluginOptions,
+      appDirectory,
+      () => assetPrefix,
+      routeChunkOptions,
+      {
+        future,
+        manifestChunkNames,
+        onManifest: (manifest, sri, moduleExportsByRouteId, context) =>
+          stageLatestManifests(
+            manifest,
+            sri,
+            moduleExportsByRouteId,
+            context.compilation
+          ),
       }
     );
 
@@ -1568,12 +1566,28 @@ export const pluginReactRouter = (
           args.environment?.name,
           'module:client-only-stub',
           args.resource,
-          async () =>
-            routeTransformExecutor.run({
+          async () => {
+            const resolveExportAllModule =
+              typeof args.resolve === 'function'
+                ? (specifier: string, importerPath: string) =>
+                    new Promise<string | null>(resolveModule => {
+                      args.resolve(
+                        dirname(importerPath),
+                        specifier,
+                        (error, path) => {
+                          resolveModule(error || !path ? null : path);
+                        }
+                      );
+                    })
+                : undefined;
+
+            return routeTransformExecutor.run({
               kind: 'clientOnlyStub',
               code: args.code,
               resourcePath: args.resourcePath,
-            })
+              resolveExportAllModule,
+            });
+          }
         )
     );
 

--- a/src/modify-browser-manifest.ts
+++ b/src/modify-browser-manifest.ts
@@ -1,7 +1,6 @@
 import { createHash } from 'node:crypto';
 import type { Route, PluginOptions } from './types.js';
-import { rspack } from '@rsbuild/core';
-import type { Rspack } from '@rsbuild/core';
+import type { RsbuildPluginAPI, Rspack } from '@rsbuild/core';
 import {
   createReactRouterManifestStats,
   generateReactRouterManifestForDev,
@@ -12,145 +11,171 @@ import {
 import { combineURLs } from './plugin-utils.js';
 import jsesc from 'jsesc';
 
-/**
- * Creates a Webpack/Rspack plugin that modifies the browser manifest
- * @param routes - The routes configuration
- * @param pluginOptions - The plugin options
- * @param appDirectory - The application directory
- * @returns A webpack/rspack plugin
- */
-export function createModifyBrowserManifestPlugin(
+type ModifyBrowserManifestOptions = {
+  future?: { unstable_subResourceIntegrity?: boolean };
+  manifestChunkNames?: ReadonlySet<string>;
+  onManifest?: (
+    manifest: Awaited<ReturnType<typeof getReactRouterManifestForDev>>,
+    sri: Record<string, string> | undefined,
+    moduleExportsByRouteId: Awaited<
+      ReturnType<typeof generateReactRouterManifestForDev>
+    >['moduleExportsByRouteId'],
+    context: {
+      compilation: Rspack.Compilation;
+      manifestStats: ReturnType<typeof createReactRouterManifestStats>;
+    }
+  ) => void;
+};
+
+type ProcessAssetsApi = Pick<RsbuildPluginAPI, 'processAssets'>;
+type AssetPrefixInput = string | (() => string);
+type ReactRouterManifest = Awaited<
+  ReturnType<typeof getReactRouterManifestForDev>
+>;
+type RouteManifestModuleExports = Awaited<
+  ReturnType<typeof generateReactRouterManifestForDev>
+>['moduleExportsByRouteId'];
+type GeneratedManifest = {
+  manifest: ReactRouterManifest;
+  moduleExportsByRouteId: RouteManifestModuleExports;
+  manifestStats: ReturnType<typeof createReactRouterManifestStats>;
+  assetPrefix: string;
+};
+
+const BROWSER_MANIFEST_ASSET =
+  'static/js/virtual/react-router/browser-manifest.js';
+
+const createSubresourceIntegrity = (
+  compilation: Rspack.Compilation,
+  assetPrefix: string
+) => {
+  const sri: Record<string, string> = {};
+  for (const asset of compilation.getAssets()) {
+    if (!asset.name.endsWith('.js')) {
+      continue;
+    }
+    const source = asset.source.source().toString();
+    const hash = createHash('sha384').update(source).digest('base64');
+    sri[combineURLs(assetPrefix, asset.name)] = `sha384-${hash}`;
+  }
+  return sri;
+};
+
+export function registerModifyBrowserManifestAssets(
+  api: ProcessAssetsApi,
   routes: Record<string, Route>,
   pluginOptions: PluginOptions,
   appDirectory: string,
-  assetPrefix = '/',
+  assetPrefix: AssetPrefixInput = '/',
   routeChunkOptions?: Parameters<typeof getReactRouterManifestForDev>[5],
-  options?: {
-    future?: { unstable_subResourceIntegrity?: boolean };
-    manifestChunkNames?: ReadonlySet<string>;
-    onManifest?: (
-      manifest: Awaited<ReturnType<typeof getReactRouterManifestForDev>>,
-      sri: Record<string, string> | undefined,
-      moduleExportsByRouteId: Awaited<
-        ReturnType<typeof generateReactRouterManifestForDev>
-      >['moduleExportsByRouteId'],
-      context: {
-        compilation: Rspack.Compilation;
-        manifestStats: ReturnType<typeof createReactRouterManifestStats>;
-      }
-    ) => void;
-  }
-) {
+  options?: ModifyBrowserManifestOptions
+): void {
+  const getAssetPrefix =
+    typeof assetPrefix === 'function' ? assetPrefix : () => assetPrefix;
   const manifestChunkNames =
     options?.manifestChunkNames ??
     getReactRouterManifestChunkNames(
       routes,
       routeChunkOptions?.splitRouteModules
     );
+  const finalizeSri =
+    routeChunkOptions?.isBuild &&
+    options?.future?.unstable_subResourceIntegrity;
+  const generatedManifests = finalizeSri
+    ? new WeakMap<Rspack.Compilation, GeneratedManifest>()
+    : undefined;
 
-  return {
-    apply(compiler: Rspack.Compiler): void {
-      compiler.hooks.emit.tapPromise(
-        'ModifyBrowserManifest',
-        async (compilation: Rspack.Compilation) => {
-          const stats = createReactRouterManifestStats(
-            compilation,
-            manifestChunkNames
-          );
-          const { manifest, moduleExportsByRouteId } =
-            await generateReactRouterManifestForDev(
-              routes,
-              pluginOptions,
-              stats,
-              appDirectory,
-              assetPrefix,
-              routeChunkOptions
-            );
-
-          const virtualManifestPath =
-            'static/js/virtual/react-router/browser-manifest.js';
-          if (compilation.assets[virtualManifestPath]) {
-            const originalSource = compilation.assets[virtualManifestPath]
-              .source()
-              .toString();
-            const newSource = originalSource.replace(
-              /["'`]PLACEHOLDER["'`]/,
-              jsesc(manifest, { es6: true })
-            );
-            compilation.assets[virtualManifestPath] = {
-              source: () => newSource,
-              size: () => newSource.length,
-              map: () => ({
-                version: 3,
-                sources: [virtualManifestPath],
-                names: [],
-                mappings: '',
-                file: virtualManifestPath,
-                sourcesContent: [newSource],
-              }),
-              sourceAndMap: () => ({
-                source: newSource,
-                map: {
-                  version: 3,
-                  sources: [virtualManifestPath],
-                  names: [],
-                  mappings: '',
-                  file: virtualManifestPath,
-                  sourcesContent: [newSource],
-                },
-              }),
-              updateHash: hash => hash.update(newSource),
-              buffer: () => Buffer.from(newSource),
-            };
-          }
-
-          if (routeChunkOptions?.isBuild) {
-            const entryAssets = stats?.assetsByChunkName?.['entry.client'];
-            const entryJsAssets =
-              entryAssets?.filter(asset => asset.endsWith('.js')) || [];
-            const manifestPath = getReactRouterManifestPath({
-              version: manifest.version,
-              isBuild: true,
-              entryModulePath: entryJsAssets[0],
-            });
-            const manifestSource = `window.__reactRouterManifest=${jsesc(
-              manifest,
-              { es6: true }
-            )};`;
-            compilation.assets[manifestPath] = new rspack.sources.RawSource(
-              manifestSource
-            );
-          }
-
-          let sri: Record<string, string> | undefined;
-          if (
-            routeChunkOptions?.isBuild &&
-            options?.future?.unstable_subResourceIntegrity
-          ) {
-            const assets =
-              typeof compilation.getAssets === 'function'
-                ? compilation.getAssets()
-                : Object.entries(compilation.assets).map(([name, asset]) => ({
-                    name,
-                    source: asset,
-                  }));
-            sri = {};
-            for (const asset of assets) {
-              if (!asset.name.endsWith('.js')) {
-                continue;
-              }
-              const source = asset.source.source().toString();
-              const hash = createHash('sha384').update(source).digest('base64');
-              sri[combineURLs(assetPrefix, asset.name)] = `sha384-${hash}`;
-            }
-          }
-
-          options?.onManifest?.(manifest, sri, moduleExportsByRouteId, {
-            compilation,
-            manifestStats: stats,
-          });
-        }
+  api.processAssets(
+    { stage: 'additions', environments: ['web'] },
+    async ({ assets, sources, compilation }) => {
+      const currentAssetPrefix = getAssetPrefix();
+      const stats = createReactRouterManifestStats(
+        compilation,
+        manifestChunkNames
       );
-    },
-  };
+      const { manifest, moduleExportsByRouteId } =
+        await generateReactRouterManifestForDev(
+          routes,
+          pluginOptions,
+          stats,
+          appDirectory,
+          currentAssetPrefix,
+          routeChunkOptions
+        );
+
+      const browserManifestAsset = assets[BROWSER_MANIFEST_ASSET];
+      if (browserManifestAsset) {
+        const originalSource = browserManifestAsset.source().toString();
+        const newSource = originalSource.replace(
+          /["'`]PLACEHOLDER["'`]/,
+          jsesc(manifest, { es6: true })
+        );
+        compilation.updateAsset(
+          BROWSER_MANIFEST_ASSET,
+          new sources.RawSource(newSource)
+        );
+      }
+
+      if (routeChunkOptions?.isBuild) {
+        const entryAssets = stats?.assetsByChunkName?.['entry.client'];
+        const entryJsAssets =
+          entryAssets?.filter(asset => asset.endsWith('.js')) || [];
+        const manifestPath = getReactRouterManifestPath({
+          version: manifest.version,
+          isBuild: true,
+          entryModulePath: entryJsAssets[0],
+        });
+        const manifestSource = `window.__reactRouterManifest=${jsesc(manifest, {
+          es6: true,
+        })};`;
+        const source = new sources.RawSource(manifestSource);
+        if (compilation.getAsset(manifestPath)) {
+          compilation.updateAsset(manifestPath, source);
+        } else {
+          compilation.emitAsset(manifestPath, source);
+        }
+      }
+
+      if (generatedManifests) {
+        generatedManifests.set(compilation, {
+          manifest,
+          moduleExportsByRouteId,
+          manifestStats: stats,
+          assetPrefix: currentAssetPrefix,
+        });
+        return;
+      }
+
+      options?.onManifest?.(manifest, undefined, moduleExportsByRouteId, {
+        compilation,
+        manifestStats: stats,
+      });
+    }
+  );
+
+  if (generatedManifests) {
+    api.processAssets(
+      { stage: 'report', environments: ['web'] },
+      ({ compilation }) => {
+        const generatedManifest = generatedManifests.get(compilation);
+        if (!generatedManifest) {
+          return;
+        }
+
+        generatedManifests.delete(compilation);
+        options?.onManifest?.(
+          generatedManifest.manifest,
+          createSubresourceIntegrity(
+            compilation,
+            generatedManifest.assetPrefix
+          ),
+          generatedManifest.moduleExportsByRouteId,
+          {
+            compilation,
+            manifestStats: generatedManifest.manifestStats,
+          }
+        );
+      }
+    );
+  }
 }

--- a/src/parallel-route-transforms.ts
+++ b/src/parallel-route-transforms.ts
@@ -131,6 +131,9 @@ class ParallelRouteTransformExecutor implements RouteTransformExecutor {
     if (this.#closed) {
       return executeRouteTransformTask(task, this.options);
     }
+    if (task.kind === 'clientOnlyStub' && task.resolveExportAllModule) {
+      return executeRouteTransformTask(task, this.options);
+    }
 
     try {
       return await this.#runInWorker(task);

--- a/src/route-export-resolution.ts
+++ b/src/route-export-resolution.ts
@@ -204,9 +204,15 @@ const resolveExportAllModule = (
   }
 };
 
+export type RouteExportResolver = (
+  specifier: string,
+  importerPath: string
+) => Promise<string | null> | string | null;
+
 export const collectClientOnlyStubExportNames = async (
   code: string,
-  resourcePath: string
+  resourcePath: string,
+  resolveModule: RouteExportResolver = resolveExportAllModule
 ): Promise<Set<string>> => {
   const { exportNames: directExportNames, exportAllModules } =
     await getExportNamesAndExportAll(code);
@@ -229,7 +235,7 @@ export const collectClientOnlyStubExportNames = async (
       }
     }
     for (const nestedSpecifier of moduleExportAll) {
-      const nestedPath = resolveExportAllModule(nestedSpecifier, modulePath);
+      const nestedPath = await resolveModule(nestedSpecifier, modulePath);
       if (!nestedPath) {
         unresolvedExportAll.add(nestedSpecifier);
         continue;
@@ -239,7 +245,7 @@ export const collectClientOnlyStubExportNames = async (
   };
 
   for (const specifier of exportAllModules) {
-    const resolvedPath = resolveExportAllModule(specifier, resourcePath);
+    const resolvedPath = await resolveModule(specifier, resourcePath);
     if (!resolvedPath) {
       unresolvedExportAll.add(specifier);
       continue;

--- a/src/route-transform-tasks.ts
+++ b/src/route-transform-tasks.ts
@@ -10,7 +10,10 @@ import {
   removeUnusedImports,
   transformRoute,
 } from './plugin-utils.js';
-import { collectClientOnlyStubExportNames } from './route-export-resolution.js';
+import {
+  collectClientOnlyStubExportNames,
+  type RouteExportResolver,
+} from './route-export-resolution.js';
 import {
   createRouteChunkArtifact,
   createRouteClientEntryArtifact,
@@ -53,6 +56,7 @@ export type SplitRouteExportsTransformTask = BaseRouteTransformTask & {
 
 export type ClientOnlyStubTransformTask = BaseRouteTransformTask & {
   kind: 'clientOnlyStub';
+  resolveExportAllModule?: RouteExportResolver;
 };
 
 export type RouteModuleTransformTask = BaseRouteTransformTask & {
@@ -130,7 +134,8 @@ const createClientOnlyStub = async (
 ): Promise<RouteTransformResult> => {
   const exportNames = await collectClientOnlyStubExportNames(
     task.code,
-    task.resourcePath
+    task.resourcePath,
+    task.resolveExportAllModule
   );
 
   return {

--- a/tests/client-modules.test.ts
+++ b/tests/client-modules.test.ts
@@ -97,4 +97,53 @@ describe('client-only module transforms', () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  it('uses the Rsbuild transform resolver for export-all modules', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'rr-client-modules-resolve-'));
+    const appDirectory = join(root, 'app');
+    const resourcePath = join(appDirectory, 'example.client.ts');
+    const resolvedPath = join(root, 'generated', 'client-exports.ts');
+    await mkdir(appDirectory, { recursive: true });
+    await mkdir(join(root, 'generated'), { recursive: true });
+    await writeFile(resourcePath, "export * from '@client/exports';");
+    await writeFile(
+      resolvedPath,
+      'export const fromResolver = true; export const alsoResolver = true;'
+    );
+
+    try {
+      const rsbuild = await createStubRsbuild({
+        rsbuildConfig: {},
+      });
+
+      const plugin = pluginReactRouter();
+      await plugin.setup(rsbuild as any);
+
+      const transformCall = (rsbuild.transform as any).mock.calls.find(
+        (call: any[]) => call[0].test?.toString().includes('\\.client')
+      );
+      expect(transformCall).toBeDefined();
+
+      const handler = transformCall?.[1];
+      const result = await handler({
+        environment: { name: 'node' },
+        code: await readFile(resourcePath, 'utf8'),
+        resourcePath,
+        resolve(
+          context: string,
+          specifier: string,
+          callback: (error: Error | null, resolved?: string) => void
+        ) {
+          expect(context).toBe(appDirectory);
+          expect(specifier).toBe('@client/exports');
+          callback(null, resolvedPath);
+        },
+      });
+
+      expect(result.code).toContain('export const fromResolver = undefined;');
+      expect(result.code).toContain('export const alsoResolver = undefined;');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/modify-browser-manifest.test.ts
+++ b/tests/modify-browser-manifest.test.ts
@@ -1,8 +1,14 @@
+import { createHash } from 'node:crypto';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from '@rstest/core';
-import { createModifyBrowserManifestPlugin } from '../src/modify-browser-manifest';
+import { registerModifyBrowserManifestAssets } from '../src/modify-browser-manifest';
+
+const BROWSER_MANIFEST_PATH =
+  'static/js/virtual/react-router/browser-manifest.js';
+const PLACEHOLDER_MANIFEST_SOURCE =
+  'window.__reactRouterManifest="PLACEHOLDER";';
 
 const createTempApp = () => {
   const root = mkdtempSync(join(tmpdir(), 'rr-modify-manifest-'));
@@ -24,38 +30,156 @@ const createAsset = (source: string) => ({
   size: () => source.length,
 });
 
-describe('modify browser manifest plugin', () => {
-  it('reports the exact compilation that produced the manifest', async () => {
-    const { root, appDir } = createTempApp();
-    const routes = {
-      root: { id: 'root', file: 'root.tsx', path: '' },
-    };
-    let emit: ((compilation: unknown) => Promise<void>) | undefined;
-    let reportedCompilation: unknown;
-    const compiler = {
-      hooks: {
-        emit: {
-          tapPromise(_name: string, callback: typeof emit) {
-            emit = callback;
-          },
-        },
+class RawSource {
+  constructor(private readonly value: string) {}
+  source() {
+    return this.value;
+  }
+  size() {
+    return this.value.length;
+  }
+}
+
+type Asset = ReturnType<typeof createAsset>;
+type ProcessAssetsContext = {
+  assets: Record<string, Asset>;
+  compilation: unknown;
+};
+type ProcessAssetsDescriptor = {
+  stage: string;
+  environments?: string[];
+};
+type ProcessAssetsHandler = (
+  context: ProcessAssetsContext & { sources: { RawSource: typeof RawSource } }
+) => Promise<void> | void;
+type ProcessAssetsRegistration = {
+  descriptor: ProcessAssetsDescriptor;
+  handler: ProcessAssetsHandler;
+};
+
+const createProcessAssetsHarness = () => {
+  const registrations: ProcessAssetsRegistration[] = [];
+
+  return {
+    api: {
+      processAssets(
+        processAssetsDescriptor: ProcessAssetsDescriptor,
+        processAssetsHandler: ProcessAssetsHandler
+      ) {
+        registrations.push({
+          descriptor: processAssetsDescriptor,
+          handler: processAssetsHandler,
+        });
       },
-    };
-    const compilation = {
-      namedChunks: new Map([
+    },
+    getDescriptor: () => registrations[0]?.descriptor,
+    getDescriptors: () =>
+      registrations.map(registration => registration.descriptor),
+    run(context: ProcessAssetsContext) {
+      const registration = registrations[0];
+      expect(registration).toBeDefined();
+      return registration!.handler({ ...context, sources: { RawSource } });
+    },
+    runStage(stage: string, context: ProcessAssetsContext) {
+      const registration = registrations.find(
+        registration => registration.descriptor.stage === stage
+      );
+      expect(registration).toBeDefined();
+      return registration!.handler({ ...context, sources: { RawSource } });
+    },
+  };
+};
+
+const createCompilation = (
+  namedChunks: Array<[string, unknown]>,
+  assets: Record<string, Asset> = {}
+) => ({
+  namedChunks: new Map(namedChunks),
+  assets,
+  getAsset(name: string) {
+    const asset = assets[name];
+    return asset ? { name, source: asset } : undefined;
+  },
+  updateAsset(name: string, source: Asset) {
+    assets[name] = source;
+  },
+  emitAsset(name: string, source: Asset) {
+    assets[name] = source;
+  },
+  getAssets() {
+    return Object.entries(assets).map(([name, source]) => ({ name, source }));
+  },
+});
+
+const rootRoute = { id: 'root', file: 'root.tsx', path: '' };
+
+const createRoutesWithPage = () => ({
+  root: rootRoute,
+  'routes/page': {
+    id: 'routes/page',
+    parentId: 'root',
+    file: 'routes/page.tsx',
+    path: 'page',
+  },
+});
+
+const createBrowserManifestAssets = () => ({
+  [BROWSER_MANIFEST_PATH]: createAsset(PLACEHOLDER_MANIFEST_SOURCE),
+});
+
+const createSriHash = (source: string) =>
+  `sha384-${createHash('sha384').update(source).digest('base64')}`;
+
+describe('modify browser manifest plugin', () => {
+  it('registers browser manifest mutation with Rsbuild processAssets', async () => {
+    const { root, appDir } = createTempApp();
+    const harness = createProcessAssetsHarness();
+    const assets = createBrowserManifestAssets();
+    const compilation = createCompilation(
+      [
         ['entry.client', { files: new Set(['static/js/entry.client.js']) }],
         ['root', { files: new Set(['static/js/root.js']) }],
-      ]),
-      assets: {
-        'static/js/virtual/react-router/browser-manifest.js': createAsset(
-          'window.__reactRouterManifest="PLACEHOLDER";'
-        ),
-      },
-    };
+      ],
+      assets
+    );
 
     try {
-      createModifyBrowserManifestPlugin(
-        routes,
+      registerModifyBrowserManifestAssets(
+        harness.api as never,
+        { root: rootRoute },
+        {},
+        appDir
+      );
+
+      expect(harness.getDescriptor()).toEqual({
+        stage: 'additions',
+        environments: ['web'],
+      });
+      await harness.run({ assets, compilation });
+
+      expect(assets[BROWSER_MANIFEST_PATH].source()).toContain('routes');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('reports the exact compilation that produced the manifest', async () => {
+    const { root, appDir } = createTempApp();
+    const harness = createProcessAssetsHarness();
+    const assets = createBrowserManifestAssets();
+    const compilation = createCompilation(
+      [
+        ['entry.client', { files: new Set(['static/js/entry.client.js']) }],
+        ['root', { files: new Set(['static/js/root.js']) }],
+      ],
+      assets
+    );
+    let reportedCompilation: unknown;
+
+    try {
+      registerModifyBrowserManifestAssets(
+        harness.api as never,
+        { root: rootRoute },
         {},
         appDir,
         '/',
@@ -65,10 +189,9 @@ describe('modify browser manifest plugin', () => {
             reportedCompilation = context.compilation;
           },
         }
-      ).apply(compiler as never);
+      );
 
-      expect(emit).toBeDefined();
-      await emit(compilation);
+      await harness.run({ assets, compilation });
 
       expect(reportedCompilation).toBe(compilation);
     } finally {
@@ -76,39 +199,85 @@ describe('modify browser manifest plugin', () => {
     }
   });
 
-  it('rejects the promise hook when build route analysis fails', async () => {
+  it('hashes build SRI after later asset stages mutate JavaScript', async () => {
     const { root, appDir } = createTempApp();
-    writeFileSync(join(appDir, 'routes/page.tsx'), 'export const = broken;');
-    const routes = {
-      root: { id: 'root', file: 'root.tsx', path: '' },
-      'routes/page': {
-        id: 'routes/page',
-        parentId: 'root',
-        file: 'routes/page.tsx',
-        path: 'page',
-      },
+    const harness = createProcessAssetsHarness();
+    const originalEntrySource = 'console.log("before optimize");';
+    const optimizedEntrySource = 'console.log("after optimize");';
+    const assets = {
+      ...createBrowserManifestAssets(),
+      'static/js/entry.client.js': createAsset(originalEntrySource),
+      'static/js/root.js': createAsset('console.log("root");'),
     };
-    let emit: ((compilation: unknown) => Promise<void>) | undefined;
-    const compiler = {
-      hooks: {
-        emit: {
-          tapPromise(_name: string, callback: typeof emit) {
-            emit = callback;
-          },
-        },
-      },
-    };
+    const compilation = createCompilation(
+      [
+        ['entry.client', { files: new Set(['static/js/entry.client.js']) }],
+        ['root', { files: new Set(['static/js/root.js']) }],
+      ],
+      assets
+    );
+    let reportedSri: Record<string, string> | undefined;
 
     try {
-      createModifyBrowserManifestPlugin(routes, {}, appDir, '/', {
-        isBuild: true,
-      }).apply(compiler as never);
+      registerModifyBrowserManifestAssets(
+        harness.api as never,
+        { root: rootRoute },
+        {},
+        appDir,
+        '/',
+        { isBuild: true },
+        {
+          future: { unstable_subResourceIntegrity: true },
+          onManifest(_manifest, sri) {
+            reportedSri = sri;
+          },
+        }
+      );
 
-      expect(emit).toBeDefined();
+      expect(harness.getDescriptors()).toEqual([
+        { stage: 'additions', environments: ['web'] },
+        { stage: 'report', environments: ['web'] },
+      ]);
+
+      await harness.runStage('additions', { assets, compilation });
+      expect(reportedSri).toBeUndefined();
+
+      compilation.updateAsset(
+        'static/js/entry.client.js',
+        createAsset(optimizedEntrySource)
+      );
+      await harness.runStage('report', { assets, compilation });
+
+      expect(reportedSri?.['/static/js/entry.client.js']).toBe(
+        createSriHash(optimizedEntrySource)
+      );
+      expect(reportedSri?.['/static/js/entry.client.js']).not.toBe(
+        createSriHash(originalEntrySource)
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects the promise hook when build route analysis fails', async () => {
+    const { root, appDir } = createTempApp();
+    const harness = createProcessAssetsHarness();
+    writeFileSync(join(appDir, 'routes/page.tsx'), 'export const = broken;');
+
+    try {
+      registerModifyBrowserManifestAssets(
+        harness.api as never,
+        createRoutesWithPage(),
+        {},
+        appDir,
+        '/',
+        { isBuild: true }
+      );
+
       await expect(
-        emit({
-          namedChunks: new Map(),
+        harness.run({
           assets: {},
+          compilation: createCompilation([]),
         })
       ).rejects.toThrow();
     } finally {
@@ -118,51 +287,31 @@ describe('modify browser manifest plugin', () => {
 
   it('does not read ignored chunk files while creating manifest stats', async () => {
     const { root, appDir } = createTempApp();
-    const routes = {
-      root: { id: 'root', file: 'root.tsx', path: '' },
-      'routes/page': {
-        id: 'routes/page',
-        parentId: 'root',
-        file: 'routes/page.tsx',
-        path: 'page',
+    const harness = createProcessAssetsHarness();
+    const assets = createBrowserManifestAssets();
+    const ignoredChunk = {};
+    Object.defineProperty(ignoredChunk, 'files', {
+      get() {
+        throw new Error('ignored chunk files should not be read');
       },
-    };
-    let emit: ((compilation: unknown) => Promise<void>) | undefined;
-    const compiler = {
-      hooks: {
-        emit: {
-          tapPromise(_name: string, callback: typeof emit) {
-            emit = callback;
-          },
-        },
-      },
-    };
+    });
 
     try {
-      createModifyBrowserManifestPlugin(routes, {}, appDir).apply(
-        compiler as never
+      registerModifyBrowserManifestAssets(
+        harness.api as never,
+        createRoutesWithPage(),
+        {},
+        appDir
       );
 
-      const ignoredChunk = {};
-      Object.defineProperty(ignoredChunk, 'files', {
-        get() {
-          throw new Error('ignored chunk files should not be read');
-        },
-      });
-
-      expect(emit).toBeDefined();
-      await emit({
-        namedChunks: new Map([
+      await harness.run({
+        assets,
+        compilation: createCompilation([
           ['entry.client', { files: new Set(['static/js/entry.client.js']) }],
           ['root', { files: new Set(['static/js/root.js']) }],
           ['routes/page', { files: new Set(['static/js/routes/page.js']) }],
           ['vendor', ignoredChunk],
         ]),
-        assets: {
-          'static/js/virtual/react-router/browser-manifest.js': createAsset(
-            'window.__reactRouterManifest="PLACEHOLDER";'
-          ),
-        },
       });
     } finally {
       rmSync(root, { recursive: true, force: true });
@@ -171,29 +320,19 @@ describe('modify browser manifest plugin', () => {
 
   it('uses actual manifest chunk names instead of theoretical split route chunks', async () => {
     const { root, appDir } = createTempApp();
-    const routes = {
-      root: { id: 'root', file: 'root.tsx', path: '' },
-      'routes/page': {
-        id: 'routes/page',
-        parentId: 'root',
-        file: 'routes/page.tsx',
-        path: 'page',
+    const harness = createProcessAssetsHarness();
+    const assets = createBrowserManifestAssets();
+    const theoreticalSplitChunk = {};
+    Object.defineProperty(theoreticalSplitChunk, 'files', {
+      get() {
+        throw new Error('theoretical split chunk files should not be read');
       },
-    };
-    let emit: ((compilation: unknown) => Promise<void>) | undefined;
-    const compiler = {
-      hooks: {
-        emit: {
-          tapPromise(_name: string, callback: typeof emit) {
-            emit = callback;
-          },
-        },
-      },
-    };
+    });
 
     try {
-      createModifyBrowserManifestPlugin(
-        routes,
+      registerModifyBrowserManifestAssets(
+        harness.api as never,
+        createRoutesWithPage(),
         {},
         appDir,
         '/',
@@ -205,28 +344,16 @@ describe('modify browser manifest plugin', () => {
         {
           manifestChunkNames: new Set(['entry.client', 'root', 'routes/page']),
         }
-      ).apply(compiler as never);
+      );
 
-      const theoreticalSplitChunk = {};
-      Object.defineProperty(theoreticalSplitChunk, 'files', {
-        get() {
-          throw new Error('theoretical split chunk files should not be read');
-        },
-      });
-
-      expect(emit).toBeDefined();
-      await emit({
-        namedChunks: new Map([
+      await harness.run({
+        assets,
+        compilation: createCompilation([
           ['entry.client', { files: new Set(['static/js/entry.client.js']) }],
           ['root', { files: new Set(['static/js/root.js']) }],
           ['routes/page', { files: new Set(['static/js/routes/page.js']) }],
           ['routes/page-client-loader', theoreticalSplitChunk],
         ]),
-        assets: {
-          'static/js/virtual/react-router/browser-manifest.js': createAsset(
-            'window.__reactRouterManifest="PLACEHOLDER";'
-          ),
-        },
       });
     } finally {
       rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

This stacks on `codex/architecture-refactors` and moves two architecture hot spots closer to Rsbuild/Rspack extension points.

- replace the browser-manifest Rspack `emit` plugin with a Rsbuild `api.processAssets` registration that updates/emits assets through `updateAsset` and `emitAsset`
- keep manifest staging/dev-runtime capture behavior intact while observing the finalized asset prefix lazily
- thread Rsbuild transform resolution into client-only `export *` stub generation so aliases/package resolution can come from the bundler instead of only the fallback filesystem/package resolver
- keep resolver-backed client-only stub transforms on the main thread because resolver functions cannot be posted to workers

## Validation

- `pnpm test:core tests/modify-browser-manifest.test.ts`
- `pnpm test:core tests/client-modules.test.ts`
- `pnpm test:core tests/modify-browser-manifest.test.ts tests/client-modules.test.ts tests/parallel-route-transforms.test.ts tests/route-chunks.test.ts tests/index.test.ts`
- `pnpm test:core`
- `pnpm format:check`
- `pnpm build`
- `pnpm test:package-interop`
- `pnpm bench:smoke`

## Benchmark

`pnpm bench:smoke` completed successfully for `synthetic-48-ssr-esm`. Results were written to `.benchmark/results/smoke` and were not committed.

Smoke build timing reported by `/usr/bin/time`: wall clock `0:01.04`, max RSS `269532 KB`, exit status `0`.
