### PR TITLE
Refactor plugin architecture boundaries

### DIFF
--- a/src/build-output-transforms.ts
+++ b/src/build-output-transforms.ts
@@ -1,6 +1,6 @@
 import type { RsbuildPluginAPI } from '@rsbuild/core';
 import jsesc from 'jsesc';
-import { dirname, relative } from 'pathe';
+import { relative } from 'pathe';
 import { PLUGIN_NAME } from './constants.js';
 import {
   getReactRouterManifestForDev,
@@ -8,6 +8,7 @@ import {
 } from './manifest.js';
 import type { RouteTransformExecutor } from './parallel-route-transforms.js';
 import type { ReactRouterPerformanceProfiler } from './performance.js';
+import { createBundlerRouteExportResolver } from './route-export-resolution.js';
 import type { RouteChunkConfig } from './route-chunks.js';
 import type { PluginOptions, Route } from './types.js';
 import { isSourceMapEnabled } from './warnings/warn-on-client-source-maps.js';
@@ -228,18 +229,7 @@ export const registerBuildOutputTransforms = ({
             resourcePath: args.resourcePath,
             resolveExportAllModule:
               typeof args.resolve === 'function'
-                ? (specifier: string, importerPath: string) =>
-                    new Promise<string | null>(resolveResolvedPath => {
-                      args.resolve?.(
-                        dirname(importerPath),
-                        specifier,
-                        (error, resolved) => {
-                          resolveResolvedPath(
-                            error || !resolved ? null : resolved
-                          );
-                        }
-                      );
-                    })
+                ? createBundlerRouteExportResolver(args.resolve)
                 : undefined,
           });
         }

--- a/src/build-output-transforms.ts
+++ b/src/build-output-transforms.ts
@@ -1,0 +1,275 @@
+import type { RsbuildPluginAPI } from '@rsbuild/core';
+import jsesc from 'jsesc';
+import { dirname, relative } from 'pathe';
+import { PLUGIN_NAME } from './constants.js';
+import {
+  getReactRouterManifestForDev,
+  type ReactRouterManifestStats,
+} from './manifest.js';
+import type { RouteTransformExecutor } from './parallel-route-transforms.js';
+import type { ReactRouterPerformanceProfiler } from './performance.js';
+import type { RouteChunkConfig } from './route-chunks.js';
+import type { PluginOptions, Route } from './types.js';
+import { isSourceMapEnabled } from './warnings/warn-on-client-source-maps.js';
+
+type ReactRouterManifest = Awaited<
+  ReturnType<typeof getReactRouterManifestForDev>
+>;
+
+type RegisterBuildOutputTransformsOptions = {
+  api: RsbuildPluginAPI;
+  resolvedServerOutput: 'module' | 'commonjs';
+  performanceProfiler: ReactRouterPerformanceProfiler;
+  getLatestServerManifest: () => ReactRouterManifest | null;
+  getLatestServerManifestByBundleId: (
+    bundleId: string
+  ) => ReactRouterManifest | undefined;
+  routes: Record<string, Route>;
+  pluginOptions: PluginOptions;
+  getClientStats: () => ReactRouterManifestStats | undefined;
+  appDirectory: string;
+  getAssetPrefix: () => string;
+  routeChunkOptions: Parameters<typeof getReactRouterManifestForDev>[5];
+  routeTransformExecutor: RouteTransformExecutor;
+  routeByFilePath: Map<string, Route>;
+  routeChunkConfig: RouteChunkConfig;
+  isBuild: boolean;
+  splitRouteModules: boolean;
+  ssr: boolean;
+  isSpaMode: boolean;
+  rootRoutePath: string;
+};
+
+export const registerBuildOutputTransforms = ({
+  api,
+  resolvedServerOutput,
+  performanceProfiler,
+  getLatestServerManifest,
+  getLatestServerManifestByBundleId,
+  routes,
+  pluginOptions,
+  getClientStats,
+  appDirectory,
+  getAssetPrefix,
+  routeChunkOptions,
+  routeTransformExecutor,
+  routeByFilePath,
+  routeChunkConfig,
+  isBuild,
+  splitRouteModules,
+  ssr,
+  isSpaMode,
+  rootRoutePath,
+}: RegisterBuildOutputTransformsOptions): void => {
+  api.processAssets(
+    { stage: 'additional', targets: ['node'] },
+    ({ sources, compilation }) => {
+      const packageJsonPath = 'package.json';
+      const source = new sources.RawSource(
+        `{"type": "${resolvedServerOutput}"}`
+      );
+
+      if (compilation.getAsset(packageJsonPath)) {
+        compilation.updateAsset(packageJsonPath, source);
+      } else {
+        compilation.emitAsset(packageJsonPath, source);
+      }
+    }
+  );
+
+  api.transform(
+    {
+      test: /virtual\/react-router\/(browser|server)-manifest/,
+    },
+    async args =>
+      performanceProfiler.record(
+        args.environment?.name,
+        'manifest:transform',
+        args.resource,
+        async () => {
+          if (args.environment.name === 'web') {
+            return {
+              code: `window.__reactRouterManifest = "PLACEHOLDER";`,
+            };
+          }
+
+          const bundleMatch = args.resource.match(
+            /virtual\/react-router\/server-manifest(?:-([^?]+))?/
+          );
+          const bundleId = bundleMatch?.[1]?.replace(/\.js$/, '');
+          const latestServerManifest = getLatestServerManifest();
+          const manifest =
+            (latestServerManifest
+              ? ((bundleId && getLatestServerManifestByBundleId(bundleId)) ??
+                latestServerManifest)
+              : null) ??
+            (await getReactRouterManifestForDev(
+              routes,
+              pluginOptions,
+              getClientStats(),
+              appDirectory,
+              getAssetPrefix(),
+              routeChunkOptions
+            ));
+          return {
+            code: `export default ${jsesc(manifest, { es6: true })};`,
+          };
+        }
+      )
+  );
+
+  api.transform(
+    {
+      resourceQuery: /__react-router-build-client-route/,
+    },
+    async args =>
+      performanceProfiler.record(
+        args.environment?.name,
+        'route:client-entry',
+        args.resource,
+        async () =>
+          routeTransformExecutor.run({
+            kind: 'routeClientEntry',
+            code: args.code,
+            resourcePath: args.resourcePath,
+            environmentName: args.environment?.name,
+            isBuild,
+            routeChunkConfig,
+          })
+      )
+  );
+
+  api.transform(
+    {
+      resourceQuery: /route-chunk=/,
+      environments: ['web'],
+    },
+    async args =>
+      performanceProfiler.record(
+        args.environment?.name,
+        'route:chunk',
+        args.resource,
+        async () =>
+          routeTransformExecutor.run({
+            kind: 'routeChunk',
+            code: args.code,
+            resource: args.resource,
+            resourcePath: args.resourcePath,
+            isBuild,
+            routeChunkConfig,
+          })
+      )
+  );
+
+  if (isBuild && splitRouteModules) {
+    api.transform(
+      {
+        test: path => routeByFilePath.has(path),
+        resourceQuery: {
+          not: /__react-router-build-client-route|react-router-route|route-chunk=/,
+        },
+        environments: ['web'],
+      },
+      async args =>
+        performanceProfiler.record(
+          args.environment?.name,
+          'route:split-exports',
+          args.resource,
+          async () => {
+            const route = routeByFilePath.get(args.resourcePath);
+            if (!route) {
+              return { code: args.code, map: null };
+            }
+
+            return routeTransformExecutor.run({
+              kind: 'splitRouteExports',
+              code: args.code,
+              resourcePath: args.resourcePath,
+              routeChunkConfig,
+            });
+          }
+        )
+    );
+  }
+
+  api.transform(
+    {
+      test: /[\\/]\.server[\\/]|\.server(\.[cm]?[jt]sx?)?$/,
+      environments: ['web'],
+    },
+    async args =>
+      performanceProfiler.record(
+        args.environment?.name,
+        'module:server-only-guard',
+        args.resource,
+        async () => {
+          const relativePath = relative(process.cwd(), args.resourcePath);
+          throw new Error(
+            `[${PLUGIN_NAME}] Server-only module referenced by client: ${relativePath}`
+          );
+        }
+      )
+  );
+
+  api.transform(
+    {
+      test: /[\\/]\.client[\\/]|\.client(\.[cm]?[jt]sx?)?$/,
+      environments: ['node'],
+    },
+    async args =>
+      performanceProfiler.record(
+        args.environment?.name,
+        'module:client-only-stub',
+        args.resource,
+        async () => {
+          return routeTransformExecutor.run({
+            kind: 'clientOnlyStub',
+            code: args.code,
+            resourcePath: args.resourcePath,
+            resolveExportAllModule:
+              typeof args.resolve === 'function'
+                ? (specifier: string, importerPath: string) =>
+                    new Promise<string | null>(resolveResolvedPath => {
+                      args.resolve?.(
+                        dirname(importerPath),
+                        specifier,
+                        (error, resolved) => {
+                          resolveResolvedPath(
+                            error || !resolved ? null : resolved
+                          );
+                        }
+                      );
+                    })
+                : undefined,
+          });
+        }
+      )
+  );
+
+  api.transform(
+    {
+      resourceQuery: /\?react-router-route/,
+    },
+    async args =>
+      performanceProfiler.record(
+        args.environment?.name,
+        'route:module',
+        args.resource,
+        async () =>
+          routeTransformExecutor.run({
+            kind: 'routeModule',
+            code: args.code,
+            resource: args.resource,
+            resourcePath: args.resourcePath,
+            environmentName: args.environment.name,
+            sourceMaps: isSourceMapEnabled(
+              args.environment.config.output.sourceMap
+            ),
+            ssr,
+            isBuild,
+            isSpaMode,
+            rootRoutePath,
+          })
+      )
+  );
+};

--- a/src/export-utils.ts
+++ b/src/export-utils.ts
@@ -4,7 +4,9 @@ import { setBoundedCacheEntry } from './bounded-cache.js';
 import {
   getExportedName,
   getIdentifierNamesFromPattern,
+  getProgram,
   type AnyNode,
+  type ProgramNode,
 } from './route-ast.js';
 
 type ExportInfo = {
@@ -41,7 +43,7 @@ const cachePromiseOnReject = <T>(
     throw error;
   });
 
-const parseProgram = (code: string, resourcePath?: string) => {
+const parseProgram = (code: string, resourcePath?: string): ProgramNode => {
   const result = parse(code, {
     sourceType: 'module',
     lang: resourcePath ? langFromPath(resourcePath) : 'tsx',
@@ -52,7 +54,7 @@ const parseProgram = (code: string, resourcePath?: string) => {
   if (errors.length > 0) {
     throw new Error(errors.map(error => error.message).join('\n'));
   }
-  return result.program;
+  return getProgram(result);
 };
 
 const isTypeOnlyExport = (node: AnyNode): boolean =>
@@ -62,7 +64,7 @@ const isTypeOnlyExport = (node: AnyNode): boolean =>
   (node.type === 'ExportDefaultDeclaration' &&
     node.declaration?.type === 'TSInterfaceDeclaration');
 
-export const collectProgramExportNames = (program: AnyNode): string[] => {
+export const collectProgramExportNames = (program: ProgramNode): string[] => {
   const exportNames = new Set<string>();
   for (const statement of program.body ?? []) {
     if (isTypeOnlyExport(statement)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
-import { mkdir, writeFile } from 'node:fs/promises';
-import { pathToFileURL } from 'node:url';
 import fsExtra from 'fs-extra';
 import type { Config } from './react-router-config.js';
 import type { RouteConfigEntry } from '@react-router/dev/routes';
-import type { ResultPromise } from 'execa';
 import {
   rspack,
   type RsbuildEntryDescription,
@@ -12,8 +9,7 @@ import {
   type Rspack,
 } from '@rsbuild/core';
 import { createJiti } from 'jiti';
-import jsesc from 'jsesc';
-import { dirname, relative, resolve } from 'pathe';
+import { relative, resolve } from 'pathe';
 
 import {
   BUILD_CLIENT_ROUTE_QUERY_STRING,
@@ -31,24 +27,15 @@ import type { PluginOptions } from './types.js';
 import {
   generateServerBuild,
   resolveReactRouterServerBuild,
-  resolveServerBuildModule,
 } from './server-utils.js';
-import {
-  createPrerenderRoutes,
-  getPrerenderConcurrency,
-  getSsrFalsePrerenderExportErrors,
-  normalizePrerenderMatchPath,
-  resolvePrerenderPaths,
-  validatePrerenderConfig,
-  withBuildRequest,
-} from './prerender.js';
+import { resolvePrerenderPaths, validatePrerenderConfig } from './prerender.js';
+import { runReactRouterPrerenderBuild } from './prerender-build.js';
 import {
   resolveReactRouterConfig,
   type ResolvedReactRouterConfig,
 } from './react-router-config.js';
 import {
   getReactRouterManifestForDev,
-  generateReactRouterManifestForDev,
   configRoutesToRouteManifest,
   configRoutesToRouteManifestEntries,
   createReactRouterManifestStats,
@@ -56,7 +43,7 @@ import {
   type RouteManifestModuleExports,
 } from './manifest.js';
 import { registerModifyBrowserManifestAssets } from './modify-browser-manifest.js';
-import { createRequestHandler, matchRoutes } from 'react-router';
+import { registerBuildOutputTransforms } from './build-output-transforms.js';
 import {
   getRouteChunkEntryName,
   getRouteChunkModuleId,
@@ -85,10 +72,7 @@ import {
   createReactRouterNodeEntries,
   createReactRouterServerBuildPlan,
 } from './server-build-plan.js';
-import {
-  isSourceMapEnabled,
-  warnOnClientSourceMaps,
-} from './warnings/warn-on-client-source-maps.js';
+import { warnOnClientSourceMaps } from './warnings/warn-on-client-source-maps.js';
 import { validatePluginOrderFromConfig } from './validation/validate-plugin-order.js';
 import { getSsrExternals } from './ssr-externals.js';
 import {
@@ -97,11 +81,10 @@ import {
 } from './performance.js';
 import { mapVirtualModules } from './virtual-modules.js';
 import { createReactRouterDevRuntimeController } from './dev-runtime-controller.js';
+import { registerReactRouterTypegen } from './typegen.js';
 
 export { loadReactRouterServerBuild } from './dev-generation.js';
 export { resolveReactRouterServerBuild };
-
-const redirectStatusCodes = new Set([301, 302, 303, 307, 308]);
 
 type ModuleFederationPluginLike = {
   name?: string;
@@ -191,54 +174,7 @@ export const pluginReactRouter = (
       warnOnClientSourceMaps(normalized, msg => api.logger.warn(msg), 'web');
     });
 
-    let typegenProcess: ResultPromise | undefined;
-
-    // Run typegen on build/dev
-    api.onBeforeStartDevServer(async () => {
-      if (typegenProcess) {
-        return;
-      }
-      const { execa } = await import('execa');
-      // Run typegen in background (non-blocking) for watch mode
-      const process = execa(
-        'npx',
-        ['--yes', 'react-router', 'typegen', '--watch'],
-        {
-          stdio: 'inherit',
-          detached: false,
-          cleanup: true,
-        }
-      );
-      typegenProcess = process;
-      // Don't await - let it run in the background
-      process
-        .catch(() => {
-          // Silently ignore errors when the process is killed on server shutdown
-        })
-        .finally(() => {
-          if (typegenProcess === process) {
-            typegenProcess = undefined;
-          }
-        });
-    });
-
-    api.onCloseDevServer(async () => {
-      const process = typegenProcess;
-      typegenProcess = undefined;
-      if (!process) {
-        return;
-      }
-      process.kill('SIGTERM');
-      await process.catch(() => undefined);
-    });
-
-    api.onBeforeBuild(async () => {
-      const { execa } = await import('execa');
-      // Run typegen synchronously before build
-      await execa('npx', ['--yes', 'react-router', 'typegen'], {
-        stdio: 'inherit',
-      });
-    });
+    registerReactRouterTypegen(api);
 
     const jiti = createJiti(process.cwd(), {
       moduleCache: false,
@@ -694,431 +630,31 @@ export const pluginReactRouter = (
         warn: message => api.logger.warn(message),
       }
     );
-    const prerenderData = async (
-      handler: (request: Request) => Promise<Response>,
-      prerenderPath: string,
-      onlyRoutes: string[] | null,
-      clientBuildDir: string,
-      requestInit?: RequestInit
-    ): Promise<string> => {
-      let dataRequestPath: string;
-      if (future?.unstable_trailingSlashAwareDataRequests) {
-        if (prerenderPath.endsWith('/')) {
-          dataRequestPath = `${prerenderPath}_.data`;
-        } else {
-          dataRequestPath = `${prerenderPath}.data`;
-        }
-      } else {
-        dataRequestPath =
-          prerenderPath === '/'
-            ? '/_root.data'
-            : `${prerenderPath.replace(/\/$/, '')}.data`;
-      }
-
-      const normalizedPath = `${basename}${dataRequestPath}`.replace(
-        /\/\/+/g,
-        '/'
-      );
-      const url = new URL(`http://localhost${normalizedPath}`);
-      if (onlyRoutes?.length) {
-        url.searchParams.set('_routes', onlyRoutes.join(','));
-      }
-      return withBuildRequest(url, requestInit, async request => {
-        const response = await handler(request);
-        const data = await response.text();
-
-        if (response.status !== 200 && response.status !== 202) {
-          throw new Error(
-            `Prerender (data): Received a ${response.status} status code from ` +
-              `\`entry.server.tsx\` while prerendering the \`${prerenderPath}\` path.\n` +
-              `${normalizedPath}`
-          );
-        }
-
-        const outputPath = resolve(
-          clientBuildDir,
-          ...normalizedPath.split('/')
-        );
-        await mkdir(dirname(outputPath), { recursive: true });
-        await writeFile(outputPath, data);
-        api.logger.info(
-          `Prerender (data): ${prerenderPath} -> ${relative(
-            process.cwd(),
-            outputPath
-          )}`
-        );
-        return data;
-      });
-    };
-
-    const prerenderRoute = async (
-      handler: (request: Request) => Promise<Response>,
-      prerenderPath: string,
-      clientBuildDir: string,
-      requestInit?: RequestInit
-    ): Promise<void> => {
-      const normalizedPath = `${basename}${prerenderPath}/`.replace(
-        /\/\/+/g,
-        '/'
-      );
-      await withBuildRequest(
-        `http://localhost${normalizedPath}`,
-        requestInit,
-        async request => {
-          const response = await handler(request);
-          let html = await response.text();
-
-          if (redirectStatusCodes.has(response.status)) {
-            const location = response.headers.get('Location');
-            const delay = response.status === 302 ? 2 : 0;
-            html = `<!doctype html>
-<head>
-<title>Redirecting to: ${location}</title>
-<meta http-equiv="refresh" content="${delay};url=${location}">
-<meta name="robots" content="noindex">
-</head>
-<body>
-\t<a href="${location}">
-    Redirecting from <code>${normalizedPath}</code> to <code>${location}</code>
-  </a>
-</body>
-</html>`;
-          } else if (response.status !== 200) {
-            throw new Error(
-              `Prerender (html): Received a ${response.status} status code from ` +
-                `\`entry.server.tsx\` while prerendering the \`${normalizedPath}\` path.\n` +
-                html
-            );
-          }
-
-          const outputPath = resolve(
-            clientBuildDir,
-            ...normalizedPath.split('/'),
-            'index.html'
-          );
-          await mkdir(dirname(outputPath), { recursive: true });
-          await writeFile(outputPath, html);
-          api.logger.info(
-            `Prerender (html): ${prerenderPath} -> ${relative(
-              process.cwd(),
-              outputPath
-            )}`
-          );
-        }
-      );
-    };
-
-    const prerenderResourceRoute = async (
-      handler: (request: Request) => Promise<Response>,
-      prerenderPath: string,
-      clientBuildDir: string,
-      requestInit?: RequestInit
-    ): Promise<void> => {
-      const normalizedPath = `${basename}${prerenderPath}/`
-        .replace(/\/\/+/g, '/')
-        .replace(/\/$/g, '');
-      await withBuildRequest(
-        `http://localhost${normalizedPath}`,
-        requestInit,
-        async request => {
-          const response = await handler(request);
-          const content = Buffer.from(await response.arrayBuffer());
-
-          if (response.status !== 200) {
-            throw new Error(
-              `Prerender (resource): Received a ${response.status} status code from ` +
-                `\`entry.server.tsx\` while prerendering the \`${normalizedPath}\` path.\n` +
-                content.toString('utf8')
-            );
-          }
-
-          const outputPath = resolve(
-            clientBuildDir,
-            ...normalizedPath.split('/')
-          );
-          await mkdir(dirname(outputPath), { recursive: true });
-          await writeFile(outputPath, content);
-          api.logger.info(
-            `Prerender (resource): ${prerenderPath} -> ${relative(
-              process.cwd(),
-              outputPath
-            )}`
-          );
-        }
-      );
-    };
-
-    const handleSpaMode = async (
-      handler: (request: Request) => Promise<Response>,
-      build: any,
-      clientBuildDir: string
-    ): Promise<void> => {
-      await withBuildRequest(
-        `http://localhost${basename}`,
-        {
-          headers: {
-            'X-React-Router-SPA-Mode': 'yes',
-          },
-        },
-        async request => {
-          const response = await handler(request);
-          const html = await response.text();
-          const isPrerenderSpaFallback = build.prerender?.includes('/');
-          const filename = isPrerenderSpaFallback
-            ? '__spa-fallback.html'
-            : 'index.html';
-
-          if (response.status !== 200) {
-            if (isPrerenderSpaFallback) {
-              throw new Error(
-                `Prerender: Received a ${response.status} status code from ` +
-                  `\`entry.server.tsx\` while prerendering your \`${filename}\` file.\n` +
-                  html
-              );
-            }
-            throw new Error(
-              `SPA Mode: Received a ${response.status} status code from ` +
-                `\`entry.server.tsx\` while prerendering your \`${filename}\` file.\n` +
-                html
-            );
-          }
-
-          if (
-            !html.includes('window.__reactRouterContext =') ||
-            !html.includes('window.__reactRouterRouteModules =')
-          ) {
-            throw new Error(
-              'SPA Mode: Did you forget to include `<Scripts/>` in your root route? ' +
-                'Your pre-rendered HTML cannot hydrate without `<Scripts />`.'
-            );
-          }
-
-          const outputPath = resolve(clientBuildDir, filename);
-          await writeFile(outputPath, html);
-          const prettyPath = relative(process.cwd(), outputPath);
-          if (build.prerender?.length) {
-            api.logger.info(`Prerender (html): SPA Fallback -> ${prettyPath}`);
-          } else {
-            api.logger.info(`SPA Mode: Generated ${prettyPath}`);
-          }
-        }
-      );
-    };
-
-    const assertValidSsrFalsePrerenderExports = (
-      manifestRoutes: Awaited<
-        ReturnType<typeof getReactRouterManifestForDev>
-      >['routes'],
-      routeExports: RouteManifestModuleExports,
-      prerenderList: string[]
-    ) => {
-      const errors = getSsrFalsePrerenderExportErrors({
-        routes,
-        manifestRoutes,
-        routeExports,
-        prerenderPaths: prerenderList,
-      });
-      if (errors.length > 0) {
-        api.logger.error(errors.join('\n'));
-        throw new Error(
-          'Invalid route exports found when prerendering with `ssr:false`'
-        );
-      }
-    };
 
     api.onAfterBuild(async ({ environments }) => {
-      const webEnv = environments.web;
-      if (!webEnv) {
-        return;
-      }
-
-      const serverBuildDir = resolve(buildDirectory, 'server');
-      const defaultServerBuildFile = 'static/js/app.js';
-      const configuredServerBuildFile = serverBuildFile || 'index.js';
-      const configuredServerBuildPath = resolve(
-        serverBuildDir,
-        configuredServerBuildFile
-      );
-      const defaultServerBuildPath = resolve(
-        serverBuildDir,
-        defaultServerBuildFile
-      );
-      if (
-        configuredServerBuildFile !== defaultServerBuildFile &&
-        existsSync(defaultServerBuildPath) &&
-        !existsSync(configuredServerBuildPath)
-      ) {
-        await mkdir(dirname(configuredServerBuildPath), { recursive: true });
-        await fsExtra.copy(defaultServerBuildPath, configuredServerBuildPath);
-      }
-      const serverBuildPath = existsSync(configuredServerBuildPath)
-        ? configuredServerBuildPath
-        : defaultServerBuildPath;
-      const clientBuildDir = resolve(buildDirectory, 'client');
-
-      if (!existsSync(serverBuildPath)) {
-        console.warn(
-          `[${PLUGIN_NAME}] Server build not found at ${serverBuildPath}. ` +
-            'Skipping prerendering.'
-        );
-        return;
-      }
-
-      await mkdir(clientBuildDir, { recursive: true });
-
-      if (!ssr || isPrerenderEnabled) {
-        process.env.IS_RR_BUILD_REQUEST = 'yes';
-        const buildModule = await import(
-          pathToFileURL(serverBuildPath).toString()
-        );
-        const build = await resolveServerBuildModule(
-          buildModule,
-          `Server build ${JSON.stringify(serverBuildPath)}`
-        );
-        const requestHandler = createRequestHandler(build, 'production');
-
-        if (isPrerenderEnabled) {
-          if (!ssr) {
-            const generated = latestBrowserManifest
-              ? {
-                  manifest: latestBrowserManifest,
-                  moduleExportsByRouteId: latestBrowserManifestModuleExports,
-                }
-              : await generateReactRouterManifestForDev(
-                  routes,
-                  pluginOptions,
-                  clientStats,
-                  appDirectory,
-                  assetPrefix,
-                  routeChunkOptions
-                );
-            assertValidSsrFalsePrerenderExports(
-              generated.manifest.routes,
-              generated.moduleExportsByRouteId,
-              prerenderPaths
-            );
-          }
-
-          const routeTree = createPrerenderRoutes(routes);
-          for (const path of prerenderPaths) {
-            const matches = matchRoutes(
-              routeTree,
-              normalizePrerenderMatchPath(path)
-            );
-            if (!matches) {
-              throw new Error(
-                `Unable to prerender path because it does not match any routes: ${path}`
-              );
-            }
-          }
-
-          if (prerenderPaths.length > 0) {
-            api.logger.info(
-              `Prerender (html): ${prerenderPaths.length} path(s)...`
-            );
-          }
-
-          const buildRoutes = createPrerenderRoutes(build.routes);
-          const concurrency = getPrerenderConcurrency(prerenderConfig);
-          const pending = new Set<Promise<void>>();
-          const enqueue = async (path: string) => {
-            const matches = matchRoutes(
-              buildRoutes,
-              normalizePrerenderMatchPath(path)
-            );
-            if (!matches) return;
-
-            const leafRoute = matches[matches.length - 1]?.route as any;
-            const manifestRoute = leafRoute
-              ? build.routes?.[leafRoute.id]?.module
-              : null;
-            const isResourceRoute =
-              manifestRoute &&
-              !manifestRoute.default &&
-              !manifestRoute.ErrorBoundary;
-
-            if (isResourceRoute) {
-              if (manifestRoute.loader) {
-                await prerenderData(
-                  requestHandler,
-                  path,
-                  [leafRoute.id],
-                  clientBuildDir
-                );
-                await prerenderResourceRoute(
-                  requestHandler,
-                  path,
-                  clientBuildDir
-                );
-              } else {
-                api.logger.warn(
-                  `⚠️ Skipping prerendering for resource route without a loader: ${leafRoute?.id}`
-                );
-              }
-            } else {
-              const hasLoaders = matches.some(match => {
-                const routeId = match.route.id;
-                if (!routeId) {
-                  return false;
-                }
-                return build.assets?.routes?.[routeId]?.hasLoader;
-              });
-              let data: string | undefined;
-              if (hasLoaders) {
-                data = await prerenderData(
-                  requestHandler,
-                  path,
-                  null,
-                  clientBuildDir
-                );
-              }
-              await prerenderRoute(
-                requestHandler,
-                path,
-                clientBuildDir,
-                data
-                  ? {
-                      headers: {
-                        'X-React-Router-Prerender-Data': encodeURI(data),
-                      },
-                    }
-                  : undefined
-              );
-            }
-          };
-
-          for (const path of prerenderPaths) {
-            const task = enqueue(path);
-            pending.add(task);
-            task.finally(() => pending.delete(task));
-            if (pending.size >= concurrency) {
-              await Promise.race(pending);
-            }
-          }
-          await Promise.all(pending);
-        }
-
-        if (!ssr) {
-          await handleSpaMode(requestHandler, build, clientBuildDir);
-        }
-      }
-
-      // Remove server output for SPA mode and when not using SSR
-      // This makes the build deployable as static assets
-      if (!ssr) {
-        await fsExtra.remove(serverBuildDir);
-        api.logger.info(
-          `[${PLUGIN_NAME}] Removed server build (static deployment)`
-        );
-      }
-
-      if (buildEnd) {
-        await buildEnd({
-          buildManifest,
-          reactRouterConfig: resolvedConfigWithRoutes,
-          viteConfig: api.getNormalizedConfig(),
-        });
-      }
+      await runReactRouterPrerenderBuild({
+        api,
+        hasWebEnvironment: Boolean(environments.web),
+        buildDirectory,
+        serverBuildFile,
+        ssr,
+        isPrerenderEnabled,
+        prerenderConfig,
+        prerenderPaths,
+        basename,
+        future,
+        routes,
+        latestBrowserManifest,
+        latestBrowserManifestModuleExports,
+        clientStats,
+        pluginOptions,
+        appDirectory,
+        assetPrefix,
+        routeChunkOptions,
+        buildManifest,
+        resolvedConfigWithRoutes,
+        buildEnd,
+      });
     });
 
     const allowedActionOriginsForBuild =
@@ -1407,215 +943,27 @@ export const pluginReactRouter = (
       }
     );
 
-    api.processAssets(
-      { stage: 'additional', targets: ['node'] },
-      ({ sources, compilation }) => {
-        const packageJsonPath = 'package.json';
-        const source = new sources.RawSource(
-          `{"type": "${resolvedServerOutput}"}`
-        );
-
-        if (compilation.getAsset(packageJsonPath)) {
-          compilation.updateAsset(packageJsonPath, source);
-        } else {
-          compilation.emitAsset(packageJsonPath, source);
-        }
-      }
-    );
-
-    api.transform(
-      {
-        test: /virtual\/react-router\/(browser|server)-manifest/,
-      },
-      async args =>
-        performanceProfiler.record(
-          args.environment?.name,
-          'manifest:transform',
-          args.resource,
-          async () => {
-            if (args.environment.name === 'web') {
-              return {
-                code: `window.__reactRouterManifest = "PLACEHOLDER";`,
-              };
-            }
-
-            const bundleMatch = args.resource.match(
-              /virtual\/react-router\/server-manifest(?:-([^?]+))?/
-            );
-            const bundleId = bundleMatch?.[1]?.replace(/\.js$/, '');
-            const manifest =
-              (latestServerManifest
-                ? ((bundleId && latestServerManifestsByBundleId[bundleId]) ??
-                  latestServerManifest)
-                : null) ??
-              (await getReactRouterManifestForDev(
-                routes,
-                pluginOptions,
-                clientStats,
-                appDirectory,
-                assetPrefix,
-                routeChunkOptions
-              ));
-            return {
-              code: `export default ${jsesc(manifest, { es6: true })};`,
-            };
-          }
-        )
-    );
-
-    api.transform(
-      {
-        resourceQuery: /__react-router-build-client-route/,
-      },
-      async args =>
-        performanceProfiler.record(
-          args.environment?.name,
-          'route:client-entry',
-          args.resource,
-          async () =>
-            routeTransformExecutor.run({
-              kind: 'routeClientEntry',
-              code: args.code,
-              resourcePath: args.resourcePath,
-              environmentName: args.environment?.name,
-              isBuild,
-              routeChunkConfig,
-            })
-        )
-    );
-
-    api.transform(
-      {
-        resourceQuery: /route-chunk=/,
-        environments: ['web'],
-      },
-      async args =>
-        performanceProfiler.record(
-          args.environment?.name,
-          'route:chunk',
-          args.resource,
-          async () =>
-            routeTransformExecutor.run({
-              kind: 'routeChunk',
-              code: args.code,
-              resource: args.resource,
-              resourcePath: args.resourcePath,
-              isBuild,
-              routeChunkConfig,
-            })
-        )
-    );
-
-    if (isBuild && splitRouteModules) {
-      api.transform(
-        {
-          test: path => routeByFilePath.has(path),
-          resourceQuery: {
-            not: /__react-router-build-client-route|react-router-route|route-chunk=/,
-          },
-          environments: ['web'],
-        },
-        async args =>
-          performanceProfiler.record(
-            args.environment?.name,
-            'route:split-exports',
-            args.resource,
-            async () => {
-              const route = routeByFilePath.get(args.resourcePath);
-              if (!route) {
-                return { code: args.code, map: null };
-              }
-
-              return routeTransformExecutor.run({
-                kind: 'splitRouteExports',
-                code: args.code,
-                resourcePath: args.resourcePath,
-                routeChunkConfig,
-              });
-            }
-          )
-      );
-    }
-
-    api.transform(
-      {
-        test: /[\\/]\.server[\\/]|\.server(\.[cm]?[jt]sx?)?$/,
-        environments: ['web'],
-      },
-      async args =>
-        performanceProfiler.record(
-          args.environment?.name,
-          'module:server-only-guard',
-          args.resource,
-          async () => {
-            const relativePath = relative(process.cwd(), args.resourcePath);
-            throw new Error(
-              `[${PLUGIN_NAME}] Server-only module referenced by client: ${relativePath}`
-            );
-          }
-        )
-    );
-
-    api.transform(
-      {
-        test: /[\\/]\.client[\\/]|\.client(\.[cm]?[jt]sx?)?$/,
-        environments: ['node'],
-      },
-      async args =>
-        performanceProfiler.record(
-          args.environment?.name,
-          'module:client-only-stub',
-          args.resource,
-          async () => {
-            const resolveExportAllModule =
-              typeof args.resolve === 'function'
-                ? (specifier: string, importerPath: string) =>
-                    new Promise<string | null>(resolveModule => {
-                      args.resolve(
-                        dirname(importerPath),
-                        specifier,
-                        (error, path) => {
-                          resolveModule(error || !path ? null : path);
-                        }
-                      );
-                    })
-                : undefined;
-
-            return routeTransformExecutor.run({
-              kind: 'clientOnlyStub',
-              code: args.code,
-              resourcePath: args.resourcePath,
-              resolveExportAllModule,
-            });
-          }
-        )
-    );
-
-    api.transform(
-      {
-        resourceQuery: /\?react-router-route/,
-      },
-      async args =>
-        performanceProfiler.record(
-          args.environment?.name,
-          'route:module',
-          args.resource,
-          async () =>
-            routeTransformExecutor.run({
-              kind: 'routeModule',
-              code: args.code,
-              resource: args.resource,
-              resourcePath: args.resourcePath,
-              environmentName: args.environment.name,
-              sourceMaps: isSourceMapEnabled(
-                args.environment.config.output.sourceMap
-              ),
-              ssr,
-              isBuild,
-              isSpaMode,
-              rootRoutePath,
-            })
-        )
-    );
+    registerBuildOutputTransforms({
+      api,
+      resolvedServerOutput,
+      performanceProfiler,
+      getLatestServerManifest: () => latestServerManifest,
+      getLatestServerManifestByBundleId: bundleId =>
+        latestServerManifestsByBundleId[bundleId],
+      routes,
+      pluginOptions,
+      getClientStats: () => clientStats,
+      appDirectory,
+      getAssetPrefix: () => assetPrefix,
+      routeChunkOptions,
+      routeTransformExecutor,
+      routeByFilePath,
+      routeChunkConfig,
+      isBuild,
+      splitRouteModules: Boolean(splitRouteModules),
+      ssr,
+      isSpaMode,
+      rootRoutePath,
+    });
   },
 });

--- a/src/prerender-build.ts
+++ b/src/prerender-build.ts
@@ -1,0 +1,623 @@
+import { existsSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+import fsExtra from 'fs-extra';
+import type { RsbuildPluginAPI } from '@rsbuild/core';
+import {
+  createRequestHandler,
+  matchRoutes,
+  type ServerBuild,
+} from 'react-router';
+import { dirname, relative, resolve } from 'pathe';
+import { PLUGIN_NAME } from './constants.js';
+import { getBuildManifest } from './build-manifest.js';
+import {
+  generateReactRouterManifestForDev,
+  getReactRouterManifestForDev,
+  type ReactRouterManifestStats,
+  type RouteManifestModuleExports,
+} from './manifest.js';
+import {
+  createPrerenderRoutes,
+  getPrerenderConcurrency,
+  getSsrFalsePrerenderExportErrors,
+  normalizePrerenderMatchPath,
+  withBuildRequest,
+} from './prerender.js';
+import type {
+  Config,
+  ResolvedReactRouterConfig,
+} from './react-router-config.js';
+import { resolveServerBuildModule } from './server-utils.js';
+import type { PluginOptions, Route } from './types.js';
+
+type ReactRouterManifest = Awaited<
+  ReturnType<typeof getReactRouterManifestForDev>
+>;
+
+type BuildRouteModule = {
+  loader?: unknown;
+  default?: unknown;
+  ErrorBoundary?: unknown;
+};
+
+type PrerenderServerBuild = ServerBuild & {
+  routes: Record<string, { id?: string; module?: BuildRouteModule }>;
+  assets?: {
+    routes?: Record<string, { hasLoader?: boolean }>;
+  };
+  prerender?: string[];
+};
+
+type PrerenderBuildApi = Pick<
+  RsbuildPluginAPI,
+  'logger' | 'getNormalizedConfig'
+>;
+
+type RunReactRouterPrerenderBuildOptions = {
+  api: PrerenderBuildApi;
+  hasWebEnvironment: boolean;
+  buildDirectory: string;
+  serverBuildFile?: string;
+  ssr: boolean;
+  isPrerenderEnabled: boolean;
+  prerenderConfig: Config['prerender'];
+  prerenderPaths: string[];
+  basename: string;
+  future: ResolvedReactRouterConfig['future'];
+  routes: Record<string, Route>;
+  latestBrowserManifest: ReactRouterManifest | null;
+  latestBrowserManifestModuleExports: RouteManifestModuleExports;
+  clientStats: ReactRouterManifestStats | undefined;
+  pluginOptions: PluginOptions;
+  appDirectory: string;
+  assetPrefix: string;
+  routeChunkOptions: Parameters<typeof getReactRouterManifestForDev>[5];
+  buildManifest: Awaited<ReturnType<typeof getBuildManifest>>;
+  resolvedConfigWithRoutes: ResolvedReactRouterConfig;
+  buildEnd: Config['buildEnd'];
+};
+
+const redirectStatusCodes = new Set([301, 302, 303, 307, 308]);
+
+const getServerBuildPath = async ({
+  buildDirectory,
+  serverBuildFile,
+}: {
+  buildDirectory: string;
+  serverBuildFile?: string;
+}): Promise<{ serverBuildDir: string; serverBuildPath: string }> => {
+  const serverBuildDir = resolve(buildDirectory, 'server');
+  const defaultServerBuildFile = 'static/js/app.js';
+  const configuredServerBuildFile = serverBuildFile || 'index.js';
+  const configuredServerBuildPath = resolve(
+    serverBuildDir,
+    configuredServerBuildFile
+  );
+  const defaultServerBuildPath = resolve(
+    serverBuildDir,
+    defaultServerBuildFile
+  );
+
+  if (
+    configuredServerBuildFile !== defaultServerBuildFile &&
+    existsSync(defaultServerBuildPath) &&
+    !existsSync(configuredServerBuildPath)
+  ) {
+    await mkdir(dirname(configuredServerBuildPath), { recursive: true });
+    await fsExtra.copy(defaultServerBuildPath, configuredServerBuildPath);
+  }
+
+  return {
+    serverBuildDir,
+    serverBuildPath: existsSync(configuredServerBuildPath)
+      ? configuredServerBuildPath
+      : defaultServerBuildPath,
+  };
+};
+
+const createDataRequestPath = (
+  prerenderPath: string,
+  trailingSlashAwareDataRequests: boolean
+): string => {
+  if (trailingSlashAwareDataRequests) {
+    return prerenderPath.endsWith('/')
+      ? `${prerenderPath}_.data`
+      : `${prerenderPath}.data`;
+  }
+
+  return prerenderPath === '/'
+    ? '/_root.data'
+    : `${prerenderPath.replace(/\/$/, '')}.data`;
+};
+
+const prerenderData = async ({
+  handler,
+  prerenderPath,
+  onlyRoutes,
+  clientBuildDir,
+  basename,
+  trailingSlashAwareDataRequests,
+  api,
+  requestInit,
+}: {
+  handler: (request: Request) => Promise<Response>;
+  prerenderPath: string;
+  onlyRoutes: string[] | null;
+  clientBuildDir: string;
+  basename: string;
+  trailingSlashAwareDataRequests: boolean;
+  api: PrerenderBuildApi;
+  requestInit?: RequestInit;
+}): Promise<string> => {
+  const dataRequestPath = createDataRequestPath(
+    prerenderPath,
+    trailingSlashAwareDataRequests
+  );
+  const normalizedPath = `${basename}${dataRequestPath}`.replace(/\/\/+/g, '/');
+  const url = new URL(`http://localhost${normalizedPath}`);
+  if (onlyRoutes?.length) {
+    url.searchParams.set('_routes', onlyRoutes.join(','));
+  }
+
+  return withBuildRequest(url, requestInit, async request => {
+    const response = await handler(request);
+    const data = await response.text();
+
+    if (response.status !== 200 && response.status !== 202) {
+      throw new Error(
+        `Prerender (data): Received a ${response.status} status code from ` +
+          `\`entry.server.tsx\` while prerendering the \`${prerenderPath}\` path.\n` +
+          `${normalizedPath}`
+      );
+    }
+
+    const outputPath = resolve(clientBuildDir, ...normalizedPath.split('/'));
+    await mkdir(dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, data);
+    api.logger.info(
+      `Prerender (data): ${prerenderPath} -> ${relative(
+        process.cwd(),
+        outputPath
+      )}`
+    );
+    return data;
+  });
+};
+
+const prerenderRoute = async ({
+  handler,
+  prerenderPath,
+  clientBuildDir,
+  basename,
+  api,
+  requestInit,
+}: {
+  handler: (request: Request) => Promise<Response>;
+  prerenderPath: string;
+  clientBuildDir: string;
+  basename: string;
+  api: PrerenderBuildApi;
+  requestInit?: RequestInit;
+}): Promise<void> => {
+  const normalizedPath = `${basename}${prerenderPath}/`.replace(/\/\/+/g, '/');
+  await withBuildRequest(
+    `http://localhost${normalizedPath}`,
+    requestInit,
+    async request => {
+      const response = await handler(request);
+      let html = await response.text();
+
+      if (redirectStatusCodes.has(response.status)) {
+        const location = response.headers.get('Location');
+        const delay = response.status === 302 ? 2 : 0;
+        html = `<!doctype html>
+<head>
+<title>Redirecting to: ${location}</title>
+<meta http-equiv="refresh" content="${delay};url=${location}">
+<meta name="robots" content="noindex">
+</head>
+<body>
+\t<a href="${location}">
+    Redirecting from <code>${normalizedPath}</code> to <code>${location}</code>
+  </a>
+</body>
+</html>`;
+      } else if (response.status !== 200) {
+        throw new Error(
+          `Prerender (html): Received a ${response.status} status code from ` +
+            `\`entry.server.tsx\` while prerendering the \`${normalizedPath}\` path.\n` +
+            html
+        );
+      }
+
+      const outputPath = resolve(
+        clientBuildDir,
+        ...normalizedPath.split('/'),
+        'index.html'
+      );
+      await mkdir(dirname(outputPath), { recursive: true });
+      await writeFile(outputPath, html);
+      api.logger.info(
+        `Prerender (html): ${prerenderPath} -> ${relative(
+          process.cwd(),
+          outputPath
+        )}`
+      );
+    }
+  );
+};
+
+const prerenderResourceRoute = async ({
+  handler,
+  prerenderPath,
+  clientBuildDir,
+  basename,
+  api,
+  requestInit,
+}: {
+  handler: (request: Request) => Promise<Response>;
+  prerenderPath: string;
+  clientBuildDir: string;
+  basename: string;
+  api: PrerenderBuildApi;
+  requestInit?: RequestInit;
+}): Promise<void> => {
+  const normalizedPath = `${basename}${prerenderPath}/`
+    .replace(/\/\/+/g, '/')
+    .replace(/\/$/g, '');
+  await withBuildRequest(
+    `http://localhost${normalizedPath}`,
+    requestInit,
+    async request => {
+      const response = await handler(request);
+      const content = Buffer.from(await response.arrayBuffer());
+
+      if (response.status !== 200) {
+        throw new Error(
+          `Prerender (resource): Received a ${response.status} status code from ` +
+            `\`entry.server.tsx\` while prerendering the \`${normalizedPath}\` path.\n` +
+            content.toString('utf8')
+        );
+      }
+
+      const outputPath = resolve(clientBuildDir, ...normalizedPath.split('/'));
+      await mkdir(dirname(outputPath), { recursive: true });
+      await writeFile(outputPath, content);
+      api.logger.info(
+        `Prerender (resource): ${prerenderPath} -> ${relative(
+          process.cwd(),
+          outputPath
+        )}`
+      );
+    }
+  );
+};
+
+const handleSpaMode = async ({
+  handler,
+  build,
+  clientBuildDir,
+  basename,
+  api,
+}: {
+  handler: (request: Request) => Promise<Response>;
+  build: PrerenderServerBuild;
+  clientBuildDir: string;
+  basename: string;
+  api: PrerenderBuildApi;
+}): Promise<void> => {
+  await withBuildRequest(
+    `http://localhost${basename}`,
+    {
+      headers: {
+        'X-React-Router-SPA-Mode': 'yes',
+      },
+    },
+    async request => {
+      const response = await handler(request);
+      const html = await response.text();
+      const isPrerenderSpaFallback = build.prerender?.includes('/');
+      const filename = isPrerenderSpaFallback
+        ? '__spa-fallback.html'
+        : 'index.html';
+
+      if (response.status !== 200) {
+        if (isPrerenderSpaFallback) {
+          throw new Error(
+            `Prerender: Received a ${response.status} status code from ` +
+              `\`entry.server.tsx\` while prerendering your \`${filename}\` file.\n` +
+              html
+          );
+        }
+        throw new Error(
+          `SPA Mode: Received a ${response.status} status code from ` +
+            `\`entry.server.tsx\` while prerendering your \`${filename}\` file.\n` +
+            html
+        );
+      }
+
+      if (
+        !html.includes('window.__reactRouterContext =') ||
+        !html.includes('window.__reactRouterRouteModules =')
+      ) {
+        throw new Error(
+          'SPA Mode: Did you forget to include `<Scripts/>` in your root route? ' +
+            'Your pre-rendered HTML cannot hydrate without `<Scripts />`.'
+        );
+      }
+
+      const outputPath = resolve(clientBuildDir, filename);
+      await writeFile(outputPath, html);
+      const prettyPath = relative(process.cwd(), outputPath);
+      if (build.prerender?.length) {
+        api.logger.info(`Prerender (html): SPA Fallback -> ${prettyPath}`);
+      } else {
+        api.logger.info(`SPA Mode: Generated ${prettyPath}`);
+      }
+    }
+  );
+};
+
+const assertValidSsrFalsePrerenderExports = ({
+  routes,
+  manifestRoutes,
+  routeExports,
+  prerenderPaths,
+  api,
+}: {
+  routes: Record<string, Route>;
+  manifestRoutes: ReactRouterManifest['routes'];
+  routeExports: RouteManifestModuleExports;
+  prerenderPaths: string[];
+  api: PrerenderBuildApi;
+}) => {
+  const errors = getSsrFalsePrerenderExportErrors({
+    routes,
+    manifestRoutes,
+    routeExports,
+    prerenderPaths,
+  });
+  if (errors.length > 0) {
+    api.logger.error(errors.join('\n'));
+    throw new Error(
+      'Invalid route exports found when prerendering with `ssr:false`'
+    );
+  }
+};
+
+const validatePrerenderPathMatches = (
+  routes: Record<string, Route>,
+  prerenderPaths: string[]
+): void => {
+  const routeTree = createPrerenderRoutes(routes);
+  for (const path of prerenderPaths) {
+    const matches = matchRoutes(routeTree, normalizePrerenderMatchPath(path));
+    if (!matches) {
+      throw new Error(
+        `Unable to prerender path because it does not match any routes: ${path}`
+      );
+    }
+  }
+};
+
+const runPrerenderPaths = async ({
+  build,
+  requestHandler,
+  clientBuildDir,
+  options,
+}: {
+  build: PrerenderServerBuild;
+  requestHandler: (request: Request) => Promise<Response>;
+  clientBuildDir: string;
+  options: RunReactRouterPrerenderBuildOptions;
+}): Promise<void> => {
+  const { api, basename, future, prerenderConfig, prerenderPaths } = options;
+  const buildRoutes = createPrerenderRoutes(build.routes);
+  const concurrency = getPrerenderConcurrency(prerenderConfig);
+  const pending = new Set<Promise<void>>();
+
+  const enqueue = async (path: string) => {
+    const matches = matchRoutes(buildRoutes, normalizePrerenderMatchPath(path));
+    if (!matches) {
+      return;
+    }
+
+    const leafRoute = matches[matches.length - 1]?.route;
+    const routeId = leafRoute?.id;
+    const manifestRoute = routeId ? build.routes?.[routeId]?.module : null;
+    const isResourceRoute =
+      manifestRoute && !manifestRoute.default && !manifestRoute.ErrorBoundary;
+
+    if (isResourceRoute) {
+      if (manifestRoute.loader && routeId) {
+        await prerenderData({
+          handler: requestHandler,
+          prerenderPath: path,
+          onlyRoutes: [routeId],
+          clientBuildDir,
+          basename,
+          trailingSlashAwareDataRequests:
+            future.unstable_trailingSlashAwareDataRequests,
+          api,
+        });
+        await prerenderResourceRoute({
+          handler: requestHandler,
+          prerenderPath: path,
+          clientBuildDir,
+          basename,
+          api,
+        });
+      } else {
+        api.logger.warn(
+          `⚠️ Skipping prerendering for resource route without a loader: ${routeId}`
+        );
+      }
+      return;
+    }
+
+    const hasLoaders = matches.some(match => {
+      const matchedRouteId = match.route.id;
+      if (!matchedRouteId) {
+        return false;
+      }
+      return build.assets?.routes?.[matchedRouteId]?.hasLoader;
+    });
+    let data: string | undefined;
+    if (hasLoaders) {
+      data = await prerenderData({
+        handler: requestHandler,
+        prerenderPath: path,
+        onlyRoutes: null,
+        clientBuildDir,
+        basename,
+        trailingSlashAwareDataRequests:
+          future.unstable_trailingSlashAwareDataRequests,
+        api,
+      });
+    }
+    await prerenderRoute({
+      handler: requestHandler,
+      prerenderPath: path,
+      clientBuildDir,
+      basename,
+      api,
+      requestInit: data
+        ? {
+            headers: {
+              'X-React-Router-Prerender-Data': encodeURI(data),
+            },
+          }
+        : undefined,
+    });
+  };
+
+  for (const path of prerenderPaths) {
+    const task = enqueue(path);
+    pending.add(task);
+    task.finally(() => pending.delete(task));
+    if (pending.size >= concurrency) {
+      await Promise.race(pending);
+    }
+  }
+  await Promise.all(pending);
+};
+
+export const runReactRouterPrerenderBuild = async (
+  options: RunReactRouterPrerenderBuildOptions
+): Promise<void> => {
+  if (!options.hasWebEnvironment) {
+    return;
+  }
+
+  const {
+    api,
+    buildDirectory,
+    serverBuildFile,
+    ssr,
+    isPrerenderEnabled,
+    prerenderPaths,
+    routes,
+    latestBrowserManifest,
+    latestBrowserManifestModuleExports,
+    clientStats,
+    pluginOptions,
+    appDirectory,
+    assetPrefix,
+    routeChunkOptions,
+    buildManifest,
+    resolvedConfigWithRoutes,
+    buildEnd,
+    basename,
+  } = options;
+  const { serverBuildDir, serverBuildPath } = await getServerBuildPath({
+    buildDirectory,
+    serverBuildFile,
+  });
+  const clientBuildDir = resolve(buildDirectory, 'client');
+
+  if (!existsSync(serverBuildPath)) {
+    console.warn(
+      `[${PLUGIN_NAME}] Server build not found at ${serverBuildPath}. ` +
+        'Skipping prerendering.'
+    );
+    return;
+  }
+
+  await mkdir(clientBuildDir, { recursive: true });
+
+  if (!ssr || isPrerenderEnabled) {
+    process.env.IS_RR_BUILD_REQUEST = 'yes';
+    const buildModule = await import(pathToFileURL(serverBuildPath).toString());
+    const build = (await resolveServerBuildModule(
+      buildModule,
+      `Server build ${JSON.stringify(serverBuildPath)}`
+    )) as PrerenderServerBuild;
+    const requestHandler = createRequestHandler(build, 'production');
+
+    if (isPrerenderEnabled) {
+      if (!ssr) {
+        const generated = latestBrowserManifest
+          ? {
+              manifest: latestBrowserManifest,
+              moduleExportsByRouteId: latestBrowserManifestModuleExports,
+            }
+          : await generateReactRouterManifestForDev(
+              routes,
+              pluginOptions,
+              clientStats,
+              appDirectory,
+              assetPrefix,
+              routeChunkOptions
+            );
+        assertValidSsrFalsePrerenderExports({
+          routes,
+          manifestRoutes: generated.manifest.routes,
+          routeExports: generated.moduleExportsByRouteId,
+          prerenderPaths,
+          api,
+        });
+      }
+
+      validatePrerenderPathMatches(routes, prerenderPaths);
+
+      if (prerenderPaths.length > 0) {
+        api.logger.info(
+          `Prerender (html): ${prerenderPaths.length} path(s)...`
+        );
+      }
+
+      await runPrerenderPaths({
+        build,
+        requestHandler,
+        clientBuildDir,
+        options,
+      });
+    }
+
+    if (!ssr) {
+      await handleSpaMode({
+        handler: requestHandler,
+        build,
+        clientBuildDir,
+        basename,
+        api,
+      });
+    }
+  }
+
+  if (!ssr) {
+    await fsExtra.remove(serverBuildDir);
+    api.logger.info(
+      `[${PLUGIN_NAME}] Removed server build (static deployment)`
+    );
+  }
+
+  if (buildEnd) {
+    await buildEnd({
+      buildManifest,
+      reactRouterConfig: resolvedConfigWithRoutes,
+      viteConfig: api.getNormalizedConfig(),
+    });
+  }
+};

--- a/src/route-ast.ts
+++ b/src/route-ast.ts
@@ -2,8 +2,12 @@ import type { ParseResult } from 'yuku-parser';
 
 export type AnyNode = Record<string, any>;
 
-export const getProgram = (ast: ParseResult | AnyNode): AnyNode =>
-  (ast as ParseResult).program ?? ast;
+export type ProgramNode = AnyNode & {
+  body: AnyNode[];
+};
+
+export const getProgram = (ast: ParseResult | AnyNode): ProgramNode =>
+  ((ast as ParseResult).program ?? ast) as ProgramNode;
 
 export const getPatternIdentifierNames = (
   pattern: AnyNode | null | undefined,

--- a/src/route-export-pruning.ts
+++ b/src/route-export-pruning.ts
@@ -5,93 +5,86 @@ import {
   getProgram,
   removeFromArray,
   type AnyNode,
+  type ProgramNode,
 } from './route-ast.js';
 
 export function validateDestructuredExports(
   id: AnyNode,
   exportsToRemove: readonly string[]
 ): void {
-  if (id.type === 'Identifier') {
-    if (exportsToRemove.includes(id.name)) {
-      throw invalidDestructureError(id.name);
-    }
-    return;
-  }
-
-  if (id.type === 'AssignmentPattern') {
-    validateDestructuredExports(id.left, exportsToRemove);
-    return;
-  }
-
-  if (id.type === 'ArrayPattern') {
-    for (const element of id.elements ?? []) {
-      if (!element) {
-        continue;
-      }
-
-      if (element.type === 'AssignmentPattern') {
-        validateDestructuredExports(element, exportsToRemove);
-        continue;
-      }
-
-      if (
-        element.type === 'Identifier' &&
-        exportsToRemove.includes(element.name)
-      ) {
-        throw invalidDestructureError(element.name);
-      }
-
-      if (
-        element.type === 'RestElement' &&
-        element.argument.type === 'Identifier' &&
-        exportsToRemove.includes(element.argument.name)
-      ) {
-        throw invalidDestructureError(element.argument.name);
-      }
-
-      if (element.type === 'ArrayPattern' || element.type === 'ObjectPattern') {
-        validateDestructuredExports(element, exportsToRemove);
-      }
-    }
-  }
-
-  if (id.type === 'ObjectPattern') {
-    for (const property of id.properties ?? []) {
-      if (!property) {
-        continue;
-      }
-
-      if (property.type === 'Property') {
-        if (
-          property.value.type === 'Identifier' &&
-          exportsToRemove.includes(property.value.name)
-        ) {
-          throw invalidDestructureError(property.value.name);
-        }
-
-        if (
-          property.value.type === 'AssignmentPattern' ||
-          property.value.type === 'ArrayPattern' ||
-          property.value.type === 'ObjectPattern'
-        ) {
-          validateDestructuredExports(property.value, exportsToRemove);
-        }
-      }
-
-      if (
-        property.type === 'RestElement' &&
-        property.argument.type === 'Identifier' &&
-        exportsToRemove.includes(property.argument.name)
-      ) {
-        throw invalidDestructureError(property.argument.name);
-      }
-    }
-  }
+  validateBindingTarget(id, new Set(exportsToRemove));
 }
 
 export function invalidDestructureError(name: string): Error {
   return new Error(`Cannot remove destructured export "${name}"`);
 }
+
+const assertAllowedBindingName = (
+  name: string,
+  exportsToRemove: ReadonlySet<string>
+): void => {
+  if (exportsToRemove.has(name)) {
+    throw invalidDestructureError(name);
+  }
+};
+
+const validateRestElement = (
+  element: AnyNode,
+  exportsToRemove: ReadonlySet<string>
+): void => {
+  if (element.argument?.type === 'Identifier' && element.argument.name) {
+    assertAllowedBindingName(element.argument.name, exportsToRemove);
+  }
+};
+
+const validateObjectProperty = (
+  property: AnyNode,
+  exportsToRemove: ReadonlySet<string>
+): void => {
+  if (property.type === 'RestElement') {
+    validateRestElement(property, exportsToRemove);
+    return;
+  }
+  if (property.type === 'Property') {
+    validateBindingTarget(
+      property.value as AnyNode | null | undefined,
+      exportsToRemove
+    );
+  }
+};
+
+const validateBindingTarget = (
+  node: AnyNode | null | undefined,
+  exportsToRemove: ReadonlySet<string>
+): void => {
+  if (!node) {
+    return;
+  }
+
+  switch (node.type) {
+    case 'Identifier':
+      if (node.name) {
+        assertAllowedBindingName(node.name, exportsToRemove);
+      }
+      return;
+    case 'AssignmentPattern':
+      validateBindingTarget(node.left, exportsToRemove);
+      return;
+    case 'ArrayPattern':
+      for (const element of node.elements ?? []) {
+        if (element?.type === 'RestElement') {
+          validateRestElement(element, exportsToRemove);
+        } else {
+          validateBindingTarget(element, exportsToRemove);
+        }
+      }
+      return;
+    case 'ObjectPattern':
+      for (const property of node.properties ?? []) {
+        validateObjectProperty(property, exportsToRemove);
+      }
+  }
+};
 
 const getDeclaredNames = (node: AnyNode): Set<string> => {
   const names = new Set<string>();
@@ -128,7 +121,9 @@ const isIdentifierDeclaration = (node: AnyNode, parent: AnyNode | null) => {
     return true;
   }
   if (parent.type === 'VariableDeclarator') {
-    return getPatternIdentifierNames(parent.id).has(node.name);
+    return Boolean(
+      node.name && getPatternIdentifierNames(parent.id).has(node.name)
+    );
   }
   if (
     (parent.type === 'ImportSpecifier' ||
@@ -142,11 +137,12 @@ const isIdentifierDeclaration = (node: AnyNode, parent: AnyNode | null) => {
     (parent.type === 'FunctionDeclaration' ||
       parent.type === 'FunctionExpression' ||
       parent.type === 'ArrowFunctionExpression') &&
-    (parent.params ?? []).some((param: AnyNode) =>
-      getPatternIdentifierNames(param).has(node.name)
-    )
+    node.name
   ) {
-    return true;
+    const name = node.name;
+    return (parent.params ?? []).some((param: AnyNode) =>
+      getPatternIdentifierNames(param).has(name)
+    );
   }
   return false;
 };
@@ -204,43 +200,49 @@ const isUppercaseName = (name: string): boolean => /^[A-Z]/.test(name);
 
 const collectReferencedNames = (node: AnyNode): Set<string> => {
   const referenced = new Set<string>();
-  walk(node as any, {
-    Identifier(node: AnyNode, ctx: any) {
-      const parent = ctx.parent as AnyNode | null;
-      if (!isNonReferenceIdentifier(node, parent)) {
-        referenced.add(node.name);
+  walk(node as never, {
+    Identifier(node, ctx) {
+      const current = node as unknown as AnyNode;
+      const parent = (ctx as { parent?: unknown }).parent as AnyNode | null;
+      if (!isNonReferenceIdentifier(current, parent) && current.name) {
+        referenced.add(current.name);
       }
     },
-    JSXIdentifier(node: AnyNode, ctx: any) {
-      const parent = ctx.parent as AnyNode | null;
+    JSXIdentifier(node, ctx) {
+      const current = node as unknown as AnyNode;
+      const parent = (ctx as { parent?: unknown }).parent as AnyNode | null;
       if (!parent) {
         return;
       }
-      if (parent.type === 'JSXMemberExpression' && parent.object === node) {
-        referenced.add(node.name);
+      if (parent.type === 'JSXMemberExpression' && parent.object === current) {
+        if (current.name) {
+          referenced.add(current.name);
+        }
         return;
       }
-      if (!isUppercaseName(node.name)) {
+      if (!current.name || !isUppercaseName(current.name)) {
         return;
       }
       if (
         (parent.type === 'JSXOpeningElement' ||
           parent.type === 'JSXClosingElement') &&
-        parent.name === node
+        parent.name === current
       ) {
-        referenced.add(node.name);
+        referenced.add(current.name);
         return;
       }
     },
-    ExportSpecifier(node: AnyNode, ctx: any) {
-      const declaration = ctx.parent as AnyNode | null;
+    ExportSpecifier(node, ctx) {
+      const current = node as unknown as AnyNode;
+      const declaration = (ctx as { parent?: unknown })
+        .parent as AnyNode | null;
       if (
         !declaration?.source &&
         declaration?.exportKind !== 'type' &&
-        node.local?.name &&
-        node.exportKind !== 'type'
+        current.local?.name &&
+        current.exportKind !== 'type'
       ) {
-        referenced.add(node.local.name);
+        referenced.add(current.local.name);
       }
     },
   });
@@ -257,7 +259,7 @@ type TopLevelDeclarationGraph = {
 };
 
 const createTopLevelDeclarationGraph = (
-  program: AnyNode
+  program: ProgramNode
 ): TopLevelDeclarationGraph => {
   const declarationsByNode = new Map<AnyNode, TopLevelDeclaration>();
   const declarationsByName = new Map<string, Set<TopLevelDeclaration>>();
@@ -280,7 +282,7 @@ const createTopLevelDeclarationGraph = (
 
   for (const statement of [...(program.body ?? [])]) {
     if (statement.type === 'VariableDeclaration') {
-      for (const declarator of statement.declarations) {
+      for (const declarator of statement.declarations ?? []) {
         registerDeclaration(
           declarator,
           declarator,
@@ -301,7 +303,7 @@ const createTopLevelDeclarationGraph = (
 };
 
 const collectLiveTopLevelDeclarations = (
-  program: AnyNode,
+  program: ProgramNode,
   graph: TopLevelDeclarationGraph
 ): Set<TopLevelDeclaration> => {
   const pendingNames: string[] = [];
@@ -384,7 +386,7 @@ const declarationReferencesName = (
 };
 
 const removeNewlyDeadTopLevelDeclarations = (
-  program: AnyNode,
+  program: ProgramNode,
   graph: TopLevelDeclarationGraph,
   previouslyLive: ReadonlySet<TopLevelDeclaration>,
   removedExportReferencedNames: ReadonlySet<string>
@@ -409,7 +411,7 @@ const removeNewlyDeadTopLevelDeclarations = (
 
   program.body = program.body.filter((statement: AnyNode) => {
     if (statement.type === 'VariableDeclaration') {
-      statement.declarations = statement.declarations.filter(
+      statement.declarations = (statement.declarations ?? []).filter(
         (declarator: AnyNode) => !isRemovableDeadDeclaration(declarator)
       );
       return statement.declarations.length > 0;
@@ -419,7 +421,7 @@ const removeNewlyDeadTopLevelDeclarations = (
 };
 
 const hasRemovableExport = (
-  program: AnyNode,
+  program: ProgramNode,
   exportsToRemove: ReadonlySet<string>
 ): boolean => {
   const removesNamedExports = [...exportsToRemove].some(
@@ -557,20 +559,23 @@ export const removeExports = (
 
       const declaration = statement.declaration;
       if (declaration?.type === 'VariableDeclaration') {
-        declaration.declarations = declaration.declarations.filter(
+        declaration.declarations = (declaration.declarations ?? []).filter(
           (declarator: AnyNode) => {
-            if (declarator.id.type === 'Identifier') {
-              if (exportsToRemoveSet.has(declarator.id.name)) {
+            const id = declarator.id;
+            if (id?.type === 'Identifier') {
+              if (id.name && exportsToRemoveSet.has(id.name)) {
                 exportsChanged = true;
-                removedExportLocalNames.add(declarator.id.name);
-                removedExportReferencedNames.add(declarator.id.name);
+                removedExportLocalNames.add(id.name);
+                removedExportReferencedNames.add(id.name);
                 trackRemovedExportReferences(declarator);
                 return false;
               }
               return true;
             }
 
-            validateDestructuredExports(declarator.id, exportsToRemove);
+            if (id) {
+              validateDestructuredExports(id, exportsToRemove);
+            }
             return true;
           }
         );
@@ -599,7 +604,7 @@ export const removeExports = (
     ) {
       exportsChanged = true;
       const declaration = statement.declaration;
-      if (declaration?.type === 'Identifier') {
+      if (declaration?.type === 'Identifier' && declaration.name) {
         removedExportLocalNames.add(declaration.name);
         removedExportReferencedNames.add(declaration.name);
       } else if (declaration?.id?.name) {
@@ -619,6 +624,7 @@ export const removeExports = (
     if (
       left?.type === 'MemberExpression' &&
       left.object?.type === 'Identifier' &&
+      left.object.name &&
       removedExportLocalNames.has(left.object.name)
     ) {
       removeFromArray(program.body, statement);

--- a/src/route-export-resolution.ts
+++ b/src/route-export-resolution.ts
@@ -1,23 +1,11 @@
-import { readFileSync, statSync, type Stats } from 'node:fs';
+import { statSync, type Stats } from 'node:fs';
 import { createRequire } from 'node:module';
-import { pathToFileURL } from 'node:url';
 import { dirname, relative, resolve } from 'pathe';
 import { JS_EXTENSIONS, PLUGIN_NAME } from './constants.js';
 import {
   getExportNamesAndExportAll,
   getRouteModuleAnalysis,
 } from './export-utils.js';
-
-type PackageJson = {
-  exports?: unknown;
-  module?: unknown;
-  main?: unknown;
-};
-
-type PackageImportResolution =
-  | { status: 'resolved'; path: string }
-  | { status: 'blocked-by-exports' }
-  | { status: 'not-found' };
 
 const tryStat = (path: string): Stats | null =>
   statSync(path, { throwIfNoEntry: false }) ?? null;
@@ -53,144 +41,6 @@ const resolvePathWithExtensions = (basePath: string): string | null => {
   return resolveIndexFile(basePath);
 };
 
-const parsePackageSpecifier = (
-  specifier: string
-): { packageName: string; subpath: string } | null => {
-  if (
-    specifier.startsWith('.') ||
-    specifier.startsWith('/') ||
-    specifier.startsWith('node:')
-  ) {
-    return null;
-  }
-  const parts = specifier.split('/');
-  const packageName = specifier.startsWith('@')
-    ? parts.slice(0, 2).join('/')
-    : parts[0];
-  if (!packageName || (specifier.startsWith('@') && parts.length < 2)) {
-    return null;
-  }
-  const rest = parts.slice(packageName.startsWith('@') ? 2 : 1).join('/');
-  return {
-    packageName,
-    subpath: rest ? `./${rest}` : '.',
-  };
-};
-
-const findPackageDirectory = (
-  packageName: string,
-  importerPath: string
-): string | null => {
-  let currentDirectory = dirname(importerPath);
-  while (true) {
-    const candidate = resolve(currentDirectory, 'node_modules', packageName);
-    if (tryStat(candidate)?.isDirectory()) {
-      return candidate;
-    }
-    const parentDirectory = dirname(currentDirectory);
-    if (parentDirectory === currentDirectory) {
-      return null;
-    }
-    currentDirectory = parentDirectory;
-  }
-};
-
-const readPackageJson = (packageDirectory: string): PackageJson | null => {
-  try {
-    return JSON.parse(
-      readFileSync(resolve(packageDirectory, 'package.json'), 'utf8')
-    );
-  } catch {
-    return null;
-  }
-};
-
-const resolvePackageTarget = (
-  packageDirectory: string,
-  target: unknown
-): string | null => {
-  if (typeof target === 'string') {
-    return resolvePathWithExtensions(resolve(packageDirectory, target));
-  }
-  if (Array.isArray(target)) {
-    for (const item of target) {
-      const resolved = resolvePackageTarget(packageDirectory, item);
-      if (resolved) {
-        return resolved;
-      }
-    }
-    return null;
-  }
-  if (target && typeof target === 'object') {
-    const conditions = target as Record<string, unknown>;
-    for (const condition of ['import', 'default']) {
-      const resolved = resolvePackageTarget(
-        packageDirectory,
-        conditions[condition]
-      );
-      if (resolved) {
-        return resolved;
-      }
-    }
-  }
-  return null;
-};
-
-const resolvePackageImport = (
-  specifier: string,
-  importerPath: string
-): PackageImportResolution => {
-  const parsed = parsePackageSpecifier(specifier);
-  if (!parsed) {
-    return { status: 'not-found' };
-  }
-  const packageDirectory = findPackageDirectory(
-    parsed.packageName,
-    importerPath
-  );
-  if (!packageDirectory) {
-    return { status: 'not-found' };
-  }
-  const packageJson = readPackageJson(packageDirectory);
-  if (!packageJson) {
-    return { status: 'not-found' };
-  }
-  const exportsField = packageJson.exports;
-  if ('exports' in packageJson) {
-    const hasSubpathExports =
-      typeof exportsField === 'object' &&
-      !Array.isArray(exportsField) &&
-      exportsField !== null &&
-      Object.keys(exportsField).some(key => key.startsWith('.'));
-    const target =
-      parsed.subpath === '.' && !hasSubpathExports
-        ? exportsField
-        : hasSubpathExports
-          ? (exportsField as Record<string, unknown>)[parsed.subpath]
-          : undefined;
-    const resolved = resolvePackageTarget(packageDirectory, target);
-    if (resolved) {
-      return { status: 'resolved', path: resolved };
-    }
-    return { status: 'blocked-by-exports' };
-  }
-  if (parsed.subpath !== '.') {
-    const resolved = resolvePathWithExtensions(
-      resolve(packageDirectory, parsed.subpath)
-    );
-    return resolved
-      ? { status: 'resolved', path: resolved }
-      : { status: 'not-found' };
-  }
-  const resolved =
-    resolvePackageTarget(packageDirectory, packageJson.module) ??
-    resolvePackageTarget(packageDirectory, packageJson.main) ??
-    resolveIndexFile(packageDirectory);
-  return resolved
-    ? { status: 'resolved', path: resolved }
-    : { status: 'not-found' };
-};
-
 const resolveExportAllModule = (
   specifier: string,
   importerPath: string
@@ -205,17 +55,8 @@ const resolveExportAllModule = (
     }
   }
 
-  const packageImport = resolvePackageImport(specifier, importerPath);
-  if (packageImport.status === 'resolved') {
-    return packageImport.path;
-  }
-  if (packageImport.status === 'blocked-by-exports') {
-    return null;
-  }
-
   try {
-    const resolver = createRequire(pathToFileURL(importerPath).href);
-    return resolver.resolve(specifier);
+    return createRequire(importerPath).resolve(specifier);
   } catch {
     return null;
   }
@@ -225,6 +66,26 @@ export type RouteExportResolver = (
   specifier: string,
   importerPath: string
 ) => Promise<string | null> | string | null;
+
+export type RouteModuleResolveCallback = (
+  error: Error | null,
+  resolved?: string | false
+) => void;
+
+export type RouteModuleResolver = (
+  context: string,
+  specifier: string,
+  callback: RouteModuleResolveCallback
+) => void;
+
+export const createBundlerRouteExportResolver =
+  (resolveModule: RouteModuleResolver): RouteExportResolver =>
+  (specifier, importerPath) =>
+    new Promise<string | null>(resolveResolvedPath => {
+      resolveModule(dirname(importerPath), specifier, (error, resolved) => {
+        resolveResolvedPath(error || !resolved ? null : resolved);
+      });
+    });
 
 export const collectClientOnlyStubExportNames = async (
   code: string,

--- a/src/route-export-resolution.ts
+++ b/src/route-export-resolution.ts
@@ -1,4 +1,4 @@
-import { statSync, type Stats } from 'node:fs';
+import { readFileSync, statSync, type Stats } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, relative, resolve } from 'pathe';
 import { JS_EXTENSIONS, PLUGIN_NAME } from './constants.js';
@@ -9,6 +9,23 @@ import {
 
 const tryStat = (path: string): Stats | null =>
   statSync(path, { throwIfNoEntry: false }) ?? null;
+
+type PackageExportTarget =
+  | string
+  | PackageExportTarget[]
+  | { [condition: string]: PackageExportTarget | undefined }
+  | null;
+
+type PackageJson = {
+  exports?: PackageExportTarget;
+  main?: string;
+  module?: string;
+};
+
+const PACKAGE_IMPORT_CONDITIONS = new Set(['import', 'node']);
+const PACKAGE_RESOLUTION_NOT_APPLICABLE = Symbol(
+  'package resolution not applicable'
+);
 
 const resolveIndexFile = (dirPath: string): string | null => {
   for (const ext of JS_EXTENSIONS) {
@@ -41,6 +58,167 @@ const resolvePathWithExtensions = (basePath: string): string | null => {
   return resolveIndexFile(basePath);
 };
 
+const parsePackageSpecifier = (
+  specifier: string
+): { packageName: string; packageSubpath: string } | null => {
+  if (
+    specifier.startsWith('.') ||
+    specifier.startsWith('/') ||
+    specifier.startsWith('#')
+  ) {
+    return null;
+  }
+
+  const parts = specifier.split('/');
+  const packageName = specifier.startsWith('@')
+    ? parts.slice(0, 2).join('/')
+    : parts[0];
+  const packagePathParts = specifier.startsWith('@')
+    ? parts.slice(2)
+    : parts.slice(1);
+
+  return {
+    packageName,
+    packageSubpath:
+      packagePathParts.length > 0 ? `./${packagePathParts.join('/')}` : '.',
+  };
+};
+
+const findPackageDirectory = (
+  importerPath: string,
+  packageName: string
+): string | null => {
+  let currentDirectory = dirname(importerPath);
+
+  while (true) {
+    const packageDirectory = resolve(
+      currentDirectory,
+      'node_modules',
+      packageName
+    );
+    const packageJsonPath = resolve(packageDirectory, 'package.json');
+    if (tryStat(packageJsonPath)?.isFile()) {
+      return packageDirectory;
+    }
+
+    const parentDirectory = dirname(currentDirectory);
+    if (parentDirectory === currentDirectory) {
+      return null;
+    }
+    currentDirectory = parentDirectory;
+  }
+};
+
+const readPackageJson = (packageDirectory: string): PackageJson | null => {
+  try {
+    return JSON.parse(
+      readFileSync(resolve(packageDirectory, 'package.json'), 'utf8')
+    ) as PackageJson;
+  } catch {
+    return null;
+  }
+};
+
+const resolvePackageExportTarget = (
+  target: PackageExportTarget | undefined
+): string | null => {
+  if (!target) {
+    return null;
+  }
+
+  if (typeof target === 'string') {
+    return target;
+  }
+
+  if (Array.isArray(target)) {
+    for (const nestedTarget of target) {
+      const resolvedTarget = resolvePackageExportTarget(nestedTarget);
+      if (resolvedTarget) {
+        return resolvedTarget;
+      }
+    }
+    return null;
+  }
+
+  for (const [condition, nestedTarget] of Object.entries(target)) {
+    if (condition === 'default' || PACKAGE_IMPORT_CONDITIONS.has(condition)) {
+      const resolvedTarget = resolvePackageExportTarget(nestedTarget);
+      if (resolvedTarget) {
+        return resolvedTarget;
+      }
+    }
+  }
+
+  return null;
+};
+
+const resolvePackageExports = (
+  packageDirectory: string,
+  packageSubpath: string,
+  packageJson: PackageJson
+): string | null => {
+  const exports = packageJson.exports;
+  if (!exports) {
+    const entry = packageJson.module ?? packageJson.main;
+    return entry
+      ? resolvePathWithExtensions(resolve(packageDirectory, entry))
+      : null;
+  }
+
+  const target =
+    typeof exports === 'object' &&
+    !Array.isArray(exports) &&
+    Object.keys(exports).some(key => key.startsWith('.'))
+      ? exports[packageSubpath]
+      : packageSubpath === '.'
+        ? exports
+        : undefined;
+
+  const resolvedTarget = resolvePackageExportTarget(target);
+  if (!resolvedTarget || !resolvedTarget.startsWith('./')) {
+    return null;
+  }
+
+  return resolvePathWithExtensions(resolve(packageDirectory, resolvedTarget));
+};
+
+const resolvePackageImport = (
+  specifier: string,
+  importerPath: string
+): string | null | typeof PACKAGE_RESOLUTION_NOT_APPLICABLE => {
+  const parsedSpecifier = parsePackageSpecifier(specifier);
+  if (!parsedSpecifier) {
+    return PACKAGE_RESOLUTION_NOT_APPLICABLE;
+  }
+
+  const packageDirectory = findPackageDirectory(
+    importerPath,
+    parsedSpecifier.packageName
+  );
+  if (!packageDirectory) {
+    return PACKAGE_RESOLUTION_NOT_APPLICABLE;
+  }
+
+  const packageJson = readPackageJson(packageDirectory);
+  if (!packageJson) {
+    return PACKAGE_RESOLUTION_NOT_APPLICABLE;
+  }
+
+  if (
+    packageJson.exports === undefined &&
+    !packageJson.module &&
+    !packageJson.main
+  ) {
+    return PACKAGE_RESOLUTION_NOT_APPLICABLE;
+  }
+
+  return resolvePackageExports(
+    packageDirectory,
+    parsedSpecifier.packageSubpath,
+    packageJson
+  );
+};
+
 const resolveExportAllModule = (
   specifier: string,
   importerPath: string
@@ -53,6 +231,11 @@ const resolveExportAllModule = (
     if (resolvedPath) {
       return resolvedPath;
     }
+  }
+
+  const importResolvedPath = resolvePackageImport(specifier, importerPath);
+  if (importResolvedPath !== PACKAGE_RESOLUTION_NOT_APPLICABLE) {
+    return importResolvedPath;
   }
 
   try {

--- a/src/route-transform-tasks.ts
+++ b/src/route-transform-tasks.ts
@@ -24,6 +24,7 @@ import {
   type RouteChunkCache,
   type RouteChunkConfig,
 } from './route-chunks.js';
+import { getProgram } from './route-ast.js';
 
 export type RouteTransformResult = {
   code: string;
@@ -165,7 +166,7 @@ const transformRouteModule = async (
 
   const ast = parse(code, { sourceType: 'module' });
   if (task.environmentName === 'web' && !task.ssr && task.isSpaMode) {
-    const resolvedExportNames = collectProgramExportNames(ast.program);
+    const resolvedExportNames = collectProgramExportNames(getProgram(ast));
     const isRootRoute = task.resourcePath === task.rootRoutePath;
     const relativePath = relative(process.cwd(), task.resourcePath);
 

--- a/src/typegen.ts
+++ b/src/typegen.ts
@@ -1,0 +1,49 @@
+import type { RsbuildPluginAPI } from '@rsbuild/core';
+import type { ResultPromise } from 'execa';
+
+export const registerReactRouterTypegen = (api: RsbuildPluginAPI): void => {
+  let typegenProcess: ResultPromise | undefined;
+
+  api.onBeforeStartDevServer(async () => {
+    if (typegenProcess) {
+      return;
+    }
+    const { execa } = await import('execa');
+    const process = execa(
+      'npx',
+      ['--yes', 'react-router', 'typegen', '--watch'],
+      {
+        stdio: 'inherit',
+        detached: false,
+        cleanup: true,
+      }
+    );
+    typegenProcess = process;
+    process
+      .catch(() => {
+        // Ignore errors when the process is killed on server shutdown.
+      })
+      .finally(() => {
+        if (typegenProcess === process) {
+          typegenProcess = undefined;
+        }
+      });
+  });
+
+  api.onCloseDevServer(async () => {
+    const process = typegenProcess;
+    typegenProcess = undefined;
+    if (!process) {
+      return;
+    }
+    process.kill('SIGTERM');
+    await process.catch(() => undefined);
+  });
+
+  api.onBeforeBuild(async () => {
+    const { execa } = await import('execa');
+    await execa('npx', ['--yes', 'react-router', 'typegen'], {
+      stdio: 'inherit',
+    });
+  });
+};

--- a/tests/client-modules.test.ts
+++ b/tests/client-modules.test.ts
@@ -85,10 +85,20 @@ describe('client-only module transforms', () => {
       expect(transformCall).toBeDefined();
 
       const handler = transformCall?.[1];
+      const resolvedPath = join(packageDirectory, 'esm.js');
       const result = await handler({
         environment: { name: 'node' },
         code: await readFile(resourcePath, 'utf8'),
         resourcePath,
+        resolve(
+          context: string,
+          specifier: string,
+          callback: (error: Error | null, resolved?: string) => void
+        ) {
+          expect(context).toBe(join(root, 'app'));
+          expect(specifier).toBe('conditional-client-lib');
+          callback(null, resolvedPath);
+        },
       });
 
       expect(result.code).toContain('export const esmOnly = undefined;');

--- a/tests/client-modules.test.ts
+++ b/tests/client-modules.test.ts
@@ -109,6 +109,56 @@ describe('client-only module transforms', () => {
     }
   });
 
+  it('uses import conditions in the fallback export-all resolver', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'rr-client-modules-fallback-'));
+    const packageDirectory = join(
+      root,
+      'node_modules',
+      'fallback-conditional-client-lib'
+    );
+    await mkdir(packageDirectory, { recursive: true });
+    await writeFile(
+      join(packageDirectory, 'package.json'),
+      JSON.stringify({
+        name: 'fallback-conditional-client-lib',
+        exports: {
+          '.': {
+            import: './esm.js',
+            require: './cjs.cjs',
+          },
+        },
+        type: 'module',
+      })
+    );
+    await writeFile(
+      join(packageDirectory, 'esm.js'),
+      'export const esmOnly = true; export const shared = true;'
+    );
+    await writeFile(
+      join(packageDirectory, 'cjs.cjs'),
+      'exports.cjsOnly = true; exports.shared = true;'
+    );
+    const resourcePath = join(root, 'app', 'example.client.ts');
+    await mkdir(join(root, 'app'), { recursive: true });
+    await writeFile(
+      resourcePath,
+      "export * from 'fallback-conditional-client-lib';"
+    );
+
+    try {
+      const exportNames = await collectClientOnlyStubExportNames(
+        await readFile(resourcePath, 'utf8'),
+        resourcePath
+      );
+
+      expect(exportNames).toContain('esmOnly');
+      expect(exportNames).toContain('shared');
+      expect(exportNames).not.toContain('cjsOnly');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('does not bypass package exports for private export-all subpaths', async () => {
     const root = await mkdtemp(join(tmpdir(), 'rr-client-modules-private-'));
     const packageDirectory = join(root, 'node_modules', 'private-client-lib');

--- a/tests/remove-exports.test.ts
+++ b/tests/remove-exports.test.ts
@@ -196,6 +196,75 @@ describe('removeExports', () => {
     );
   });
 
+  it('rejects nested destructured bindings for removed exports', () => {
+    const code = `
+      const route = { data: { nested: { loader: async () => null } } };
+      export const { data: { nested: { loader } } } = route;
+      export default function Route() {
+        return null;
+      }
+    `;
+
+    const ast = parse(code, { sourceType: 'module' });
+
+    expect(() => removeExports(ast, ['loader'])).toThrowError(
+      'Cannot remove destructured export "loader"'
+    );
+  });
+
+  it('rejects rest identifiers for removed exports', () => {
+    const code = `
+      const route = { action: async () => null, loader: async () => null };
+      export const { action, ...loader } = route;
+      export default function Route() {
+        return null;
+      }
+    `;
+
+    const ast = parse(code, { sourceType: 'module' });
+
+    expect(() => removeExports(ast, ['loader'])).toThrowError(
+      'Cannot remove destructured export "loader"'
+    );
+  });
+
+  it('checks aliased destructuring by local binding name', () => {
+    const code = `
+      const route = { loader: async () => null };
+      export const { loader: clientLoader } = route;
+      export default function Route() {
+        return null;
+      }
+    `;
+
+    const ast = parse(code, { sourceType: 'module' });
+
+    expect(() => removeExports(ast, ['loader'])).not.toThrow();
+    expect(() => removeExports(ast, ['clientLoader'])).toThrowError(
+      'Cannot remove destructured export "clientLoader"'
+    );
+  });
+
+  it('ignores array holes and default initializer references', () => {
+    const code = `
+      const route = [undefined, async () => loader()];
+      export const [, action = loader] = route;
+      function loader() {
+        return null;
+      }
+      export default function Route() {
+        return null;
+      }
+    `;
+
+    const ast = parse(code, { sourceType: 'module' });
+
+    expect(() => removeExports(ast, ['loader'])).not.toThrow();
+    expect(() => removeExports(ast, ['action'])).toThrowError(
+      'Cannot remove destructured export "action"'
+    );
+  });
+
   it('removes every declaration in a deep dead dependency chain', () => {
     const helperCount = 64;
     const helpers = Array.from({ length: helperCount }, (_, index) => {


### PR DESCRIPTION
## Summary
- extract typegen and build-output transform registration out of the main plugin setup
- move prerender build execution into a focused prerender-build module
- replace bespoke package export resolution with the bundler resolver boundary where available, keeping a small fallback for non-bundler callers
- add route export pruning coverage for nested/rest destructuring cases

## Verification
- pnpm format:check
- pnpm build
- pnpm test:core
- pnpm test:package-interop
- git diff --check
- pnpm bench:smoke (synthetic-48-ssr-esm: 0.96s wall clock, 243748 KB max RSS)
