### PR TITLE
[codex] Preserve CSS re-add reload state

### DIFF
--- a/src/dev-generation.ts
+++ b/src/dev-generation.ts
@@ -494,9 +494,11 @@ export const createReactRouterDevRuntime = ({
         if (cssAssetsRemoved) {
           reloadAfterCssRemoval = !cssAssetsAdded;
           notifyCssAssetOwnershipChanged();
-        } else if (webChanged && reloadAfterCssRemoval) {
+        } else if (cssAssetsAdded) {
+          if (reloadAfterCssRemoval) {
+            notifyCssAssetOwnershipChanged();
+          }
           reloadAfterCssRemoval = false;
-          notifyCssAssetOwnershipChanged();
         }
       } catch (cause) {
         rejectAttempt(

--- a/tests/dev-generation.test.ts
+++ b/tests/dev-generation.test.ts
@@ -406,6 +406,19 @@ describe('React Router development runtime', () => {
       cssOnlyChange,
       graphIdentity(removedCssWeb, node)
     );
+    expect(onCssAssetOwnershipChanged).toHaveBeenCalledOnce();
+
+    const contentOnlyWeb = createCompilation('web');
+    runtime.beginAttempt();
+    captureWeb(runtime, contentOnlyWeb, 'without-css-content-edit', {
+      routes: { 'routes/about': [] },
+    });
+    await runtime.finishAttempt(
+      createGraphStats(contentOnlyWeb, node),
+      cssOnlyChange,
+      graphIdentity(contentOnlyWeb, node)
+    );
+    expect(onCssAssetOwnershipChanged).toHaveBeenCalledOnce();
 
     const readdedCssWeb = createCompilation('web');
     runtime.beginAttempt();


### PR DESCRIPTION
## Summary

- keep the post-removal CSS reload state armed through unrelated web updates
- only fire the follow-up hard reload when CSS ownership is actually added back
- add a unit regression covering content-only web updates between removal and re-add

## Context

This stacks on PR #39. The base branch already fails closed for lazy extracted-CSS ownership removal; this follow-up tightens the state machine so normal web HMR is preserved after a removal until CSS is re-added.

## Validation

- `pnpm test:core tests/dev-generation.test.ts tests/dev-runtime-controller.test.ts`
- `pnpm build`
- `pnpm --filter ./examples/default-template test:e2e:lazy`
- `pnpm test:core`
- `git diff --check`
- `pnpm exec prettier --check src/dev-generation.ts tests/dev-generation.test.ts`
- `pnpm test:package-interop`
- `pnpm bench:smoke` (synthetic-48 SSR ESM: 1.53s wall, 259428 KB max RSS)
