### PR TITLE
fix: preserve mixed asset query semantics

### DIFF
--- a/.changeset/mixed-url-assets.md
+++ b/.changeset/mixed-url-assets.md
@@ -1,0 +1,5 @@
+---
+'rsbuild-plugin-react-router': patch
+---
+
+Preserve mixed asset query semantics for `?url&raw` and `?url&inline` requests.

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,7 +128,8 @@ const ensureFederationAsyncStartup = (
 
 const cssUrlAssetExtensions =
   /\.(?:css|less|sass|scss|styl|stylus|pcss|postcss|sss)$/;
-const urlAssetResourceQuery = /(?:\?|&)url(?:&|$)/;
+const urlAssetResourceQuery =
+  /^(?=.*(?:\?|&)url(?:&|$))(?!.*(?:\?|&)(?:raw|inline)(?:&|$))/;
 
 export const pluginReactRouter = (
   options: PluginOptions = {}

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -237,7 +237,7 @@ describe('pluginReactRouter', () => {
       const config = await rsbuild.unwrapConfig();
       const getRules = (name: 'web' | 'node') =>
         config.environments?.[name]?.tools?.rspack?.module?.rules ?? [];
-      const includedQueries = ['?url', '?foo=bar&url'];
+      const includedQueries = ['?url', '?url&foo=bar', '?foo=bar&url'];
       const excludedQueries = [
         '?raw',
         '?inline',
@@ -246,12 +246,22 @@ describe('pluginReactRouter', () => {
         '?url&inline',
         '?inline&url',
       ];
-      const hasUrlAssetRule = (rule: any) =>
-        rule.resourceQuery?.toString().includes('url') &&
-        rule.exclude?.test('app/styles.css') &&
-        includedQueries.every(query => rule.resourceQuery?.test(query)) &&
-        excludedQueries.every(query => !rule.resourceQuery?.test(query)) &&
-        rule.type === 'asset/resource';
+      const hasUrlAssetRule = (rule: {
+        resourceQuery?: RegExp;
+        exclude?: RegExp;
+        type?: string;
+      }) => {
+        const { resourceQuery, exclude, type } = rule;
+        return (
+          resourceQuery instanceof RegExp &&
+          exclude instanceof RegExp &&
+          resourceQuery.toString().includes('url') &&
+          exclude.test('app/styles.css') &&
+          includedQueries.every(query => resourceQuery.test(query)) &&
+          excludedQueries.every(query => !resourceQuery.test(query)) &&
+          type === 'asset/resource'
+        );
+      };
 
       expect(getRules('web').some(hasUrlAssetRule)).toBe(true);
       expect(getRules('node').some(hasUrlAssetRule)).toBe(true);

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -237,17 +237,20 @@ describe('pluginReactRouter', () => {
       const config = await rsbuild.unwrapConfig();
       const getRules = (name: 'web' | 'node') =>
         config.environments?.[name]?.tools?.rspack?.module?.rules ?? [];
+      const includedQueries = ['?url', '?foo=bar&url'];
+      const excludedQueries = [
+        '?raw',
+        '?inline',
+        '?url&raw',
+        '?raw&url',
+        '?url&inline',
+        '?inline&url',
+      ];
       const hasUrlAssetRule = (rule: any) =>
         rule.resourceQuery?.toString().includes('url') &&
         rule.exclude?.test('app/styles.css') &&
-        rule.resourceQuery?.test('?url') &&
-        rule.resourceQuery?.test('?foo=bar&url') &&
-        !rule.resourceQuery?.test('?raw') &&
-        !rule.resourceQuery?.test('?inline') &&
-        !rule.resourceQuery?.test('?url&raw') &&
-        !rule.resourceQuery?.test('?raw&url') &&
-        !rule.resourceQuery?.test('?url&inline') &&
-        !rule.resourceQuery?.test('?inline&url') &&
+        includedQueries.every(query => rule.resourceQuery?.test(query)) &&
+        excludedQueries.every(query => !rule.resourceQuery?.test(query)) &&
         rule.type === 'asset/resource';
 
       expect(getRules('web').some(hasUrlAssetRule)).toBe(true);

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -240,6 +240,14 @@ describe('pluginReactRouter', () => {
       const hasUrlAssetRule = (rule: any) =>
         rule.resourceQuery?.toString().includes('url') &&
         rule.exclude?.test('app/styles.css') &&
+        rule.resourceQuery?.test('?url') &&
+        rule.resourceQuery?.test('?foo=bar&url') &&
+        !rule.resourceQuery?.test('?raw') &&
+        !rule.resourceQuery?.test('?inline') &&
+        !rule.resourceQuery?.test('?url&raw') &&
+        !rule.resourceQuery?.test('?raw&url') &&
+        !rule.resourceQuery?.test('?url&inline') &&
+        !rule.resourceQuery?.test('?inline&url') &&
         rule.type === 'asset/resource';
 
       expect(getRules('web').some(hasUrlAssetRule)).toBe(true);


### PR DESCRIPTION
## Summary
- tighten the generic non-CSS `?url` asset rule so it does not steal mixed `?url&raw` or `?url&inline` requests
- preserve CSS `?url` handling outside the generic asset rule
- add coverage for query ordering and mixed-query exclusions
- add a patch changeset

## Validation
- `pnpm exec prettier --check src/index.ts tests/features.test.ts .changeset/mixed-url-assets.md`
- `pnpm test:core tests/features.test.ts tests/dev-runtime.integration.test.ts`
- `pnpm test:core`
- `pnpm build`

## Notes
Restacked directly on current `main` after PR #56 merged.