### PR TITLE
fix: reload on route manifest metadata changes

### DIFF
--- a/src/dev-generation.ts
+++ b/src/dev-generation.ts
@@ -228,7 +228,7 @@ const hasRouteManifestMetadataChanges = (
   if (previousEntryNames.length !== Object.keys(next).length) {
     return true;
   }
-  return previousEntryNames.some(entryName => {
+  for (const entryName of previousEntryNames) {
     const nextManifest = next[entryName];
     if (!nextManifest) {
       return true;
@@ -239,12 +239,15 @@ const hasRouteManifestMetadataChanges = (
     if (previousRouteIds.length !== Object.keys(nextRoutes).length) {
       return true;
     }
-    return previousRouteIds.some(routeId => {
+    for (const routeId of previousRouteIds) {
       const previousRoute = previousRoutes[routeId];
       const nextRoute = nextRoutes[routeId];
-      return !nextRoute || !hasSameRouteMetadata(previousRoute, nextRoute);
-    });
-  });
+      if (!nextRoute || !hasSameRouteMetadata(previousRoute, nextRoute)) {
+        return true;
+      }
+    }
+  }
+  return false;
 };
 
 const createDeferred = <T>(): Deferred<T> => {

--- a/src/dev-generation.ts
+++ b/src/dev-generation.ts
@@ -195,50 +195,55 @@ const hasOnlyCssAssetOwnershipChanges = (
   });
 };
 
-const normalizeManifestForRouteMetadataCheck = (
-  manifest: ReactRouterDevManifestSet[string]
-) =>
-  Object.fromEntries(
-    Object.entries(manifest.routes ?? {})
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([routeId, route]) => [
-        routeId,
-        {
-          caseSensitive: route.caseSensitive,
-          clientActionModule: route.clientActionModule,
-          clientLoaderModule: route.clientLoaderModule,
-          clientMiddlewareModule: route.clientMiddlewareModule,
-          errorBoundary: route.hasErrorBoundary,
-          hasAction: route.hasAction,
-          hasClientAction: route.hasClientAction,
-          hasClientLoader: route.hasClientLoader,
-          hasClientMiddleware: route.hasClientMiddleware,
-          hasDefaultExport: route.hasDefaultExport,
-          hasLoader: route.hasLoader,
-          hydrateFallbackModule: route.hydrateFallbackModule,
-          id: route.id,
-          index: route.index,
-          parentId: route.parentId,
-          path: route.path,
-        },
-      ])
-  );
+type DevRouteManifestEntry = NonNullable<
+  ReactRouterDevManifestSet[string]['routes']
+>[string];
+
+const hasSameRouteMetadata = (
+  previous: DevRouteManifestEntry,
+  next: DevRouteManifestEntry
+): boolean =>
+  previous.caseSensitive === next.caseSensitive &&
+  previous.clientActionModule === next.clientActionModule &&
+  previous.clientLoaderModule === next.clientLoaderModule &&
+  previous.clientMiddlewareModule === next.clientMiddlewareModule &&
+  previous.hasErrorBoundary === next.hasErrorBoundary &&
+  previous.hasAction === next.hasAction &&
+  previous.hasClientAction === next.hasClientAction &&
+  previous.hasClientLoader === next.hasClientLoader &&
+  previous.hasClientMiddleware === next.hasClientMiddleware &&
+  previous.hasDefaultExport === next.hasDefaultExport &&
+  previous.hasLoader === next.hasLoader &&
+  previous.hydrateFallbackModule === next.hydrateFallbackModule &&
+  previous.id === next.id &&
+  previous.index === next.index &&
+  previous.parentId === next.parentId &&
+  previous.path === next.path;
 
 const hasRouteManifestMetadataChanges = (
   previous: ReactRouterDevManifestSet,
   next: ReactRouterDevManifestSet
 ): boolean => {
-  const previousEntryNames = Object.keys(previous).sort();
-  const nextEntryNames = Object.keys(next).sort();
-  if (previousEntryNames.join('\0') !== nextEntryNames.join('\0')) {
+  const previousEntryNames = Object.keys(previous);
+  if (previousEntryNames.length !== Object.keys(next).length) {
     return true;
   }
   return previousEntryNames.some(entryName => {
-    const previousRoutes = normalizeManifestForRouteMetadataCheck(
-      previous[entryName]
-    );
-    const nextRoutes = normalizeManifestForRouteMetadataCheck(next[entryName]);
-    return JSON.stringify(previousRoutes) !== JSON.stringify(nextRoutes);
+    const nextManifest = next[entryName];
+    if (!nextManifest) {
+      return true;
+    }
+    const previousRoutes = previous[entryName].routes ?? {};
+    const nextRoutes = nextManifest.routes ?? {};
+    const previousRouteIds = Object.keys(previousRoutes);
+    if (previousRouteIds.length !== Object.keys(nextRoutes).length) {
+      return true;
+    }
+    return previousRouteIds.some(routeId => {
+      const previousRoute = previousRoutes[routeId];
+      const nextRoute = nextRoutes[routeId];
+      return !nextRoute || !hasSameRouteMetadata(previousRoute, nextRoute);
+    });
   });
 };
 

--- a/src/dev-generation.ts
+++ b/src/dev-generation.ts
@@ -75,6 +75,7 @@ type CreateReactRouterDevRuntimeOptions = {
   buildPlan: ReactRouterDevBuildPlan;
   onEvaluationError: (error: Error) => void;
   onCssAssetOwnershipChanged?: (change: 'removed' | 'restored') => void;
+  onRouteManifestChanged?: () => void;
   onWarning?: (message: string) => void;
 };
 
@@ -194,6 +195,53 @@ const hasOnlyCssAssetOwnershipChanges = (
   });
 };
 
+const normalizeManifestForRouteMetadataCheck = (
+  manifest: ReactRouterDevManifestSet[string]
+) =>
+  Object.fromEntries(
+    Object.entries(manifest.routes ?? {})
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([routeId, route]) => [
+        routeId,
+        {
+          caseSensitive: route.caseSensitive,
+          clientActionModule: route.clientActionModule,
+          clientLoaderModule: route.clientLoaderModule,
+          clientMiddlewareModule: route.clientMiddlewareModule,
+          errorBoundary: route.hasErrorBoundary,
+          hasAction: route.hasAction,
+          hasClientAction: route.hasClientAction,
+          hasClientLoader: route.hasClientLoader,
+          hasClientMiddleware: route.hasClientMiddleware,
+          hasDefaultExport: route.hasDefaultExport,
+          hasLoader: route.hasLoader,
+          hydrateFallbackModule: route.hydrateFallbackModule,
+          id: route.id,
+          index: route.index,
+          parentId: route.parentId,
+          path: route.path,
+        },
+      ])
+  );
+
+const hasRouteManifestMetadataChanges = (
+  previous: ReactRouterDevManifestSet,
+  next: ReactRouterDevManifestSet
+): boolean => {
+  const previousEntryNames = Object.keys(previous).sort();
+  const nextEntryNames = Object.keys(next).sort();
+  if (previousEntryNames.join('\0') !== nextEntryNames.join('\0')) {
+    return true;
+  }
+  return previousEntryNames.some(entryName => {
+    const previousRoutes = normalizeManifestForRouteMetadataCheck(
+      previous[entryName]
+    );
+    const nextRoutes = normalizeManifestForRouteMetadataCheck(next[entryName]);
+    return JSON.stringify(previousRoutes) !== JSON.stringify(nextRoutes);
+  });
+};
+
 const createDeferred = <T>(): Deferred<T> => {
   let resolve!: (value: T) => void;
   let reject!: (error: Error) => void;
@@ -212,6 +260,7 @@ export const createReactRouterDevRuntime = ({
   buildPlan,
   onEvaluationError,
   onCssAssetOwnershipChanged = () => undefined,
+  onRouteManifestChanged = () => undefined,
   onWarning = () => undefined,
 }: CreateReactRouterDevRuntimeOptions): ReactRouterDevRuntime => {
   let nextAttemptId = 1;
@@ -235,6 +284,17 @@ export const createReactRouterDevRuntime = ({
       const reason = cause instanceof Error ? cause.message : String(cause);
       onWarning(
         `[rsbuild-plugin-react-router] Failed to notify the browser after CSS asset ownership changed: ${reason}`
+      );
+    }
+  };
+
+  const notifyRouteManifestChanged = (): void => {
+    try {
+      onRouteManifestChanged();
+    } catch (cause) {
+      const reason = cause instanceof Error ? cause.message : String(cause);
+      onWarning(
+        `[rsbuild-plugin-react-router] Failed to notify the browser after route manifest metadata changed: ${reason}`
       );
     }
   };
@@ -452,6 +512,13 @@ export const createReactRouterDevRuntime = ({
           previous.web.manifestsByEntryName,
           manifestsByEntryName
         );
+      const routeManifestMetadataChanged =
+        !!previous &&
+        webChanged &&
+        hasRouteManifestMetadataChanges(
+          previous.web.manifestsByEntryName,
+          manifestsByEntryName
+        );
       const reusePreviousNodeBuild = !!previous && cssOnlyWebManifestChange;
 
       if (
@@ -518,6 +585,9 @@ export const createReactRouterDevRuntime = ({
             notifyCssAssetOwnershipChanged('restored');
           }
           reloadAfterCssRemoval = false;
+        }
+        if (routeManifestMetadataChanged) {
+          notifyRouteManifestChanged();
         }
       } catch (cause) {
         rejectAttempt(

--- a/src/dev-runtime-controller.ts
+++ b/src/dev-runtime-controller.ts
@@ -213,6 +213,12 @@ export const createReactRouterDevRuntimeController = ({
           reloadAfterCssAssetOwnershipRemoval = change === 'removed';
           sendCssAssetOwnershipReload();
         },
+        onRouteManifestChanged() {
+          if (sessions.getActiveBinding()?.runtime !== runtime) {
+            return;
+          }
+          server.sockWrite('full-reload', { path: '*' });
+        },
         onWarning: message => api.logger.warn(message),
       });
       const binding = sessions.createBinding(server, runtime);

--- a/tests/dev-generation-fixtures.ts
+++ b/tests/dev-generation-fixtures.ts
@@ -22,7 +22,10 @@ export const captureWeb = (
 
 export const createDevRuntimeHarness = (
   loadBundle: (entryName: string) => Promise<unknown> | unknown,
-  options: { onCssAssetOwnershipChanged?: () => void } = {}
+  options: {
+    onCssAssetOwnershipChanged?: (change: 'removed' | 'restored') => void;
+    onRouteManifestChanged?: () => void;
+  } = {}
 ) => {
   const errors: Error[] = [];
   const warnings: string[] = [];
@@ -40,6 +43,7 @@ export const createDevRuntimeHarness = (
     },
     onEvaluationError: error => errors.push(error),
     onCssAssetOwnershipChanged: options.onCssAssetOwnershipChanged,
+    onRouteManifestChanged: options.onRouteManifestChanged,
     onWarning: warning => warnings.push(warning),
   });
   return { errors, loadBundle: loadBundleMock, runtime, server, warnings };

--- a/tests/dev-generation.test.ts
+++ b/tests/dev-generation.test.ts
@@ -133,7 +133,7 @@ describe('React Router development runtime', () => {
       'static/js/app': {
         ...createDevManifest('base'),
         routes: {
-          'routes/about': createRouteManifest('routes/about', [], [], {
+          'routes/about': createRouteManifest('routes/about', [], {
             hasClientLoader: false,
           }),
         },
@@ -152,7 +152,7 @@ describe('React Router development runtime', () => {
       'static/js/app': {
         ...createDevManifest('next'),
         routes: {
-          'routes/about': createRouteManifest('routes/about', [], [], {
+          'routes/about': createRouteManifest('routes/about', [], {
             hasClientLoader: true,
             clientLoaderModule: '/routes/about.clientLoader.js',
           }),

--- a/tests/dev-generation.test.ts
+++ b/tests/dev-generation.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, rstest } from '@rstest/core';
 import { loadReactRouterServerBuild } from '../src';
 import {
   createReactRouterDevRuntime,
+  type DevGraphChanges,
   registerReactRouterDevRuntime,
   unregisterReactRouterDevRuntime,
 } from '../src/dev-generation';
@@ -13,7 +14,9 @@ import {
 import {
   createBuild,
   createCompilation,
+  createDevManifest,
   createGraphStats,
+  createRouteManifest,
   graphIdentity,
   noKnownChanges,
 } from './dev-runtime-fixtures';
@@ -115,6 +118,54 @@ describe('React Router development runtime', () => {
     await expect(runtime.load()).resolves.toMatchObject({
       assets: { version: 'same-css' },
     });
+  });
+
+  it('notifies when route export metadata changes', async () => {
+    const onRouteManifestChanged = rstest.fn();
+    const { runtime } = createHarness(() => createBuild('build'), {
+      onRouteManifestChanged,
+    });
+    const firstWeb = createCompilation('web');
+    const firstNode = createCompilation('node');
+
+    runtime.beginAttempt();
+    runtime.captureWeb(firstWeb, {
+      'static/js/app': {
+        ...createDevManifest('base'),
+        routes: {
+          'routes/about': createRouteManifest('routes/about', [], [], {
+            hasClientLoader: false,
+          }),
+        },
+      },
+    });
+    await runtime.finishAttempt(
+      createGraphStats(firstWeb, firstNode),
+      noKnownChanges,
+      graphIdentity(firstWeb, firstNode)
+    );
+
+    const nextWeb = createCompilation('web');
+    const nextNode = createCompilation('node');
+    runtime.beginAttempt();
+    runtime.captureWeb(nextWeb, {
+      'static/js/app': {
+        ...createDevManifest('next'),
+        routes: {
+          'routes/about': createRouteManifest('routes/about', [], [], {
+            hasClientLoader: true,
+            clientLoaderModule: '/routes/about.clientLoader.js',
+          }),
+        },
+      },
+    });
+    await runtime.finishAttempt(
+      createGraphStats(nextWeb, nextNode),
+      noKnownChanges,
+      graphIdentity(nextWeb, nextNode)
+    );
+
+    expect(onRouteManifestChanged).toHaveBeenCalledOnce();
   });
 
   it('notifies when css ownership is re-added after a removal', async () => {

--- a/tests/dev-generation.test.ts
+++ b/tests/dev-generation.test.ts
@@ -14,9 +14,7 @@ import {
 import {
   createBuild,
   createCompilation,
-  createDevManifest,
   createGraphStats,
-  createRouteManifest,
   graphIdentity,
   noKnownChanges,
 } from './dev-runtime-fixtures';
@@ -118,54 +116,6 @@ describe('React Router development runtime', () => {
     await expect(runtime.load()).resolves.toMatchObject({
       assets: { version: 'same-css' },
     });
-  });
-
-  it('notifies when route export metadata changes', async () => {
-    const onRouteManifestChanged = rstest.fn();
-    const { runtime } = createHarness(() => createBuild('build'), {
-      onRouteManifestChanged,
-    });
-    const firstWeb = createCompilation('web');
-    const firstNode = createCompilation('node');
-
-    runtime.beginAttempt();
-    runtime.captureWeb(firstWeb, {
-      'static/js/app': {
-        ...createDevManifest('base'),
-        routes: {
-          'routes/about': createRouteManifest('routes/about', [], {
-            hasClientLoader: false,
-          }),
-        },
-      },
-    });
-    await runtime.finishAttempt(
-      createGraphStats(firstWeb, firstNode),
-      noKnownChanges,
-      graphIdentity(firstWeb, firstNode)
-    );
-
-    const nextWeb = createCompilation('web');
-    const nextNode = createCompilation('node');
-    runtime.beginAttempt();
-    runtime.captureWeb(nextWeb, {
-      'static/js/app': {
-        ...createDevManifest('next'),
-        routes: {
-          'routes/about': createRouteManifest('routes/about', [], {
-            hasClientLoader: true,
-            clientLoaderModule: '/routes/about.clientLoader.js',
-          }),
-        },
-      },
-    });
-    await runtime.finishAttempt(
-      createGraphStats(nextWeb, nextNode),
-      noKnownChanges,
-      graphIdentity(nextWeb, nextNode)
-    );
-
-    expect(onRouteManifestChanged).toHaveBeenCalledOnce();
   });
 
   it('notifies when css ownership is re-added after a removal', async () => {

--- a/tests/dev-runtime-controller.test.ts
+++ b/tests/dev-runtime-controller.test.ts
@@ -12,9 +12,8 @@ import { createReactRouterDevRuntimeController } from '../src/dev-runtime-contro
 import {
   createBuild,
   createGraphStats,
-  createDevManifest,
   createManifestSet,
-  createRouteManifest,
+  createManifestSetWithRoute,
   createStats,
 } from './dev-runtime-fixtures';
 
@@ -518,42 +517,30 @@ describe('React Router development runtime controller', () => {
     callbacks.created({
       compiler: { compilers: [web.compiler, node.compiler] },
     });
-    callbacks.before();
-    const baseWeb = web.compile();
-    controller.captureWeb(baseWeb, {
-      'static/js/app': {
-        ...createDevManifest('web-base'),
-        routes: {
-          'routes/about': createRouteManifest('routes/about', [], {
-            hasClientLoader: false,
-          }),
-        },
-      },
-    });
-    web.complete(baseWeb);
-    const baseNode = node.compile();
-    await callbacks.after({ stats: createGraphStats(baseWeb, baseNode) });
+    const finishCompile = async (
+      version: string,
+      route: Parameters<typeof createManifestSetWithRoute>[2]
+    ) => {
+      callbacks.before();
+      const webCompilation = web.compile();
+      controller.captureWeb(
+        webCompilation,
+        createManifestSetWithRoute(version, 'routes/about', route)
+      );
+      web.complete(webCompilation);
+      const nodeCompilation = node.compile();
+      await callbacks.after({
+        stats: createGraphStats(webCompilation, nodeCompilation),
+      });
+    };
 
-    callbacks.before();
-    const nextWeb = web.compile();
-    controller.captureWeb(nextWeb, {
-      'static/js/app': {
-        ...createDevManifest('web-next'),
-        routes: {
-          'routes/about': createRouteManifest('routes/about', [], {
-            hasClientLoader: true,
-            clientLoaderModule: '/routes/about.clientLoader.js',
-          }),
-        },
-      },
+    await finishCompile('web-base', { hasClientLoader: false });
+    await finishCompile('web-next', {
+      hasClientLoader: true,
+      clientLoaderModule: '/routes/about.clientLoader.js',
     });
-    web.complete(nextWeb);
-    const nextNode = node.compile();
-    await callbacks.after({ stats: createGraphStats(nextWeb, nextNode) });
 
-    expect(server.sockWrite).toHaveBeenCalledWith('full-reload', {
-      path: '*',
-    });
+    expect(server.sockWrite).toHaveBeenCalledWith('full-reload', { path: '*' });
   });
 
   it('publishes a safe node-only compile after the aggregate pre-hook', async () => {

--- a/tests/dev-runtime-controller.test.ts
+++ b/tests/dev-runtime-controller.test.ts
@@ -524,7 +524,7 @@ describe('React Router development runtime controller', () => {
       'static/js/app': {
         ...createDevManifest('web-base'),
         routes: {
-          'routes/about': createRouteManifest('routes/about', [], [], {
+          'routes/about': createRouteManifest('routes/about', [], {
             hasClientLoader: false,
           }),
         },
@@ -540,7 +540,7 @@ describe('React Router development runtime controller', () => {
       'static/js/app': {
         ...createDevManifest('web-next'),
         routes: {
-          'routes/about': createRouteManifest('routes/about', [], [], {
+          'routes/about': createRouteManifest('routes/about', [], {
             hasClientLoader: true,
             clientLoaderModule: '/routes/about.clientLoader.js',
           }),

--- a/tests/dev-runtime-controller.test.ts
+++ b/tests/dev-runtime-controller.test.ts
@@ -12,7 +12,9 @@ import { createReactRouterDevRuntimeController } from '../src/dev-runtime-contro
 import {
   createBuild,
   createGraphStats,
+  createDevManifest,
   createManifestSet,
+  createRouteManifest,
   createStats,
 } from './dev-runtime-fixtures';
 
@@ -503,6 +505,53 @@ describe('React Router development runtime controller', () => {
       path: '*',
     });
     expect(server.sockWrite).toHaveBeenNthCalledWith(2, 'full-reload', {
+      path: '*',
+    });
+  });
+
+  it('hard reloads when route export metadata changes', async () => {
+    const { callbacks, controller, loadBundle, server } = createHarness();
+    loadBundle.mockImplementation(() => createBuild('base'));
+    const web = createCompiler('web');
+    const node = createCompiler('node');
+    await callbacks.start({ server });
+    callbacks.created({
+      compiler: { compilers: [web.compiler, node.compiler] },
+    });
+    callbacks.before();
+    const baseWeb = web.compile();
+    controller.captureWeb(baseWeb, {
+      'static/js/app': {
+        ...createDevManifest('web-base'),
+        routes: {
+          'routes/about': createRouteManifest('routes/about', [], [], {
+            hasClientLoader: false,
+          }),
+        },
+      },
+    });
+    web.complete(baseWeb);
+    const baseNode = node.compile();
+    await callbacks.after({ stats: createGraphStats(baseWeb, baseNode) });
+
+    callbacks.before();
+    const nextWeb = web.compile();
+    controller.captureWeb(nextWeb, {
+      'static/js/app': {
+        ...createDevManifest('web-next'),
+        routes: {
+          'routes/about': createRouteManifest('routes/about', [], [], {
+            hasClientLoader: true,
+            clientLoaderModule: '/routes/about.clientLoader.js',
+          }),
+        },
+      },
+    });
+    web.complete(nextWeb);
+    const nextNode = node.compile();
+    await callbacks.after({ stats: createGraphStats(nextWeb, nextNode) });
+
+    expect(server.sockWrite).toHaveBeenCalledWith('full-reload', {
       path: '*',
     });
   });

--- a/tests/dev-runtime-fixtures.ts
+++ b/tests/dev-runtime-fixtures.ts
@@ -59,13 +59,18 @@ export const createBuild = (
     ssr: true,
   }) as unknown as TestServerBuild;
 
+type RouteManifestOptions = Partial<
+  Omit<
+    ReactRouterDevManifest['routes'][string],
+    'css' | 'id' | 'imports' | 'module'
+  >
+> & { imports?: string[] };
+
 export const createRouteManifest = (
   id: string,
   css: string[],
-  options: Partial<ReactRouterDevManifest['routes'][string]> = {}
-): ReactRouterDevManifest['routes'][string] => {
-  const { imports = [], ...overrides } = options;
-  return {
+  { imports = [], ...overrides }: RouteManifestOptions = {}
+): ReactRouterDevManifest['routes'][string] => ({
     id,
     module: `/${id}.js`,
     hasAction: false,
@@ -78,8 +83,7 @@ export const createRouteManifest = (
     imports,
     css,
     ...overrides,
-  };
-};
+  });
 
 export type DevManifestCss = {
   entry?: string[];
@@ -107,6 +111,19 @@ export const createManifestSet = (
   css: DevManifestCss = {}
 ) => ({
   'static/js/app': createDevManifest(version, css),
+});
+
+export const createManifestSetWithRoute = (
+  version: string,
+  routeId: string,
+  route: RouteManifestOptions
+) => ({
+  'static/js/app': {
+    ...createDevManifest(version),
+    routes: {
+      [routeId]: createRouteManifest(routeId, [], route),
+    },
+  },
 });
 
 export const createCompilation = (

--- a/tests/dev-runtime-fixtures.ts
+++ b/tests/dev-runtime-fixtures.ts
@@ -59,10 +59,11 @@ export const createBuild = (
     ssr: true,
   }) as unknown as TestServerBuild;
 
-const createRouteManifest = (
+export const createRouteManifest = (
   id: string,
   css: string[],
-  imports: string[] = []
+  imports: string[] = [],
+  overrides: Partial<ReactRouterDevManifest['routes'][string]> = {}
 ): ReactRouterDevManifest['routes'][string] => ({
   id,
   module: `/${id}.js`,
@@ -75,6 +76,7 @@ const createRouteManifest = (
   hasErrorBoundary: false,
   imports,
   css,
+  ...overrides,
 });
 
 export type DevManifestCss = {

--- a/tests/dev-runtime-fixtures.ts
+++ b/tests/dev-runtime-fixtures.ts
@@ -62,22 +62,24 @@ export const createBuild = (
 export const createRouteManifest = (
   id: string,
   css: string[],
-  imports: string[] = [],
-  overrides: Partial<ReactRouterDevManifest['routes'][string]> = {}
-): ReactRouterDevManifest['routes'][string] => ({
-  id,
-  module: `/${id}.js`,
-  hasAction: false,
-  hasLoader: false,
-  hasClientAction: false,
-  hasClientLoader: false,
-  hasClientMiddleware: false,
-  hasDefaultExport: true,
-  hasErrorBoundary: false,
-  imports,
-  css,
-  ...overrides,
-});
+  options: Partial<ReactRouterDevManifest['routes'][string]> = {}
+): ReactRouterDevManifest['routes'][string] => {
+  const { imports = [], ...overrides } = options;
+  return {
+    id,
+    module: `/${id}.js`,
+    hasAction: false,
+    hasLoader: false,
+    hasClientAction: false,
+    hasClientLoader: false,
+    hasClientMiddleware: false,
+    hasDefaultExport: true,
+    hasErrorBoundary: false,
+    imports,
+    css,
+    ...overrides,
+  };
+};
 
 export type DevManifestCss = {
   entry?: string[];
@@ -95,7 +97,7 @@ export const createDevManifest = (
   routes: Object.fromEntries(
     Object.entries(css.routes ?? {}).map(([id, routeCss]) => [
       id,
-      createRouteManifest(id, routeCss, css.routeImports?.[id]),
+      createRouteManifest(id, routeCss, { imports: css.routeImports?.[id] }),
     ])
   ),
 });


### PR DESCRIPTION
## Summary
- detect dev route manifest metadata changes such as loader/clientLoader/export flag changes
- trigger a full browser reload for those changes instead of relying on a React Router Vite-only route HMR runtime
- add runtime and controller tests proving the reload path

## Validation
- `pnpm test:core`
- `pnpm build`
- `git diff --check`

## Notes
Stacked on `codex/asset-query-parity`. This intentionally chooses the conservative full-reload fallback because the Rsbuild plugin does not currently ship React Router's Vite route-HMR runtime.
