### PR TITLE
bench: measure large dev route loads

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,7 +2,6 @@ name: Benchmark
 
 on:
   pull_request:
-    branches: [main]
 
 permissions:
   contents: write
@@ -15,14 +14,16 @@ concurrency:
 
 jobs:
   benchmark:
-    name: Compare build benchmarks
+    name: Compare large dev benchmark
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
     env:
-      BENCHMARK_PROFILE: default
-      BENCHMARK_ITERATIONS: '5'
-      BENCHMARK_WARMUP: '1'
+      BENCHMARK_PROFILE: large
+      BENCHMARK_MODE: dev
+      BENCHMARK_ITERATIONS: '3'
+      BENCHMARK_WARMUP: '0'
+      BENCHMARK_DEV_ROUTES: auto
       BENCHMARK_HISTORY_BRANCH: benchmark-results
 
     steps:
@@ -87,8 +88,10 @@ jobs:
         run: |
           node "$GITHUB_WORKSPACE/head/scripts/bench-builds.mjs" \
             --profile "$BENCHMARK_PROFILE" \
+            --mode "$BENCHMARK_MODE" \
             --iterations "$BENCHMARK_ITERATIONS" \
             --warmup "$BENCHMARK_WARMUP" \
+            --dev-routes "$BENCHMARK_DEV_ROUTES" \
             --clean build \
             --format both \
             --out "$GITHUB_WORKSPACE/benchmark-output/base"
@@ -98,8 +101,10 @@ jobs:
         run: |
           node scripts/bench-builds.mjs \
             --profile "$BENCHMARK_PROFILE" \
+            --mode "$BENCHMARK_MODE" \
             --iterations "$BENCHMARK_ITERATIONS" \
             --warmup "$BENCHMARK_WARMUP" \
+            --dev-routes "$BENCHMARK_DEV_ROUTES" \
             --clean build \
             --format both \
             --out "$GITHUB_WORKSPACE/benchmark-output/head"

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -10,15 +10,50 @@ which is intentionally ignored.
 pnpm bench:smoke
 pnpm bench:baseline
 pnpm bench:full
+pnpm bench:large
 ```
 
 `bench:smoke` is a one-iteration sanity check. `bench:baseline` is the default
-comparison point for plugin performance work. `bench:full` adds larger route
-counts for stress testing.
+comparison point for plugin performance work. CI compares the `large` profile in
+dev mode, which measures both compiler readiness and representative route loads
+after the dev server is ready. `bench:full` adds larger route counts.
+`bench:large` runs a 355-route synthetic app with a broad source graph:
+generated modules, dynamic imports, workers, SVG assets, CSS modules, and large
+public locale payloads.
 
 All benchmark profiles generate deterministic synthetic React Router apps under
 `.benchmark/fixtures/`, build the current plugin package once, then run Rsbuild
-production builds against those fixtures.
+builds with plugin performance instrumentation disabled by default. Pass
+`--log-performance` when you need diagnostic `[react-router:performance]`
+operation reports.
+
+Pass `--mode dev` to measure dev-server startup readiness instead of production
+builds:
+
+```sh
+node scripts/bench-builds.mjs --profile=large --mode=dev --iterations=3 --warmup=0
+```
+
+Dev mode starts `rsbuild dev`, waits for the required compilers to print ready
+messages, then fetches representative routes before terminating the server. The
+JSON and markdown reports separate compiler `readyMs`, post-ready
+`routeTotalMs`, and total wall time. GNU time CPU/RSS collection and Rspack
+profile capture are build-mode features.
+
+By default, dev mode requests `/`, a stable sample of generated route paths, and
+the last route in the fixture. Use `--dev-routes=none` for readiness-only
+startup measurements, or pass a comma-separated list of route indexes or paths:
+
+```sh
+node scripts/bench-builds.mjs --profile=large --mode=dev --dev-routes=0,1,10,200
+node scripts/bench-builds.mjs --profile=large --mode=dev --dev-routes=/,/route-0001
+```
+
+Numeric route indexes are ordinal benchmark positions: `0` is `/`, and `1` is
+the first non-index generated route for that fixture.
+
+Route requests automatically add `--experimental-vm-modules` to `NODE_OPTIONS`
+for SSR ESM evaluation.
 
 To capture Rspack tracing output for a benchmark, pass `--rspack-profile`:
 
@@ -50,6 +85,9 @@ plugin paths that are expensive in large apps: per-route client entries,
 `?react-router-route` transforms, client-only stubbing, split-route detection,
 and manifest emission.
 
+The `large` profile keeps those plugin paths but stresses a wider source graph
+instead of only scaling route count.
+
 ## Outputs
 
 Each run writes:
@@ -57,10 +95,13 @@ Each run writes:
 - `.benchmark/results/<profile>/baseline.json`
 - `.benchmark/results/<profile>/baseline.md`
 
-The JSON includes wall time, optional GNU `/usr/bin/time -v` user/sys/RSS data,
-per-run exit status, and Rspack trace artifact paths when tracing is enabled.
-The markdown report summarizes the same benchmark-level timing and memory data
-without opening the raw JSON.
+The JSON includes wall time, dev-mode readiness and route request timings, and
+optional GNU `/usr/bin/time -v` user/sys/RSS data. Diagnostic runs with
+`--log-performance` also include parsed
+`[react-router:performance]` reports from the plugin and an aggregated
+`pluginOperations` table per fixture. The markdown report includes the same
+operation breakdown when instrumentation is enabled so route transforms and
+manifest work can be compared without opening the raw JSON.
 
 ## Hygiene
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "bench:smoke": "node scripts/bench-builds.mjs --profile smoke --iterations 1 --warmup 0 --format both --out .benchmark/results/smoke",
     "bench:baseline": "node scripts/bench-builds.mjs --profile default --iterations 5 --warmup 1 --clean build --format both --out .benchmark/results/baseline",
     "bench:full": "node scripts/bench-builds.mjs --profile full --iterations 5 --warmup 1 --clean build --format both --out .benchmark/results/full",
+    "bench:large": "node scripts/bench-builds.mjs --profile large --iterations 1 --warmup 0 --clean cold --format both --out .benchmark/results/large",
     "e2e": "pnpm build && pnpm --filter './examples/{default-template,spa-mode,prerender,custom-node-server,cloudflare,client-only}' test:e2e",
     "dev": "rslib build --watch",
     "test": "rstest run",

--- a/scripts/bench-builds.mjs
+++ b/scripts/bench-builds.mjs
@@ -8,6 +8,7 @@ import {
   rm,
   writeFile,
 } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
 import os from 'node:os';
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
@@ -44,6 +45,14 @@ const profiles = {
       sourceMap: true,
     },
   ],
+  ci: [
+    { id: 'synthetic-1024-ssr-esm', routeCount: 1024, variant: 'ssr-esm' },
+    {
+      id: 'synthetic-1024-ssr-esm-split',
+      routeCount: 1024,
+      variant: 'ssr-esm-split',
+    },
+  ],
   full: [
     { id: 'synthetic-48-ssr-esm', routeCount: 48, variant: 'ssr-esm' },
     { id: 'synthetic-256-ssr-esm', routeCount: 256, variant: 'ssr-esm' },
@@ -65,6 +74,15 @@ const profiles = {
       sourceMap: true,
     },
   ],
+  large: [
+    {
+      id: 'large-355-ssr-esm',
+      routeCount: 355,
+      variant: 'ssr-esm',
+      fixture: 'large',
+      devRoutePathOffset: 0,
+    },
+  ],
 };
 
 const parseArgs = argv => {
@@ -74,6 +92,7 @@ const parseArgs = argv => {
     strict: true,
     options: {
       profile: { type: 'string', default: 'default' },
+      mode: { type: 'string', default: 'build' },
       iterations: { type: 'string', default: '5' },
       warmup: { type: 'string', default: '1' },
       format: { type: 'string', default: 'both' },
@@ -88,6 +107,11 @@ const parseArgs = argv => {
       'rspack-trace-output': { type: 'string' },
       'fail-fast': { type: 'boolean', default: false },
       'skip-root-build': { type: 'boolean', default: false },
+      'log-performance': { type: 'boolean', default: false },
+      'dev-port-base': { type: 'string', default: '43000' },
+      'dev-timeout': { type: 'string', default: '120000' },
+      'dev-routes': { type: 'string', default: 'auto' },
+      'dev-route-timeout': { type: 'string', default: '30000' },
     },
   });
 
@@ -98,7 +122,10 @@ const parseArgs = argv => {
     if (value === 'false' || value === '0') {
       return false;
     }
-    if (value === 'true' || value === '1' || value === 'auto') {
+    if (value === 'auto') {
+      return undefined;
+    }
+    if (value === 'true' || value === '1') {
       return true;
     }
     const maxWorkers = Number(value);
@@ -112,6 +139,7 @@ const parseArgs = argv => {
 
   const args = {
     profile: values.profile,
+    mode: values.mode,
     iterations: Number(values.iterations),
     warmup: Number(values.warmup),
     format: values.format,
@@ -123,12 +151,20 @@ const parseArgs = argv => {
     rspackTraceOutput: values['rspack-trace-output'] ?? null,
     failFast: values['fail-fast'],
     skipRootBuild: values['skip-root-build'],
+    logPerformance: values['log-performance'],
+    devPortBase: Number(values['dev-port-base']),
+    devTimeoutMs: Number(values['dev-timeout']),
+    devRoutes: values['dev-routes'],
+    devRouteTimeoutMs: Number(values['dev-route-timeout']),
   };
 
   if (!profiles[args.profile]) {
     throw new Error(
-      `Unknown profile "${args.profile}". Use smoke, default, or full.`
+      `Unknown profile "${args.profile}". Use ${Object.keys(profiles).join(', ')}.`
     );
+  }
+  if (!['build', 'dev'].includes(args.mode)) {
+    throw new Error('--mode must be build or dev.');
   }
   if (!Number.isInteger(args.iterations) || args.iterations < 1) {
     throw new Error('--iterations must be a positive integer.');
@@ -148,6 +184,33 @@ const parseArgs = argv => {
   if (args.rspackTraceOutput !== null && args.rspackTraceOutput.trim() === '') {
     throw new Error('--rspack-trace-output must not be empty.');
   }
+  if (!Number.isInteger(args.devPortBase) || args.devPortBase < 1024) {
+    throw new Error('--dev-port-base must be an integer greater than 1023.');
+  }
+  if (!Number.isInteger(args.devTimeoutMs) || args.devTimeoutMs < 1000) {
+    throw new Error('--dev-timeout must be an integer of at least 1000 ms.');
+  }
+  if (args.devRoutes.trim() === '') {
+    throw new Error(
+      '--dev-routes must be auto, none, or a comma-separated list.'
+    );
+  }
+  if (
+    !Number.isInteger(args.devRouteTimeoutMs) ||
+    args.devRouteTimeoutMs < 1000
+  ) {
+    throw new Error(
+      '--dev-route-timeout must be an integer of at least 1000 ms.'
+    );
+  }
+  if (
+    args.mode === 'dev' &&
+    (args.rspackProfile !== null || args.rspackTraceOutput !== null)
+  ) {
+    throw new Error(
+      '--rspack-profile and --rspack-trace-output require --mode build.'
+    );
+  }
 
   return args;
 };
@@ -155,7 +218,12 @@ const parseArgs = argv => {
 const hasGnuTime = async () => {
   try {
     await access('/usr/bin/time');
-    return true;
+    const probe = await execa(
+      '/usr/bin/time',
+      ['-v', process.execPath, '-e', ''],
+      { reject: false }
+    );
+    return probe.exitCode === 0;
   } catch {
     return false;
   }
@@ -190,6 +258,261 @@ const runCommand = async ({
   };
 };
 
+const stripAnsi = value => value.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '');
+
+const defaultDevRouteIndexes = [0, 1, 2, 10, 50, 100, 200];
+
+const routePathForIndex = (index, { devRoutePathOffset = 1 }) => {
+  if (index === 0) {
+    return '/';
+  }
+  const routeNumber = index + devRoutePathOffset;
+  return `/route-${String(routeNumber).padStart(4, '0')}`;
+};
+
+const resolveAutoDevRoutePaths = benchmark =>
+  [...new Set([...defaultDevRouteIndexes, benchmark.routeCount - 1])]
+    .filter(
+      index =>
+        Number.isInteger(index) && index >= 0 && index < benchmark.routeCount
+    )
+    .map(index => routePathForIndex(index, benchmark));
+
+const normalizeDevRoutePath = (value, benchmark) => {
+  const trimmed = value.trim();
+  if (/^\d+$/.test(trimmed)) {
+    return routePathForIndex(Number(trimmed), benchmark);
+  }
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+};
+
+const resolveDevRoutePaths = (value, benchmark) => {
+  if (value === 'none') {
+    return [];
+  }
+  if (value === 'auto') {
+    return resolveAutoDevRoutePaths(benchmark);
+  }
+  const routePaths = [
+    ...new Set(
+      value
+        .split(',')
+        .map(routePath => routePath.trim())
+        .filter(Boolean)
+        .map(routePath => normalizeDevRoutePath(routePath, benchmark))
+    ),
+  ];
+  if (routePaths.length === 0) {
+    throw new Error('--dev-routes must include at least one route.');
+  }
+  return routePaths;
+};
+
+const appendNodeOption = (value, option) => {
+  const options = (value ?? '').split(/\s+/).filter(Boolean);
+  return options.includes(option)
+    ? options.join(' ')
+    : [...options, option].join(' ');
+};
+
+const fetchDevRoute = async ({ origin, routePath, timeoutMs }) => {
+  const startedAt = performance.now();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  timeout.unref?.();
+
+  try {
+    const response = await fetch(new URL(routePath, origin), {
+      signal: controller.signal,
+    });
+    const body = await response.arrayBuffer();
+    return {
+      path: routePath,
+      status: response.status,
+      ok: response.ok,
+      ms: performance.now() - startedAt,
+      bytes: body.byteLength,
+    };
+  } catch (error) {
+    return {
+      path: routePath,
+      status: null,
+      ok: false,
+      ms: performance.now() - startedAt,
+      bytes: null,
+      error:
+        error?.name === 'AbortError'
+          ? `Timed out after ${timeoutMs} ms`
+          : (error?.stack ?? error?.message ?? String(error)),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+const fetchDevRoutes = async ({ origin, routePaths, timeoutMs }) => {
+  const requests = [];
+  for (const routePath of routePaths) {
+    requests.push(await fetchDevRoute({ origin, routePath, timeoutMs }));
+  }
+  return requests;
+};
+
+const runDevServerUntilReady = async ({
+  command,
+  args,
+  cwd,
+  env = {},
+  readyEnvironments,
+  devRouteOrigin,
+  devRoutePaths = [],
+  devRouteTimeoutMs,
+  timeoutMs,
+}) =>
+  new Promise(resolve => {
+    const startedAt = performance.now();
+    const requiredReady = new Set(readyEnvironments);
+    const seenReady = new Set();
+    let stdout = '';
+    let stderr = '';
+    let ready = false;
+    let readyMs = null;
+    let routePhasePending = false;
+    let routeTotalMs = null;
+    let routeRequests = [];
+    let readyStatus = 0;
+    let timedOut = false;
+    let settled = false;
+    let stopping = false;
+    let killTimer = null;
+
+    const child = spawn(command, args, {
+      cwd,
+      detached: process.platform !== 'win32',
+      env: { ...process.env, ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const finish = (status, signal) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeoutTimer);
+      clearTimeout(killTimer);
+      resolve({
+        status,
+        signal,
+        stdout,
+        stderr,
+        wallMs: performance.now() - startedAt,
+        readyMs,
+        routeTotalMs,
+        routeRequests,
+        timedOut,
+      });
+    };
+
+    const signalChild = signal => {
+      if (child.exitCode !== null) {
+        return;
+      }
+      try {
+        if (process.platform === 'win32' || !child.pid) {
+          child.kill(signal);
+        } else {
+          process.kill(-child.pid, signal);
+        }
+      } catch (error) {
+        if (error?.code !== 'ESRCH') {
+          stderr += `${error.stack ?? error.message}\n`;
+        }
+      }
+    };
+
+    const stopChild = () => {
+      if (child.exitCode !== null || stopping) {
+        return;
+      }
+      stopping = true;
+      signalChild('SIGTERM');
+      killTimer = setTimeout(() => {
+        signalChild('SIGKILL');
+      }, 5_000);
+      killTimer.unref?.();
+    };
+
+    const handleReady = async () => {
+      readyMs = performance.now() - startedAt;
+      if (devRoutePaths.length > 0) {
+        routePhasePending = true;
+        const routeStartedAt = performance.now();
+        routeRequests = await fetchDevRoutes({
+          origin: devRouteOrigin,
+          routePaths: devRoutePaths,
+          timeoutMs: devRouteTimeoutMs,
+        });
+        routeTotalMs = performance.now() - routeStartedAt;
+        routePhasePending = false;
+        if (routeRequests.some(request => !request.ok)) {
+          readyStatus = 1;
+        }
+      }
+      stopChild();
+    };
+
+    const scanReady = () => {
+      if (ready) {
+        return;
+      }
+      const output = stripAnsi(`${stdout}\n${stderr}`);
+      for (const match of output.matchAll(
+        /ready\s+built in .*?\((web|node)\)/gi
+      )) {
+        seenReady.add(match[1].toLowerCase());
+      }
+      if ([...requiredReady].every(environment => seenReady.has(environment))) {
+        ready = true;
+        void handleReady();
+      }
+    };
+
+    child.stdout?.on('data', chunk => {
+      const text = String(chunk);
+      stdout += text;
+      process.stdout.write(text);
+      scanReady();
+    });
+    child.stderr?.on('data', chunk => {
+      const text = String(chunk);
+      stderr += text;
+      process.stderr.write(text);
+      scanReady();
+    });
+
+    const timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      stopChild();
+    }, timeoutMs);
+    timeoutTimer.unref?.();
+
+    child.on('error', error => {
+      stderr += `${error.stack ?? error.message}\n`;
+      finish(1, null);
+    });
+    child.on('exit', (code, signal) => {
+      if (ready) {
+        if (routePhasePending) {
+          finish(1, signal);
+          return;
+        }
+        finish(readyStatus, signal);
+        return;
+      }
+      finish(code ?? 1, signal);
+    });
+  });
+
 const parseTimeStats = stderr => {
   const user = stderr.match(/User time \(seconds\):\s*([\d.]+)/);
   const sys = stderr.match(/System time \(seconds\):\s*([\d.]+)/);
@@ -199,6 +522,26 @@ const parseTimeStats = stderr => {
     sysMs: sys ? Number(sys[1]) * 1000 : null,
     maxRssKb: rss ? Number(rss[1]) : null,
   };
+};
+
+const parsePluginReports = output => {
+  const reports = [];
+  for (const line of output.split(/\r?\n/)) {
+    const markerIndex = line.indexOf('[react-router:performance]');
+    if (markerIndex === -1) {
+      continue;
+    }
+    const jsonStart = line.indexOf('{', markerIndex);
+    if (jsonStart === -1) {
+      continue;
+    }
+    try {
+      reports.push(JSON.parse(line.slice(jsonStart)));
+    } catch {
+      // Keep raw build output useful even if one line is malformed.
+    }
+  }
+  return reports;
 };
 
 const summarizeMetric = values => {
@@ -226,13 +569,96 @@ const summarizeMetric = values => {
 
 const summarizeRuns = runs => ({
   wallMs: summarizeMetric(runs.map(run => run.wallMs)),
+  readyMs: summarizeMetric(runs.map(run => run.readyMs)),
+  routeTotalMs: summarizeMetric(runs.map(run => run.routeTotalMs)),
   userMs: summarizeMetric(runs.map(run => run.userMs)),
   sysMs: summarizeMetric(runs.map(run => run.sysMs)),
   maxRssKb: summarizeMetric(runs.map(run => run.maxRssKb)),
 });
 
+const summarizeDevRouteRequests = runs => {
+  const requestsByPath = new Map();
+  for (const run of runs) {
+    for (const request of run.routeRequests ?? []) {
+      const requests = requestsByPath.get(request.path) ?? [];
+      requests.push(request);
+      requestsByPath.set(request.path, requests);
+    }
+  }
+
+  return [...requestsByPath.entries()].map(([routePath, requests]) => {
+    const statuses = [
+      ...new Set(
+        requests.map(request =>
+          request.status === null ? 'error' : String(request.status)
+        )
+      ),
+    ].sort();
+    return {
+      path: routePath,
+      count: requests.length,
+      statuses,
+      failures: requests.filter(request => !request.ok).length,
+      ms: summarizeMetric(requests.map(request => request.ms)),
+      bytes: summarizeMetric(requests.map(request => request.bytes)),
+    };
+  });
+};
+
+const summarizePluginOperations = runs => {
+  const operations = new Map();
+
+  for (const run of runs) {
+    for (const report of run.pluginReports) {
+      for (const [operation, metrics] of Object.entries(
+        report.operations ?? {}
+      )) {
+        if (!metrics || typeof metrics !== 'object') {
+          continue;
+        }
+
+        const count = typeof metrics.count === 'number' ? metrics.count : 0;
+        const totalMs =
+          typeof metrics.totalMs === 'number' ? metrics.totalMs : 0;
+        const wallMs =
+          typeof metrics.wallMs === 'number' ? metrics.wallMs : null;
+        const maxMs = typeof metrics.maxMs === 'number' ? metrics.maxMs : 0;
+
+        const key = `${report.environment}:${operation}`;
+        const current = operations.get(key) ?? {
+          environment: report.environment,
+          operation,
+          count: 0,
+          totalMs: 0,
+          wallMs: null,
+          maxMs: 0,
+          reports: 0,
+        };
+        current.count += count;
+        current.totalMs += totalMs;
+        if (wallMs !== null) {
+          current.wallMs = (current.wallMs ?? 0) + wallMs;
+        }
+        current.maxMs = Math.max(current.maxMs, maxMs);
+        current.reports += 1;
+        operations.set(key, current);
+      }
+    }
+  }
+
+  return [...operations.values()].sort((a, b) => {
+    if (b.totalMs !== a.totalMs) {
+      return b.totalMs - a.totalMs;
+    }
+    return `${a.environment}:${a.operation}`.localeCompare(
+      `${b.environment}:${b.operation}`
+    );
+  });
+};
+
 const formatMs = value =>
   value == null ? '-' : `${(value / 1000).toFixed(2)}s`;
+const formatReportMs = value => (value == null ? '-' : `${value.toFixed(1)}ms`);
 const formatRss = value =>
   value == null ? '-' : `${Math.round(value / 1024)} MB`;
 
@@ -246,16 +672,24 @@ const renderMarkdown = result => {
     `- pnpm: ${result.pnpm}`,
     `- Platform: ${result.platform}`,
     `- Profile: ${result.profile}`,
+    `- Mode: ${result.mode}`,
     `- Iterations: ${result.iterations}`,
     `- Warmup: ${result.warmup}`,
+    ...(result.mode === 'dev'
+      ? [
+          `- Dev routes: ${result.devRoutes}`,
+          `- Dev route timeout: ${result.devRouteTimeoutMs} ms`,
+        ]
+      : []),
     `- Parallel transforms: ${formatParallelTransforms(result.parallelTransforms)}`,
+    `- Plugin performance logging: ${String(result.logPerformance)}`,
     `- Rspack profile: ${result.rspackProfile ?? 'false'}`,
     ...(result.rspackTraceOutput
       ? [`- Rspack trace output: ${result.rspackTraceOutput}`]
       : []),
     '',
-    '| Benchmark | Routes | Variant | Median wall | Mean wall | p95 wall | Max RSS |',
-    '|---|---:|---|---:|---:|---:|---:|',
+    '| Benchmark | Routes | Variant | Median ready | Median route load | Median wall | Mean wall | p95 wall | Max RSS | Plugin reports (--log-performance) |',
+    '|---|---:|---|---:|---:|---:|---:|---:|---:|---:|',
   ];
 
   for (const benchmark of result.benchmarks) {
@@ -264,15 +698,80 @@ const renderMarkdown = result => {
         benchmark.id,
         benchmark.routeCount,
         benchmark.variant,
+        formatMs(benchmark.summary.readyMs.median),
+        formatMs(benchmark.summary.routeTotalMs.median),
         formatMs(benchmark.summary.wallMs.median),
         formatMs(benchmark.summary.wallMs.mean),
         formatMs(benchmark.summary.wallMs.p95),
         formatRss(benchmark.summary.maxRssKb.p95),
+        benchmark.runs.reduce((sum, run) => sum + run.pluginReports.length, 0),
       ]
         .join(' | ')
         .replace(/^/, '| ')
         .replace(/$/, ' |')
     );
+  }
+
+  for (const benchmark of result.benchmarks) {
+    if (!benchmark.devRouteSummary?.length) {
+      continue;
+    }
+    lines.push(
+      '',
+      `## ${benchmark.id} Dev Route Requests`,
+      '',
+      '| Route | Median | Mean | p95 | Median bytes | Statuses | Failures |',
+      '|---|---:|---:|---:|---:|---|---:|'
+    );
+    for (const request of benchmark.devRouteSummary) {
+      lines.push(
+        [
+          `\`${request.path}\``,
+          formatMs(request.ms.median),
+          formatMs(request.ms.mean),
+          formatMs(request.ms.p95),
+          request.bytes.median == null
+            ? '-'
+            : String(Math.round(request.bytes.median)),
+          request.statuses.join(', '),
+          request.failures,
+        ]
+          .join(' | ')
+          .replace(/^/, '| ')
+          .replace(/$/, ' |')
+      );
+    }
+  }
+
+  for (const benchmark of result.benchmarks) {
+    if (benchmark.pluginOperations.length === 0) {
+      continue;
+    }
+    lines.push(
+      '',
+      `## ${benchmark.id} Plugin Operations`,
+      '',
+      'Total is the sum of all measured operation durations. Wall merges overlapping intervals to approximate elapsed plugin time. Max is the slowest single operation call.',
+      '',
+      '| Environment | Operation | Count | Total | Wall | Max | Reports |',
+      '|---|---|---:|---:|---:|---:|---:|'
+    );
+    for (const operation of benchmark.pluginOperations.slice(0, 12)) {
+      lines.push(
+        [
+          operation.environment,
+          operation.operation,
+          operation.count,
+          formatReportMs(operation.totalMs),
+          formatReportMs(operation.wallMs),
+          formatReportMs(operation.maxMs),
+          operation.reports,
+        ]
+          .join(' | ')
+          .replace(/^/, '| ')
+          .replace(/$/, ' |')
+      );
+    }
   }
 
   lines.push('');
@@ -330,7 +829,7 @@ const writeOutputs = async (result, outputPaths) => {
 
 const formatParallelTransforms = parallelTransforms => {
   if (parallelTransforms === undefined) {
-    return 'default';
+    return 'adaptive';
   }
   if (!parallelTransforms) {
     return 'false';
@@ -467,13 +966,18 @@ const main = async () => {
   }
 
   const benchmarks = [];
-  for (const benchmark of selectedBenchmarks) {
+  for (const [benchmarkIndex, benchmark] of selectedBenchmarks.entries()) {
     const fixtureRoot = path.join(benchmarkRoot, 'fixtures', benchmark.id);
-    await generateSyntheticFixture({
+    const devRoutePaths =
+      args.mode === 'dev'
+        ? resolveDevRoutePaths(args.devRoutes, benchmark)
+        : [];
+    const fixtureResult = await generateSyntheticFixture({
       root: fixtureRoot,
       routeCount: benchmark.routeCount,
       variant: benchmark.variant,
       sourceMap: benchmark.sourceMap ?? false,
+      fixture: benchmark.fixture ?? 'default',
       pluginImportPath,
       pluginReactImportPath,
       parallelTransforms: args.parallelTransforms,
@@ -496,31 +1000,77 @@ const main = async () => {
       console.log(
         `${measured ? 'Measuring' : 'Warming'} ${benchmark.id} (${index + 1}/${totalRuns})`
       );
-      const rspackProfileEnabled = Boolean(args.rspackProfile);
+      const rspackProfileEnabled =
+        args.mode === 'build' && Boolean(args.rspackProfile);
       const beforeRspackProfiles = rspackProfileEnabled
         ? await listRspackProfileDirs(fixtureRoot)
         : [];
       const runLabel = `${measured ? 'run' : 'warmup'}-${
         measured ? index - args.warmup + 1 : index + 1
       }`;
-      const rspackTraceOutput = await resolveRspackTraceOutput({
-        traceOutput: args.rspackTraceOutput,
-        benchmarkId: benchmark.id,
-        runLabel,
-      });
-      const commandResult = await runCommand({
-        command: process.execPath,
-        args: [rsbuildBin, 'build', '--config', 'rsbuild.config.mjs'],
-        cwd: fixtureRoot,
-        env: {
-          NODE_ENV: 'production',
-          ...(args.rspackProfile ? { RSPACK_PROFILE: args.rspackProfile } : {}),
-          ...(rspackTraceOutput
-            ? { RSPACK_TRACE_OUTPUT: rspackTraceOutput }
-            : {}),
-        },
-        useTime,
-      });
+      const rspackTraceOutput =
+        args.mode === 'build'
+          ? await resolveRspackTraceOutput({
+              traceOutput: args.rspackTraceOutput,
+              benchmarkId: benchmark.id,
+              runLabel,
+            })
+          : null;
+      const commonEnv = {
+        NODE_ENV: args.mode === 'build' ? 'production' : 'development',
+        ...(args.logPerformance
+          ? { REACT_ROUTER_BENCHMARK_LOG_PERFORMANCE: '1' }
+          : {}),
+      };
+      const commandResult =
+        args.mode === 'dev'
+          ? await (() => {
+              const devPort = args.devPortBase + benchmarkIndex * 100 + index;
+              return runDevServerUntilReady({
+                command: process.execPath,
+                args: [
+                  rsbuildBin,
+                  'dev',
+                  '--config',
+                  'rsbuild.config.mjs',
+                  '--port',
+                  String(devPort),
+                ],
+                cwd: fixtureRoot,
+                env: {
+                  ...commonEnv,
+                  ...(devRoutePaths.length > 0
+                    ? {
+                        NODE_OPTIONS: appendNodeOption(
+                          process.env.NODE_OPTIONS,
+                          '--experimental-vm-modules'
+                        ),
+                      }
+                    : {}),
+                },
+                readyEnvironments:
+                  benchmark.variant === 'spa' ? ['web'] : ['web', 'node'],
+                devRouteOrigin: `http://localhost:${devPort}`,
+                devRoutePaths,
+                devRouteTimeoutMs: args.devRouteTimeoutMs,
+                timeoutMs: args.devTimeoutMs,
+              });
+            })()
+          : await runCommand({
+              command: process.execPath,
+              args: [rsbuildBin, 'build', '--config', 'rsbuild.config.mjs'],
+              cwd: fixtureRoot,
+              env: {
+                ...commonEnv,
+                ...(args.rspackProfile
+                  ? { RSPACK_PROFILE: args.rspackProfile }
+                  : {}),
+                ...(rspackTraceOutput
+                  ? { RSPACK_TRACE_OUTPUT: rspackTraceOutput }
+                  : {}),
+              },
+              useTime,
+            });
       const rspackProfiles = rspackProfileEnabled
         ? await collectRspackProfiles({
             fixtureRoot,
@@ -533,7 +1083,14 @@ const main = async () => {
             ),
           })
         : [];
-      const timeStats = useTime ? parseTimeStats(commandResult.stderr) : {};
+      const timeStats =
+        args.mode === 'build' && useTime
+          ? parseTimeStats(commandResult.stderr)
+          : {};
+      const pluginReports = parsePluginReports(
+        `${commandResult.stdout}\n${commandResult.stderr}`
+      );
+
       if (commandResult.status !== 0 && args.failFast) {
         process.exit(commandResult.status ?? 1);
       }
@@ -542,9 +1099,13 @@ const main = async () => {
         runs.push({
           status: commandResult.status,
           wallMs: commandResult.wallMs,
+          readyMs: commandResult.readyMs ?? null,
+          routeTotalMs: commandResult.routeTotalMs ?? null,
+          routeRequests: commandResult.routeRequests ?? [],
           userMs: timeStats.userMs ?? null,
           sysMs: timeStats.sysMs ?? null,
           maxRssKb: timeStats.maxRssKb ?? null,
+          pluginReports,
           rspackProfiles,
           rspackTraceOutput:
             rspackTraceOutput && !isTraceOutputStream(rspackTraceOutput)
@@ -556,12 +1117,19 @@ const main = async () => {
 
     benchmarks.push({
       ...benchmark,
+      fixture: fixtureResult.fixture,
+      fixtureStats: fixtureResult.stats ?? null,
       parallelTransforms: args.parallelTransforms,
+      devRoutePaths,
       cwd: path.relative(rootDir, fixtureRoot),
       command:
-        'node <repo>/node_modules/@rsbuild/core/bin/rsbuild.js build --config rsbuild.config.mjs',
+        args.mode === 'dev'
+          ? 'node <repo>/node_modules/@rsbuild/core/bin/rsbuild.js dev --config rsbuild.config.mjs --port <port>'
+          : 'node <repo>/node_modules/@rsbuild/core/bin/rsbuild.js build --config rsbuild.config.mjs',
       runs,
       summary: summarizeRuns(runs),
+      devRouteSummary: summarizeDevRouteRequests(runs),
+      pluginOperations: summarizePluginOperations(runs),
     });
   }
 
@@ -576,8 +1144,13 @@ const main = async () => {
     pnpm: await pnpmVersion(),
     platform: `${os.platform()} ${os.release()} ${os.arch()}`,
     profile: args.profile,
+    mode: args.mode,
     iterations: args.iterations,
     warmup: args.warmup,
+    clean: args.clean,
+    logPerformance: args.logPerformance,
+    devRoutes: args.mode === 'dev' ? args.devRoutes : null,
+    devRouteTimeoutMs: args.mode === 'dev' ? args.devRouteTimeoutMs : null,
     parallelTransforms: args.parallelTransforms,
     rspackProfile: args.rspackProfile,
     rspackTraceOutput: args.rspackTraceOutput,

--- a/scripts/benchmark/fixture.mjs
+++ b/scripts/benchmark/fixture.mjs
@@ -16,9 +16,28 @@ export const benchmarkFixtureNames = [
   'reexports',
   'import-fanout',
   'chunk-saturated',
+  'large',
 ];
 
 const stressFixtureNames = new Set(benchmarkFixtureNames);
+
+export const largeFixtureConfig = Object.freeze({
+  seed: 8675309,
+  routes: 355,
+  componentsPerRoute: 18,
+  utilitiesPerRoute: 4,
+  lazyModulesPerRoute: 3,
+  workers: 120,
+  restrictedModules: 1187,
+  svgAssets: 1184,
+  cssModules: 217,
+  localeFiles: 111,
+  localeTotalBytes: 151289856,
+  payloadEntriesPerComponent: 72,
+  reactCompilerEvery: 3,
+  secretEvery: 7,
+  restrictedImportEvery: 6,
+});
 
 export const padRoute = number => String(number).padStart(4, '0');
 
@@ -259,6 +278,7 @@ const createRsbuildConfig = ({
     ...(ssr ? [`      serverOutput: 'module',`] : []),
     ...renderParallelTransformsOption(parallelTransforms),
     lazyCompilationOption,
+    `      logPerformance: process.env.REACT_ROUTER_BENCHMARK_LOG_PERFORMANCE === '1',`,
     '    }),',
     '  ],',
     '  output: {',
@@ -280,9 +300,7 @@ const createReactRouterConfig = variant => {
     '',
     'export default {',
     `  ssr: ${ssr ? 'true' : 'false'},`,
-    `  future: {`,
-    `    v8_splitRouteModules: ${splitRouteModules ? 'true' : 'false'},`,
-    '  },',
+    `  splitRouteModules: ${splitRouteModules ? 'true' : 'false'},`,
     '} satisfies Config;',
     '',
   ].join('\n');
@@ -355,6 +373,438 @@ const writeFanoutFixtures = async root => {
   );
 };
 
+const largeId = index => String(index).padStart(4, '0');
+const largePairId = index => String(index).padStart(2, '0');
+
+const normalizeLargeConfig = (routeCount, largeConfig = {}) => ({
+  ...largeFixtureConfig,
+  ...largeConfig,
+  routes: largeConfig.routes ?? routeCount ?? largeFixtureConfig.routes,
+});
+
+const createLargeStats = config => ({
+  codeModules:
+    config.routes *
+      (2 +
+        config.componentsPerRoute +
+        config.utilitiesPerRoute +
+        config.lazyModulesPerRoute) +
+    config.workers +
+    config.restrictedModules +
+    3,
+  dynamicImports: config.routes * config.lazyModulesPerRoute,
+  routes: config.routes,
+  components: config.routes * config.componentsPerRoute,
+  utilities: config.routes * config.utilitiesPerRoute,
+  lazyModules: config.routes * config.lazyModulesPerRoute,
+  workers: config.workers,
+  restrictedModules: config.restrictedModules,
+  svgAssets: config.svgAssets,
+  cssModules: config.cssModules,
+  localeFiles: config.localeFiles,
+  localeTotalBytes: config.localeTotalBytes,
+});
+
+const seededNumber = (seed, index) => {
+  let value = (seed + index * 1103515245 + 12345) >>> 0;
+  value ^= value << 13;
+  value ^= value >>> 17;
+  value ^= value << 5;
+  return value >>> 0;
+};
+
+const writeInBatches = async (items, writer, batchSize = 128) => {
+  for (let start = 0; start < items.length; start += batchSize) {
+    await Promise.all(items.slice(start, start + batchSize).map(writer));
+  }
+};
+
+const range = length => Array.from({ length }, (_, index) => index);
+
+const writeFiles = (files, batchSize) =>
+  writeInBatches(
+    files,
+    ([filePath, contents]) => writeFile(filePath, contents),
+    batchSize
+  );
+
+const createLargeRoutesConfig = routeCount => {
+  const routes = [];
+  for (let index = 0; index < routeCount; index += 1) {
+    const id = `route-${largeId(index)}`;
+    routes.push(
+      [
+        '  {',
+        `    id: '${id}',`,
+        `    file: 'generated/routes/${id}.tsx',`,
+        index === 0 ? '    index: true,' : `    path: '${id}',`,
+        '  },',
+      ].join('\n')
+    );
+  }
+
+  return [
+    `import type { RouteConfigEntry } from '@react-router/dev/routes';`,
+    '',
+    'export const generatedRoutes = [',
+    ...routes,
+    '] satisfies RouteConfigEntry[];',
+    '',
+    'export default generatedRoutes;',
+    '',
+  ].join('\n');
+};
+
+const createLargeRootModule = () =>
+  [
+    `import { createElement } from 'react';`,
+    `import { Links, Meta, Outlet, Scripts, ScrollRestoration } from 'react-router';`,
+    `export function Layout({ children }) {`,
+    `  return createElement('html', null, createElement('head', null, createElement(Meta), createElement(Links)), createElement('body', null, children, createElement(ScrollRestoration), createElement(Scripts)));`,
+    `}`,
+    `export default function Root() { return createElement(Outlet); }`,
+    `export function ErrorBoundary() { return createElement('main', null, 'Synthetic benchmark error'); }`,
+    '',
+  ].join('\n');
+
+const createLargeUtilityModule = ({ featureIndex, utilityIndex, config }) => {
+  const feature = largeId(featureIndex);
+  const utility = largePairId(utilityIndex);
+  const values = range(16).map(index =>
+    seededNumber(config.seed, featureIndex * 1000 + utilityIndex * 100 + index)
+  );
+
+  return [
+    `export const utility${feature}_${utility}Values = ${JSON.stringify(values)};`,
+    `export function utility${feature}_${utility}(input) {`,
+    `  return utility${feature}_${utility}Values.reduce((total, value, index) => total + ((value ^ input.length ^ index) % 997), 0);`,
+    `}`,
+    '',
+  ].join('\n');
+};
+
+const createLargeComponentModule = ({
+  featureIndex,
+  componentIndex,
+  config,
+}) => {
+  const feature = largeId(featureIndex);
+  const component = largePairId(componentIndex);
+  const cssIndex = largeId(
+    (featureIndex * config.componentsPerRoute + componentIndex) %
+      config.cssModules
+  );
+  const svgIndex = largeId(
+    (featureIndex * config.componentsPerRoute + componentIndex) %
+      config.svgAssets
+  );
+  const utilityIndex = componentIndex % config.utilitiesPerRoute;
+  const restrictedIndex =
+    (featureIndex * config.componentsPerRoute + componentIndex) %
+    config.restrictedModules;
+  const includeRestricted =
+    config.restrictedModules > 0 &&
+    (featureIndex * config.componentsPerRoute + componentIndex) %
+      config.restrictedImportEvery ===
+      0;
+  const payload = range(config.payloadEntriesPerComponent).map(
+    index =>
+      `'${feature}:${component}:${largePairId(index)}:${seededNumber(
+        config.seed,
+        featureIndex * 10000 + componentIndex * 100 + index
+      ).toString(36)}'`
+  );
+
+  return [
+    ...(featureIndex % config.reactCompilerEvery === 0 ? [`'use memo';`] : []),
+    `import styles from '../../../styles/style-${cssIndex}.module.css';`,
+    `import iconUrl from '../../../assets/icons/icon-${svgIndex}.svg';`,
+    `import { utility${feature}_${largePairId(utilityIndex)} } from '../utils/utility-${largePairId(utilityIndex)}';`,
+    ...(includeRestricted
+      ? [
+          `import { restrictedValue${largeId(restrictedIndex)} } from '../../../restricted/restricted-${largeId(restrictedIndex)}';`,
+        ]
+      : []),
+    '',
+    `const payload = [${payload.join(', ')}];`,
+    `const secretMarker = ${componentIndex % config.secretEvery === 0 ? `'synthetic-secret-${feature}-${component}'` : 'null'};`,
+    '',
+    `export function Card${feature}_${component}({ label = 'Feature ${feature}' }) {`,
+    `  const score = utility${feature}_${largePairId(utilityIndex)}(label);`,
+    includeRestricted
+      ? `  const restricted = restrictedValue${largeId(restrictedIndex)};`
+      : `  const restricted = '';`,
+    `  return (`,
+    `    <article className={styles.card} data-score={score} data-secret={secretMarker ?? undefined}>`,
+    `      <img src={iconUrl} alt="" />`,
+    `      <h2>{label}</h2>`,
+    `      <p>{payload[(score + restricted.length) % payload.length]}</p>`,
+    `    </article>`,
+    `  );`,
+    `}`,
+    '',
+  ].join('\n');
+};
+
+const createLargeShellModule = ({ featureIndex, config }) => {
+  const feature = largeId(featureIndex);
+  const imports = range(config.componentsPerRoute).map(
+    componentIndex =>
+      `import { Card${feature}_${largePairId(componentIndex)} } from './components/card-${largePairId(componentIndex)}';`
+  );
+  const cards = range(config.componentsPerRoute).map(
+    componentIndex =>
+      `      <Card${feature}_${largePairId(componentIndex)} key="${largePairId(componentIndex)}" label="Feature ${feature} card ${largePairId(componentIndex)}" />`
+  );
+
+  return [
+    ...imports,
+    '',
+    `export function FeatureShell${feature}() {`,
+    `  return (`,
+    `    <section data-feature="${feature}">`,
+    ...cards,
+    `    </section>`,
+    `  );`,
+    `}`,
+    '',
+  ].join('\n');
+};
+
+const createLargeLazyModule = ({ featureIndex, lazyIndex, config }) => {
+  const feature = largeId(featureIndex);
+  const lazy = largePairId(lazyIndex);
+  const values = range(24).map(index =>
+    seededNumber(config.seed, featureIndex * 1000 + lazyIndex * 100 + index)
+  );
+
+  return [
+    `export const lazyValue${feature}_${lazy} = ${JSON.stringify(values)};`,
+    `export function Lazy${feature}_${lazy}() { return null; }`,
+    '',
+  ].join('\n');
+};
+
+const createLargeRouteModule = ({ featureIndex, config, isSpa }) => {
+  const feature = largeId(featureIndex);
+  const workerIndex = largeId(featureIndex % config.workers);
+  const localeIndex = largeId(featureIndex % config.localeFiles);
+  const lazyImports = range(config.lazyModulesPerRoute).map(
+    lazyIndex =>
+      `import('../features/feature-${feature}/lazy/lazy-${largePairId(lazyIndex)}')`
+  );
+
+  return [
+    `import { FeatureShell${feature} } from '../features/feature-${feature}/shell';`,
+    '',
+    `const lazyModules = [${lazyImports.join(', ')}];`,
+    `const localeUrl = '/generated/locales/synthetic-${localeIndex}.json';`,
+    '',
+    `export const handle = { syntheticFeature: ${featureIndex}, category: 'benchmark' };`,
+    `export function meta() { return [{ title: 'Synthetic feature ${feature}' }]; }`,
+    `export function shouldRevalidate() { return false; }`,
+    `export async function clientLoader() {`,
+    `  const modules = await Promise.all(lazyModules);`,
+    `  if (typeof Worker !== 'undefined') {`,
+    `    const worker = new Worker(new URL('../workers/worker-${workerIndex}.ts', import.meta.url), { type: 'module' });`,
+    `    worker.terminate();`,
+    `  }`,
+    `  return { lazyCount: modules.length, localeUrl };`,
+    `}`,
+    ...(isSpa
+      ? []
+      : [
+          `export async function loader() { return { localeUrl }; }`,
+          `export function headers() { return { 'x-synthetic-route': '${feature}' }; }`,
+          `export function HydrateFallback() { return null; }`,
+        ]),
+    `export default function Route${feature}() { return <FeatureShell${feature} />; }`,
+    '',
+  ].join('\n');
+};
+
+const writeLargeLocaleFiles = async (root, config) => {
+  await mkdir(path.join(root, 'public/generated/locales'), { recursive: true });
+  const baseSize = Math.floor(config.localeTotalBytes / config.localeFiles);
+  const remainder = config.localeTotalBytes % config.localeFiles;
+
+  await writeInBatches(
+    range(config.localeFiles),
+    index => {
+      const id = largeId(index);
+      const targetSize = baseSize + (index < remainder ? 1 : 0);
+      const prefix = `{"id":"synthetic-${id}","messages":["`;
+      const suffix = `"]}\n`;
+      const payloadSize = Math.max(
+        0,
+        targetSize - Buffer.byteLength(prefix) - Buffer.byteLength(suffix)
+      );
+      return writeFile(
+        path.join(root, `public/generated/locales/synthetic-${id}.json`),
+        `${prefix}${'x'.repeat(payloadSize)}${suffix}`
+      );
+    },
+    8
+  );
+};
+
+const generateLargeFixture = async ({
+  root,
+  routeCount,
+  variant,
+  sourceMap,
+  pluginImportPath,
+  pluginReactImportPath,
+  parallelTransforms,
+  largeConfig,
+}) => {
+  const config = normalizeLargeConfig(routeCount, largeConfig);
+  const isSpa = variant === 'spa';
+  const generatedRoot = path.join(root, 'app/generated');
+
+  await rm(root, { recursive: true, force: true });
+  await Promise.all(
+    [
+      'assets/icons',
+      'features',
+      'restricted',
+      'routes',
+      'styles',
+      'workers',
+    ].map(directory =>
+      mkdir(path.join(generatedRoot, directory), { recursive: true })
+    )
+  );
+
+  await writeFiles([
+    [
+      path.join(root, 'package.json'),
+      JSON.stringify({ type: 'module', private: true }, null, 2),
+    ],
+    [
+      path.join(root, 'rsbuild.config.mjs'),
+      createRsbuildConfig({
+        variant,
+        sourceMap,
+        pluginImportPath,
+        pluginReactImportPath,
+        parallelTransforms,
+      }),
+    ],
+    [
+      path.join(root, 'react-router.config.ts'),
+      createReactRouterConfig(variant),
+    ],
+    [
+      path.join(root, 'app/routes.ts'),
+      `export { default } from './generated/route-config';\n`,
+    ],
+    [path.join(root, 'app/root.tsx'), createLargeRootModule()],
+    [
+      path.join(generatedRoot, 'route-config.ts'),
+      createLargeRoutesConfig(config.routes),
+    ],
+    [
+      path.join(generatedRoot, 'shared-types.ts'),
+      `export type SyntheticPayload = { id: string; score: number };\n`,
+    ],
+    [
+      path.join(generatedRoot, 'catalog.ts'),
+      `export const syntheticRouteCount = ${config.routes};\n`,
+    ],
+  ]);
+
+  await writeFiles(
+    range(config.svgAssets).map(index => [
+      path.join(generatedRoot, `assets/icons/icon-${largeId(index)}.svg`),
+      `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><path fill="#${seededNumber(config.seed, index).toString(16).slice(0, 6).padEnd(6, '0')}" d="M2 2h28v28H2z"/><path fill="#fff" d="M8 16h16v2H8z"/></svg>\n`,
+    ])
+  );
+
+  await writeFiles(
+    range(config.cssModules).map(index => [
+      path.join(generatedRoot, `styles/style-${largeId(index)}.module.css`),
+      `.card { display: grid; gap: 4px; padding: ${4 + (index % 5)}px; color: #1f2937; }\n.card img { width: 16px; height: 16px; }\n`,
+    ])
+  );
+
+  await writeFiles(
+    range(config.restrictedModules).map(index => [
+      path.join(generatedRoot, `restricted/restricted-${largeId(index)}.ts`),
+      `export const restrictedValue${largeId(index)} = 'restricted-${largeId(index)}';\n`,
+    ])
+  );
+
+  await writeFiles(
+    range(config.workers).map(index => [
+      path.join(generatedRoot, `workers/worker-${largeId(index)}.ts`),
+      `self.onmessage = event => { self.postMessage({ id: '${largeId(index)}', value: event.data }); };\n`,
+    ])
+  );
+
+  await writeInBatches(
+    range(config.routes),
+    async featureIndex => {
+      const feature = largeId(featureIndex);
+      const featureRoot = path.join(
+        generatedRoot,
+        `features/feature-${feature}`
+      );
+      await Promise.all([
+        mkdir(path.join(featureRoot, 'components'), { recursive: true }),
+        mkdir(path.join(featureRoot, 'lazy'), { recursive: true }),
+        mkdir(path.join(featureRoot, 'utils'), { recursive: true }),
+      ]);
+
+      await writeFiles([
+        [
+          path.join(featureRoot, 'shell.tsx'),
+          createLargeShellModule({ featureIndex, config }),
+        ],
+        [
+          path.join(generatedRoot, `routes/route-${feature}.tsx`),
+          createLargeRouteModule({ featureIndex, config, isSpa }),
+        ],
+        ...range(config.utilitiesPerRoute).map(utilityIndex => [
+          path.join(
+            featureRoot,
+            `utils/utility-${largePairId(utilityIndex)}.ts`
+          ),
+          createLargeUtilityModule({ featureIndex, utilityIndex, config }),
+        ]),
+        ...range(config.componentsPerRoute).map(componentIndex => [
+          path.join(
+            featureRoot,
+            `components/card-${largePairId(componentIndex)}.tsx`
+          ),
+          createLargeComponentModule({
+            featureIndex,
+            componentIndex,
+            config,
+          }),
+        ]),
+        ...range(config.lazyModulesPerRoute).map(lazyIndex => [
+          path.join(featureRoot, `lazy/lazy-${largePairId(lazyIndex)}.tsx`),
+          createLargeLazyModule({ featureIndex, lazyIndex, config }),
+        ]),
+      ]);
+    },
+    24
+  );
+
+  await writeLargeLocaleFiles(root, config);
+
+  return {
+    root,
+    routeCount: config.routes,
+    variant,
+    sourceMap,
+    fixture: 'large',
+    parallelTransforms,
+    stats: createLargeStats(config),
+  };
+};
+
 export async function generateSyntheticFixture({
   root,
   routeCount,
@@ -364,11 +814,25 @@ export async function generateSyntheticFixture({
   pluginReactImportPath = '@rsbuild/plugin-react',
   fixture = 'default',
   parallelTransforms,
+  largeConfig,
 }) {
   if (!stressFixtureNames.has(fixture)) {
     throw new Error(
       `Unknown benchmark fixture "${fixture}". Use ${benchmarkFixtureNames.join(', ')}.`
     );
+  }
+
+  if (fixture === 'large') {
+    return generateLargeFixture({
+      root,
+      routeCount,
+      variant,
+      sourceMap,
+      pluginImportPath,
+      pluginReactImportPath,
+      parallelTransforms,
+      largeConfig,
+    });
   }
 
   const isSpa = variant === 'spa';

--- a/scripts/report-benchmark-ci.mjs
+++ b/scripts/report-benchmark-ci.mjs
@@ -48,6 +48,9 @@ const speedup = (base, head) =>
     : null;
 
 const medianWall = benchmark => benchmark?.summary?.wallMs?.median ?? null;
+const medianReady = benchmark => benchmark?.summary?.readyMs?.median ?? null;
+const medianRouteTotal = benchmark =>
+  benchmark?.summary?.routeTotalMs?.median ?? null;
 const p95Rss = benchmark => benchmark?.summary?.maxRssKb?.p95 ?? null;
 const cpuMedian = benchmark => {
   const user = benchmark?.summary?.userMs?.median;
@@ -75,12 +78,20 @@ const benchmarks = benchmarkIds.map(id => {
   const headBenchmark = headBenchmarks.get(id);
   const baseWallMs = medianWall(baseBenchmark);
   const headWallMs = medianWall(headBenchmark);
+  const baseReadyMs = medianReady(baseBenchmark);
+  const headReadyMs = medianReady(headBenchmark);
+  const baseRouteTotalMs = medianRouteTotal(baseBenchmark);
+  const headRouteTotalMs = medianRouteTotal(headBenchmark);
   return {
     id,
     routeCount: headBenchmark?.routeCount ?? baseBenchmark?.routeCount ?? null,
     variant: headBenchmark?.variant ?? baseBenchmark?.variant ?? null,
     baseWallMs,
     headWallMs,
+    baseReadyMs,
+    headReadyMs,
+    baseRouteTotalMs,
+    headRouteTotalMs,
     wallDeltaPercent: percentDelta(baseWallMs, headWallMs),
     wallSpeedup: speedup(baseWallMs, headWallMs),
     baseCpuMs: cpuMedian(baseBenchmark),
@@ -90,20 +101,36 @@ const benchmarks = benchmarkIds.map(id => {
   };
 });
 
-const totalBaseWallMs = benchmarks.reduce(
-  (sum, benchmark) => sum + (benchmark.baseWallMs ?? 0),
-  0
-);
-const totalHeadWallMs = benchmarks.reduce(
-  (sum, benchmark) => sum + (benchmark.headWallMs ?? 0),
-  0
-);
+const sumMetric = (benchmarks, key) => {
+  const values = benchmarks
+    .map(benchmark => benchmark[key])
+    .filter(value => typeof value === 'number');
+  return values.length === 0
+    ? null
+    : values.reduce((sum, value) => sum + value, 0);
+};
+
+const totalBaseWallMs = sumMetric(benchmarks, 'baseWallMs');
+const totalHeadWallMs = sumMetric(benchmarks, 'headWallMs');
+const totalBaseReadyMs = sumMetric(benchmarks, 'baseReadyMs');
+const totalHeadReadyMs = sumMetric(benchmarks, 'headReadyMs');
+const totalBaseRouteTotalMs = sumMetric(benchmarks, 'baseRouteTotalMs');
+const totalHeadRouteTotalMs = sumMetric(benchmarks, 'headRouteTotalMs');
 
 const summary = {
   baseWallMs: totalBaseWallMs,
   headWallMs: totalHeadWallMs,
+  baseReadyMs: totalBaseReadyMs,
+  headReadyMs: totalHeadReadyMs,
+  baseRouteTotalMs: totalBaseRouteTotalMs,
+  headRouteTotalMs: totalHeadRouteTotalMs,
   wallDeltaPercent: percentDelta(totalBaseWallMs, totalHeadWallMs),
   wallSpeedup: speedup(totalBaseWallMs, totalHeadWallMs),
+  readyDeltaPercent: percentDelta(totalBaseReadyMs, totalHeadReadyMs),
+  routeTotalDeltaPercent: percentDelta(
+    totalBaseRouteTotalMs,
+    totalHeadRouteTotalMs
+  ),
 };
 
 const report = {
@@ -121,6 +148,7 @@ const report = {
   },
   runUrl: values['run-url'] ?? null,
   profile: head.profile ?? base.profile ?? null,
+  mode: head.mode ?? base.mode ?? 'build',
   iterations: head.iterations ?? base.iterations ?? null,
   warmup: head.warmup ?? base.warmup ?? null,
   summary,
@@ -135,20 +163,26 @@ const renderComment = () => {
     `Compared PR head \`${report.head.sha?.slice(0, 7) ?? 'unknown'}\` against base \`${report.base.sha?.slice(0, 7) ?? 'unknown'}\`.`,
     '',
     `**Total median wall time:** ${formatSeconds(summary.baseWallMs)} -> ${formatSeconds(summary.headWallMs)} (${formatPercent(summary.wallDeltaPercent)}, ${formatSpeedup(summary.wallSpeedup)} speedup)`,
+    ...(report.mode === 'dev'
+      ? [
+          `**Compiler ready median:** ${formatSeconds(summary.baseReadyMs)} -> ${formatSeconds(summary.headReadyMs)} (${formatPercent(summary.readyDeltaPercent)})`,
+          `**Route load median:** ${formatSeconds(summary.baseRouteTotalMs)} -> ${formatSeconds(summary.headRouteTotalMs)} (${formatPercent(summary.routeTotalDeltaPercent)})`,
+        ]
+      : []),
     '',
-    '| Benchmark | Base | Head | Delta | Speedup | Head RSS p95 |',
-    '|---|---:|---:|---:|---:|---:|',
+    '| Benchmark | Base total | Head total | Delta | Head ready | Head routes | Speedup | Head RSS p95 |',
+    '|---|---:|---:|---:|---:|---:|---:|---:|',
   ];
 
   for (const benchmark of benchmarks) {
     lines.push(
-      `| \`${benchmark.id}\` | ${formatSeconds(benchmark.baseWallMs)} | ${formatSeconds(benchmark.headWallMs)} | ${formatPercent(benchmark.wallDeltaPercent)} | ${formatSpeedup(benchmark.wallSpeedup)} | ${formatRss(benchmark.headRssKb)} |`
+      `| \`${benchmark.id}\` | ${formatSeconds(benchmark.baseWallMs)} | ${formatSeconds(benchmark.headWallMs)} | ${formatPercent(benchmark.wallDeltaPercent)} | ${formatSeconds(benchmark.headReadyMs)} | ${formatSeconds(benchmark.headRouteTotalMs)} | ${formatSpeedup(benchmark.wallSpeedup)} | ${formatRss(benchmark.headRssKb)} |`
     );
   }
 
   lines.push(
     '',
-    `Profile: \`${report.profile ?? 'unknown'}\`; iterations: \`${report.iterations ?? 'unknown'}\`; warmup: \`${report.warmup ?? 'unknown'}\`.`,
+    `Profile: \`${report.profile ?? 'unknown'}\`; mode: \`${report.mode ?? 'unknown'}\`; iterations: \`${report.iterations ?? 'unknown'}\`; warmup: \`${report.warmup ?? 'unknown'}\`.`,
     ...(report.runUrl ? [`[Workflow run](${report.runUrl})`] : []),
     ''
   );

--- a/tests/benchmark-fixture.test.ts
+++ b/tests/benchmark-fixture.test.ts
@@ -1,0 +1,372 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { describe, expect, it } from '@rstest/core';
+
+describe('benchmark fixture generator', () => {
+  it('creates a deterministic synthetic React Router app', async () => {
+    const { generateSyntheticFixture } = await import(
+      '../scripts/benchmark/fixture.mjs'
+    );
+    const root = mkdtempSync(join(tmpdir(), 'rr-benchmark-fixture-'));
+
+    try {
+      const result = await generateSyntheticFixture({
+        root,
+        routeCount: 8,
+        variant: 'ssr-esm-split',
+        sourceMap: true,
+      });
+
+      expect(result.routeCount).toBe(8);
+      expect(result.variant).toBe('ssr-esm-split');
+      expect(existsSync(join(root, 'app/routes.ts'))).toBe(true);
+      expect(existsSync(join(root, 'rsbuild.config.mjs'))).toBe(true);
+
+      const routeConfig = readFileSync(join(root, 'app/routes.ts'), 'utf8');
+      expect(routeConfig).toContain("id: 'route-0001'");
+      expect(routeConfig).toContain("file: 'routes/route-0001.tsx'");
+      expect(routeConfig).toContain("id: 'route-0008'");
+      expect(existsSync(join(root, 'app/routes/route-0008.tsx'))).toBe(true);
+
+      const routeModule = readFileSync(
+        join(root, 'app/routes/route-0003.tsx'),
+        'utf8'
+      );
+      expect(routeModule).toContain('export async function clientLoader');
+      expect(routeModule).toContain('export default function Route0003');
+
+      const rsbuildConfig = readFileSync(join(root, 'rsbuild.config.mjs'), 'utf8');
+      expect(rsbuildConfig).toContain(
+        "import { pluginReact } from '@rsbuild/plugin-react';"
+      );
+      expect(rsbuildConfig).toContain('pluginReact(),');
+      expect(rsbuildConfig.indexOf('pluginReact(),')).toBeLessThan(
+        rsbuildConfig.indexOf('pluginReactRouter({')
+      );
+      expect(rsbuildConfig).toContain('logPerformance');
+      expect(rsbuildConfig).toContain(
+        "sourceMap: { js: 'cheap-module-source-map', css: false }"
+      );
+      expect(rsbuildConfig).not.toContain('parallelTransforms:');
+
+      const reactRouterConfig = readFileSync(
+        join(root, 'react-router.config.ts'),
+        'utf8'
+      );
+      expect(reactRouterConfig).toContain('splitRouteModules: true');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('can point the benchmark config at an explicit built plugin import', async () => {
+    const { generateSyntheticFixture } = await import(
+      '../scripts/benchmark/fixture.mjs'
+    );
+    const root = mkdtempSync(join(tmpdir(), 'rr-benchmark-fixture-'));
+
+    try {
+      await generateSyntheticFixture({
+        root,
+        routeCount: 1,
+        variant: 'ssr-esm',
+        pluginImportPath: 'file:///repo/dist/index.js',
+      });
+
+      const rsbuildConfig = readFileSync(join(root, 'rsbuild.config.mjs'), 'utf8');
+      expect(rsbuildConfig).toContain(
+        "import { pluginReactRouter } from 'file:///repo/dist/index.js';"
+      );
+      expect(rsbuildConfig).toContain("serverOutput: 'module'");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('can enable parallel route transforms in benchmark config', async () => {
+    const { generateSyntheticFixture } = await import(
+      '../scripts/benchmark/fixture.mjs'
+    );
+    const root = mkdtempSync(join(tmpdir(), 'rr-benchmark-fixture-'));
+
+    try {
+      const result = await generateSyntheticFixture({
+        root,
+        routeCount: 1,
+        variant: 'ssr-esm',
+        parallelTransforms: { maxWorkers: 3 },
+      });
+
+      const rsbuildConfig = readFileSync(join(root, 'rsbuild.config.mjs'), 'utf8');
+      expect(result.parallelTransforms).toEqual({ maxWorkers: 3 });
+      expect(rsbuildConfig).toContain(
+        'parallelTransforms: { maxWorkers: 3 },'
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('can explicitly disable parallel route transforms in benchmark config', async () => {
+    const { generateSyntheticFixture } = await import(
+      '../scripts/benchmark/fixture.mjs'
+    );
+    const root = mkdtempSync(join(tmpdir(), 'rr-benchmark-fixture-'));
+
+    try {
+      const result = await generateSyntheticFixture({
+        root,
+        routeCount: 1,
+        variant: 'ssr-esm',
+        parallelTransforms: false,
+      });
+
+      const rsbuildConfig = readFileSync(join(root, 'rsbuild.config.mjs'), 'utf8');
+      expect(result.parallelTransforms).toBe(false);
+      expect(rsbuildConfig).toContain('parallelTransforms: false,');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('omits server-only route exports from SPA benchmark fixtures', async () => {
+    const { generateSyntheticFixture } = await import(
+      '../scripts/benchmark/fixture.mjs'
+    );
+    const root = mkdtempSync(join(tmpdir(), 'rr-benchmark-fixture-'));
+
+    try {
+      await generateSyntheticFixture({
+        root,
+        routeCount: 8,
+        variant: 'spa',
+      });
+
+      const rootModule = readFileSync(join(root, 'app/root.tsx'), 'utf8');
+      expect(rootModule).toContain('Scripts');
+
+      for (let index = 1; index <= 8; index += 1) {
+        const routeModule = readFileSync(
+          join(root, `app/routes/route-${String(index).padStart(4, '0')}.tsx`),
+          'utf8'
+        );
+        expect(routeModule).not.toContain('function loader');
+        expect(routeModule).not.toContain('function action');
+        expect(routeModule).not.toContain('function headers');
+        expect(routeModule).not.toContain('HydrateFallback');
+        expect(routeModule).not.toContain('server-data.server');
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('generates deterministic named stress fixture shapes', async () => {
+    const { benchmarkFixtureNames, generateSyntheticFixture } = await import(
+      '../scripts/benchmark/fixture.mjs'
+    );
+    expect(benchmarkFixtureNames).toEqual([
+      'default',
+      'export-heavy',
+      'reexports',
+      'import-fanout',
+      'chunk-saturated',
+      'large',
+    ]);
+
+    const expectations = [
+      {
+        fixture: 'export-heavy',
+        routeFile: 'app/routes/route-0001.tsx',
+        snippets: ['unusedExport0001_31', 'export async function clientLoader'],
+      },
+      {
+        fixture: 'reexports',
+        routeFile: 'app/routes/route-0001.tsx',
+        snippets: [
+          "export * from '../route-reexports/reexport-all-0001'",
+          'app/route-reexports/reexport-0001.ts',
+        ],
+      },
+      {
+        fixture: 'import-fanout',
+        routeFile: 'app/routes/route-0001.tsx',
+        snippets: ["from '../fanout/fanout-15'", 'fanoutValues'],
+      },
+      {
+        fixture: 'chunk-saturated',
+        routeFile: 'app/routes/route-0001.tsx',
+        snippets: ['export async function clientAction', 'HydrateFallback'],
+      },
+    ];
+
+    for (const { fixture, routeFile, snippets } of expectations) {
+      const rootA = mkdtempSync(join(tmpdir(), 'rr-benchmark-fixture-a-'));
+      const rootB = mkdtempSync(join(tmpdir(), 'rr-benchmark-fixture-b-'));
+
+      try {
+        const result = await generateSyntheticFixture({
+          root: rootA,
+          routeCount: 4,
+          variant: 'ssr-esm-split',
+          fixture,
+        });
+        await generateSyntheticFixture({
+          root: rootB,
+          routeCount: 4,
+          variant: 'ssr-esm-split',
+          fixture,
+        });
+
+        expect(result.fixture).toBe(fixture);
+        const routeModuleA = readFileSync(join(rootA, routeFile), 'utf8');
+        const routeModuleB = readFileSync(join(rootB, routeFile), 'utf8');
+        expect(routeModuleA).toBe(routeModuleB);
+
+        for (const snippet of snippets) {
+          if (snippet.startsWith('app/')) {
+            expect(existsSync(join(rootA, snippet))).toBe(true);
+          } else {
+            expect(routeModuleA).toContain(snippet);
+          }
+        }
+      } finally {
+        rmSync(rootA, { recursive: true, force: true });
+        rmSync(rootB, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('generates the large synthetic app shape and statistics', async () => {
+    const { generateSyntheticFixture } = await import(
+      '../scripts/benchmark/fixture.mjs'
+    );
+    const root = mkdtempSync(join(tmpdir(), 'rr-benchmark-large-'));
+
+    try {
+      const result = await generateSyntheticFixture({
+        root,
+        routeCount: 2,
+        variant: 'ssr-esm',
+        fixture: 'large',
+        largeConfig: {
+          routes: 2,
+          componentsPerRoute: 2,
+          utilitiesPerRoute: 1,
+          lazyModulesPerRoute: 1,
+          workers: 2,
+          restrictedModules: 2,
+          svgAssets: 2,
+          cssModules: 2,
+          localeFiles: 2,
+          localeTotalBytes: 2048,
+          payloadEntriesPerComponent: 4,
+          reactCompilerEvery: 2,
+          secretEvery: 2,
+          restrictedImportEvery: 2,
+        },
+      });
+
+      expect(result.fixture).toBe('large');
+      expect(result.routeCount).toBe(2);
+      expect(result.stats).toEqual({
+        codeModules: 19,
+        dynamicImports: 2,
+        routes: 2,
+        components: 4,
+        utilities: 2,
+        lazyModules: 2,
+        workers: 2,
+        restrictedModules: 2,
+        svgAssets: 2,
+        cssModules: 2,
+        localeFiles: 2,
+        localeTotalBytes: 2048,
+      });
+      expect(existsSync(join(root, 'app/generated/route-config.ts'))).toBe(
+        true
+      );
+      expect(
+        existsSync(join(root, 'app/generated/routes/route-0000.tsx'))
+      ).toBe(true);
+      expect(
+        existsSync(
+          join(root, 'app/generated/features/feature-0000/components/card-00.tsx')
+        )
+      ).toBe(true);
+      expect(
+        existsSync(join(root, 'app/generated/features/feature-0001/lazy/lazy-00.tsx'))
+      ).toBe(true);
+      expect(
+        existsSync(join(root, 'app/generated/styles/style-0000.module.css'))
+      ).toBe(true);
+      expect(
+        existsSync(join(root, 'public/generated/locales/synthetic-0001.json'))
+      ).toBe(true);
+
+      const routeModule = readFileSync(
+        join(root, 'app/generated/routes/route-0000.tsx'),
+        'utf8'
+      );
+      expect(routeModule).toContain(
+        "import { FeatureShell0000 } from '../features/feature-0000/shell';"
+      );
+      expect(routeModule).toContain(
+        "import('../features/feature-0000/lazy/lazy-00')"
+      );
+      expect(routeModule).toContain(
+        "new Worker(new URL('../workers/worker-0000.ts', import.meta.url)"
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts equals-form CLI options before benchmark selection', () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        'scripts/bench-builds.mjs',
+        '--profile=smoke',
+        '--iterations=1',
+        '--warmup=0',
+        '--filter=missing',
+        '--rspack-profile=ALL',
+        '--rspack-trace-output=rspack.log',
+        '--skip-root-build',
+      ],
+      {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+      }
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('No benchmarks matched filter "missing".');
+    expect(result.stderr).not.toContain('Unknown benchmark argument');
+  });
+
+  it('accepts the large benchmark profile in the CLI', () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        'scripts/bench-builds.mjs',
+        '--profile=large',
+        '--iterations=1',
+        '--warmup=0',
+        '--filter=missing',
+        '--skip-root-build',
+      ],
+      {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+      }
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('No benchmarks matched filter "missing".');
+    expect(result.stderr).not.toContain('Unknown profile "large"');
+  });
+});


### PR DESCRIPTION
## Summary
- Run benchmark CI on all PR bases, including stacked PRs.
- Measure large dev compiler readiness and post-ready route loads separately.
- Add the large synthetic fixture and focused fixture coverage.

## Verification
- `node --check scripts/bench-builds.mjs && node --check scripts/report-benchmark-ci.mjs`
- `pnpm exec prettier --check .github/workflows/benchmark.yml benchmarks/README.md package.json scripts/bench-builds.mjs scripts/benchmark/fixture.mjs scripts/report-benchmark-ci.mjs tests/benchmark-fixture.test.ts`
- `pnpm test:core tests/benchmark-fixture.test.ts`
- `node scripts/bench-builds.mjs --profile smoke --mode dev --iterations 1 --warmup 0 --clean build --format both --out .benchmark/results/dev-route-smoke-main --skip-root-build --dev-port-base 44000`
- `node scripts/bench-builds.mjs --profile large --mode dev --iterations 1 --warmup 0 --clean build --format both --out .benchmark/results/dev-large-routes-main --skip-root-build --dev-port-base 44100`