### PR TITLE
fix: support stable subresource integrity config

### DIFF
--- a/.changeset/stable-subresource-integrity.md
+++ b/.changeset/stable-subresource-integrity.md
@@ -1,0 +1,7 @@
+---
+'rsbuild-plugin-react-router': patch
+---
+
+Support React Router's stable `subResourceIntegrity` config and keep it in sync
+with `future.unstable_subResourceIntegrity` when merging presets and user
+configuration.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ export default {
   serverBundles: async ({ branch }) => branch[0]?.id ?? "main",
 
   /**
+   * Enable Subresource Integrity for browser assets.
+   * @default false
+   */
+  subResourceIntegrity: true,
+
+  /**
    * Hook called after the build completes.
    */
   buildEnd: async ({ buildManifest, reactRouterConfig }) => {
@@ -283,9 +289,16 @@ If no configuration is provided, the following defaults will be used:
   ssr: true,
   buildDirectory: 'build',
   appDirectory: 'app',
-  basename: '/'
+  basename: '/',
+  subResourceIntegrity: false
 }
 ```
+
+Subresource Integrity is disabled by default. Enable it with
+`subResourceIntegrity: true` in `react-router.config.*` when the deployed app
+should emit integrity metadata for browser scripts. The legacy
+`future.unstable_subResourceIntegrity` flag is still accepted and is normalized
+to the stable option.
 
 ### Route Configuration
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -493,9 +493,9 @@ export const pluginReactRouter = (
 
     let clientStats: Rspack.StatsCompilation | undefined;
     let clientSri: Record<string, string> | undefined;
-    let resolveClientStatsReady:
-      | ((stats: Rspack.StatsCompilation | undefined) => void)
-      | undefined;
+    let resolveClientStatsReady: (
+      stats: Rspack.StatsCompilation | undefined
+    ) => void = () => {};
     let clientStatsReadyResolved = false;
     const clientStatsReady = new Promise<Rspack.StatsCompilation | undefined>(
       resolve => {
@@ -509,16 +509,15 @@ export const pluginReactRouter = (
         return;
       }
       clientStatsReadyResolved = true;
-      resolveClientStatsReady?.(stats);
+      resolveClientStatsReady(stats);
     };
     const toClientManifestStats = (
       stats: Rspack.Stats | undefined
-    ): Rspack.StatsCompilation | undefined => {
-      return stats?.toJson({
+    ): Rspack.StatsCompilation | undefined =>
+      stats?.toJson({
         all: false,
         assets: true,
       });
-    };
 
     api.onAfterEnvironmentCompile(({ stats, environment }) => {
       if (environment.name === 'web') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,10 @@ import {
   getReactRouterManifestForDev,
   configRoutesToRouteManifest,
 } from './manifest.js';
-import { createModifyBrowserManifestPlugin } from './modify-browser-manifest.js';
+import {
+  collectSubresourceIntegrity,
+  createModifyBrowserManifestPlugin,
+} from './modify-browser-manifest.js';
 import { createRequestHandler, matchRoutes } from 'react-router';
 import {
   getExportNames,
@@ -408,6 +411,27 @@ export const pluginReactRouter = (
     let latestServerManifest: ReactRouterManifest | null = null;
     const latestServerManifestsByBundleId: Record<string, ReactRouterManifest> =
       {};
+    const updateLatestServerManifestSri = (
+      sri: Record<string, string> | undefined
+    ) => {
+      if (!latestServerManifest) {
+        return;
+      }
+
+      latestServerManifest = {
+        ...latestServerManifest,
+        sri,
+      };
+
+      for (const [bundleId, manifest] of Object.entries(
+        latestServerManifestsByBundleId
+      )) {
+        latestServerManifestsByBundleId[bundleId] = {
+          ...manifest,
+          sri,
+        };
+      }
+    };
 
     const routeByFilePath = new Map(
       Object.values(routes).map(route => [
@@ -468,9 +492,46 @@ export const pluginReactRouter = (
     const assetsBuildDirectory = relative(process.cwd(), outputClientPath);
 
     let clientStats: Rspack.StatsCompilation | undefined;
+    let clientSri: Record<string, string> | undefined;
+    let resolveClientStatsReady:
+      | ((stats: Rspack.StatsCompilation | undefined) => void)
+      | undefined;
+    let clientStatsReadyResolved = false;
+    const clientStatsReady = new Promise<Rspack.StatsCompilation | undefined>(
+      resolve => {
+        resolveClientStatsReady = resolve;
+      }
+    );
+    const resolveClientStatsOnce = (
+      stats: Rspack.StatsCompilation | undefined
+    ) => {
+      if (clientStatsReadyResolved) {
+        return;
+      }
+      clientStatsReadyResolved = true;
+      resolveClientStatsReady?.(stats);
+    };
+    const toClientManifestStats = (
+      stats: Rspack.Stats | undefined
+    ): Rspack.StatsCompilation | undefined => {
+      return stats?.toJson({
+        all: false,
+        assets: true,
+      });
+    };
+
     api.onAfterEnvironmentCompile(({ stats, environment }) => {
       if (environment.name === 'web') {
-        clientStats = stats?.toJson();
+        clientStats = toClientManifestStats(stats);
+        if (isBuild && subResourceIntegrity) {
+          clientSri = collectSubresourceIntegrity(
+            clientStats,
+            undefined,
+            assetPrefix
+          );
+          updateLatestServerManifestSri(clientSri);
+        }
+        resolveClientStatsOnce(clientStats);
       }
       if (pluginOptions.federation && ssr) {
         const serverBuildDir = resolve(buildDirectory, 'server');
@@ -1129,6 +1190,15 @@ export const pluginReactRouter = (
         },
         environments: {
           web: {
+            ...(subResourceIntegrity
+              ? {
+                  security: {
+                    sri: {
+                      enable: true,
+                    },
+                  },
+                }
+              : {}),
             source: {
               entry: {
                 // no query needed when federation is disabled
@@ -1325,8 +1395,10 @@ export const pluginReactRouter = (
           /virtual\/react-router\/server-manifest(?:-([^?]+))?/
         );
         const bundleId = bundleMatch?.[1]?.replace(/\\.js$/, '');
+        const manifestStats =
+          isBuild && subResourceIntegrity ? await clientStatsReady : clientStats;
 
-        const manifest =
+        const manifestBase =
           (isBuild && latestServerManifest
             ? bundleId && latestServerManifestsByBundleId[bundleId]
               ? latestServerManifestsByBundleId[bundleId]
@@ -1335,11 +1407,24 @@ export const pluginReactRouter = (
           (await getReactRouterManifestForDev(
             routes,
             pluginOptions,
-            clientStats,
+            manifestStats ?? clientStats,
             appDirectory,
             assetPrefix,
             routeChunkOptions
           ));
+        const manifest =
+          isBuild && subResourceIntegrity
+            ? {
+                ...manifestBase,
+                sri:
+                  clientSri ??
+                  collectSubresourceIntegrity(
+                    manifestStats,
+                    undefined,
+                    assetPrefix
+                  ),
+              }
+            : manifestBase;
         return {
           code: `export default ${jsesc(manifest, { es6: true })};`,
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1324,8 +1324,6 @@ export const pluginReactRouter = (
                     assetPrefix,
                     routeChunkOptions,
                     {
-                      subResourceIntegrity:
-                        resolvedConfigWithRoutes.subResourceIntegrity,
                       future,
                       subResourceIntegrity,
                       onManifest: (manifest, sri) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,6 +229,7 @@ export const pluginReactRouter = (
       serverBuildFile,
       serverModuleFormat,
       serverBundles,
+      subResourceIntegrity,
       buildEnd,
     } = resolvedConfig;
 
@@ -1255,6 +1256,7 @@ export const pluginReactRouter = (
                     routeChunkOptions,
                     {
                       future,
+                      subResourceIntegrity,
                       onManifest: (manifest, sri) => {
                         const baseServerManifest = {
                           ...manifest,

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -127,7 +127,7 @@ export async function getReactRouterManifestForDev(
     imports: string[];
     css: string[];
   };
-  sri?: Record<string, string>;
+  sri?: Record<string, string> | true;
   routes: Record<string, RouteManifestItem>;
 }> {
   const result: Record<string, RouteManifestItem> = {};

--- a/src/modify-browser-manifest.ts
+++ b/src/modify-browser-manifest.ts
@@ -24,6 +24,12 @@ type CompilationAssetWithIntegrity = {
   };
 };
 
+type CompilationWithIntegrityAssets =
+  | {
+      getAssets?: () => readonly CompilationAssetWithIntegrity[];
+    }
+  | Pick<Rspack.Compilation, 'getAssets'>;
+
 const ABSOLUTE_URL_RE = /^[a-zA-Z][a-zA-Z\d+\-.]*:/;
 
 const toManifestAssetUrl = (assetPrefix: string, assetName: string) => {
@@ -51,10 +57,7 @@ const addIntegrity = (
 
 export const collectSubresourceIntegrity = (
   stats: StatsWithIntegrity | undefined,
-  compilation:
-    | Pick<Rspack.Compilation, 'getAssets'>
-    | { getAssets?: () => CompilationAssetWithIntegrity[] }
-    | undefined,
+  compilation: CompilationWithIntegrityAssets | undefined,
   assetPrefix = '/'
 ): Record<string, string> | undefined => {
   const sri: Record<string, string> = {};
@@ -64,13 +67,21 @@ export const collectSubresourceIntegrity = (
   }
 
   if (typeof compilation?.getAssets === 'function') {
-    for (const asset of compilation.getAssets()) {
+    const assets =
+      compilation.getAssets() as readonly CompilationAssetWithIntegrity[];
+    for (const asset of assets) {
       addIntegrity(sri, assetPrefix, asset.name, asset.info?.integrity);
     }
   }
 
   return Object.keys(sri).length > 0 ? sri : undefined;
 };
+
+const getManifestStats = (compilation: Rspack.Compilation) =>
+  compilation.getStats().toJson({
+    all: false,
+    assets: true,
+  });
 
 /**
  * Creates a Webpack/Rspack plugin that modifies the browser manifest
@@ -99,7 +110,7 @@ export function createModifyBrowserManifestPlugin(
       compiler.hooks.emit.tapAsync(
         'ModifyBrowserManifest',
         async (compilation: Rspack.Compilation, callback) => {
-          const stats = compilation.getStats().toJson();
+          const stats = getManifestStats(compilation);
           const manifest = await getReactRouterManifestForDev(
             routes,
             pluginOptions,
@@ -108,10 +119,11 @@ export function createModifyBrowserManifestPlugin(
             assetPrefix,
             routeChunkOptions
           );
-          const shouldUseSri =
+          const shouldUseSri = Boolean(
             routeChunkOptions?.isBuild &&
             (options?.subResourceIntegrity ??
-              options?.future?.unstable_subResourceIntegrity);
+              options?.future?.unstable_subResourceIntegrity)
+          );
           const manifestForBrowser = shouldUseSri
             ? { ...manifest, sri: true as const }
             : manifest;

--- a/src/modify-browser-manifest.ts
+++ b/src/modify-browser-manifest.ts
@@ -90,7 +90,7 @@ export function createModifyBrowserManifestPlugin(
     subResourceIntegrity?: boolean;
     onManifest?: (
       manifest: Awaited<ReturnType<typeof getReactRouterManifestForDev>>,
-      sri: Record<string, string> | undefined
+      sri: Record<string, string> | true | undefined
     ) => void;
   }
 ) {
@@ -114,6 +114,11 @@ export function createModifyBrowserManifestPlugin(
               options?.future?.unstable_subResourceIntegrity)
               ? { ...manifest, sri: true as const }
               : manifest;
+          const sri =
+            manifestForBrowser.sri === true
+              ? collectSubresourceIntegrity(stats, compilation, assetPrefix) ??
+                true
+              : undefined;
 
           const virtualManifestPath =
             'static/js/virtual/react-router/browser-manifest.js';
@@ -170,7 +175,7 @@ export function createModifyBrowserManifestPlugin(
             );
           }
 
-          options?.onManifest?.(manifestForBrowser, undefined);
+          options?.onManifest?.(manifestForBrowser, sri);
           callback();
         }
       );

--- a/src/modify-browser-manifest.ts
+++ b/src/modify-browser-manifest.ts
@@ -108,6 +108,12 @@ export function createModifyBrowserManifestPlugin(
             assetPrefix,
             routeChunkOptions
           );
+          const manifestForBrowser =
+            routeChunkOptions?.isBuild &&
+            (options?.subResourceIntegrity ??
+              options?.future?.unstable_subResourceIntegrity)
+              ? { ...manifest, sri: true as const }
+              : manifest;
 
           const virtualManifestPath =
             'static/js/virtual/react-router/browser-manifest.js';
@@ -117,7 +123,7 @@ export function createModifyBrowserManifestPlugin(
               .toString();
             const newSource = originalSource.replace(
               /["'`]PLACEHOLDER["'`]/,
-              jsesc(manifest, { es6: true })
+              jsesc(manifestForBrowser, { es6: true })
             );
             compilation.assets[virtualManifestPath] = {
               source: () => newSource,
@@ -156,7 +162,7 @@ export function createModifyBrowserManifestPlugin(
               entryModulePath: entryJsAssets[0],
             });
             const manifestSource = `window.__reactRouterManifest=${jsesc(
-              manifest,
+              manifestForBrowser,
               { es6: true }
             )};`;
             compilation.assets[manifestPath] = new rspack.sources.RawSource(
@@ -164,7 +170,7 @@ export function createModifyBrowserManifestPlugin(
             );
           }
 
-          options?.onManifest?.(manifest, undefined);
+          options?.onManifest?.(manifestForBrowser, undefined);
           callback();
         }
       );

--- a/src/modify-browser-manifest.ts
+++ b/src/modify-browser-manifest.ts
@@ -108,14 +108,16 @@ export function createModifyBrowserManifestPlugin(
             assetPrefix,
             routeChunkOptions
           );
-          const manifestForBrowser =
+          const shouldUseSri =
             routeChunkOptions?.isBuild &&
             (options?.subResourceIntegrity ??
-              options?.future?.unstable_subResourceIntegrity)
+              options?.future?.unstable_subResourceIntegrity);
+          const manifestForBrowser =
+            shouldUseSri
               ? { ...manifest, sri: true as const }
               : manifest;
           const sri =
-            manifestForBrowser.sri === true
+            shouldUseSri
               ? collectSubresourceIntegrity(stats, compilation, assetPrefix) ??
                 true
               : undefined;

--- a/src/modify-browser-manifest.ts
+++ b/src/modify-browser-manifest.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto';
 import type { Route, PluginOptions } from './types.js';
 import { rspack } from '@rsbuild/core';
 import type { Rspack } from '@rsbuild/core';
@@ -8,6 +7,70 @@ import {
 } from './manifest.js';
 import { combineURLs } from './plugin-utils.js';
 import jsesc from 'jsesc';
+
+type StatsAssetWithIntegrity = {
+  name?: string;
+  integrity?: unknown;
+};
+
+type StatsWithIntegrity = {
+  assets?: StatsAssetWithIntegrity[];
+};
+
+type CompilationAssetWithIntegrity = {
+  name: string;
+  info?: {
+    integrity?: unknown;
+  };
+};
+
+const ABSOLUTE_URL_RE = /^[a-zA-Z][a-zA-Z\d+\-.]*:/;
+
+const toManifestAssetUrl = (assetPrefix: string, assetName: string) => {
+  if (
+    ABSOLUTE_URL_RE.test(assetName) ||
+    assetName.startsWith('//') ||
+    assetName.startsWith('/')
+  ) {
+    return assetName;
+  }
+  return combineURLs(assetPrefix, assetName);
+};
+
+const addIntegrity = (
+  sri: Record<string, string>,
+  assetPrefix: string,
+  assetName: unknown,
+  integrity: unknown
+) => {
+  if (typeof assetName !== 'string' || typeof integrity !== 'string') {
+    return;
+  }
+  sri[toManifestAssetUrl(assetPrefix, assetName)] = integrity;
+};
+
+export const collectSubresourceIntegrity = (
+  stats: StatsWithIntegrity | undefined,
+  compilation:
+    | Pick<Rspack.Compilation, 'getAssets'>
+    | { getAssets?: () => CompilationAssetWithIntegrity[] }
+    | undefined,
+  assetPrefix = '/'
+): Record<string, string> | undefined => {
+  const sri: Record<string, string> = {};
+
+  for (const asset of stats?.assets ?? []) {
+    addIntegrity(sri, assetPrefix, asset.name, asset.integrity);
+  }
+
+  if (typeof compilation?.getAssets === 'function') {
+    for (const asset of compilation.getAssets()) {
+      addIntegrity(sri, assetPrefix, asset.name, asset.info?.integrity);
+    }
+  }
+
+  return Object.keys(sri).length > 0 ? sri : undefined;
+};
 
 /**
  * Creates a Webpack/Rspack plugin that modifies the browser manifest
@@ -101,31 +164,7 @@ export function createModifyBrowserManifestPlugin(
             );
           }
 
-          let sri: Record<string, string> | undefined;
-          if (
-            routeChunkOptions?.isBuild &&
-            (options?.subResourceIntegrity ??
-              options?.future?.unstable_subResourceIntegrity)
-          ) {
-            const assets =
-              typeof compilation.getAssets === 'function'
-                ? compilation.getAssets()
-                : Object.entries(compilation.assets).map(([name, asset]) => ({
-                    name,
-                    source: asset,
-                  }));
-            sri = {};
-            for (const asset of assets) {
-              if (!asset.name.endsWith('.js')) {
-                continue;
-              }
-              const source = asset.source.source().toString();
-              const hash = createHash('sha384').update(source).digest('base64');
-              sri[combineURLs(assetPrefix, asset.name)] = `sha384-${hash}`;
-            }
-          }
-
-          options?.onManifest?.(manifest, sri);
+          options?.onManifest?.(manifest, undefined);
           callback();
         }
       );

--- a/src/modify-browser-manifest.ts
+++ b/src/modify-browser-manifest.ts
@@ -24,6 +24,7 @@ export function createModifyBrowserManifestPlugin(
   routeChunkOptions?: Parameters<typeof getReactRouterManifestForDev>[5],
   options?: {
     future?: { unstable_subResourceIntegrity?: boolean };
+    subResourceIntegrity?: boolean;
     onManifest?: (
       manifest: Awaited<ReturnType<typeof getReactRouterManifestForDev>>,
       sri: Record<string, string> | undefined
@@ -103,7 +104,8 @@ export function createModifyBrowserManifestPlugin(
           let sri: Record<string, string> | undefined;
           if (
             routeChunkOptions?.isBuild &&
-            options?.future?.unstable_subResourceIntegrity
+            (options?.subResourceIntegrity ??
+              options?.future?.unstable_subResourceIntegrity)
           ) {
             const assets =
               typeof compilation.getAssets === 'function'

--- a/src/react-router-config.ts
+++ b/src/react-router-config.ts
@@ -121,6 +121,25 @@ const mergeReactRouterConfig = (...configs: Config[]): Config => {
   return configs.reduce(reducer, {});
 };
 
+const normalizeSubResourceIntegrity = (config: Config): Config => {
+  const subResourceIntegrity =
+    config.subResourceIntegrity ??
+    config.future?.unstable_subResourceIntegrity;
+
+  if (subResourceIntegrity === undefined) {
+    return config;
+  }
+
+  return {
+    ...config,
+    subResourceIntegrity,
+    future: {
+      ...(config.future ?? {}),
+      unstable_subResourceIntegrity: subResourceIntegrity,
+    },
+  };
+};
+
 export const resolveReactRouterConfig = async (
   reactRouterUserConfig: Config
 ): Promise<{
@@ -149,18 +168,19 @@ export const resolveReactRouterConfig = async (
   );
 
   const userAndPresetConfigs = mergeReactRouterConfig(
-    ...(presets.filter(Boolean) as Config[]),
-    reactRouterUserConfig
+    ...(presets.filter(Boolean) as Config[]).map(normalizeSubResourceIntegrity),
+    normalizeSubResourceIntegrity(reactRouterUserConfig)
   );
 
-  const resolvedFuture: FutureConfig = {
-    ...DEFAULT_CONFIG.future,
-    ...(userAndPresetConfigs.future ?? {}),
-  };
   const subResourceIntegrity =
     userAndPresetConfigs.subResourceIntegrity ??
     userAndPresetConfigs.future?.unstable_subResourceIntegrity ??
     DEFAULT_CONFIG.subResourceIntegrity;
+  const resolvedFuture: FutureConfig = {
+    ...DEFAULT_CONFIG.future,
+    ...(userAndPresetConfigs.future ?? {}),
+    unstable_subResourceIntegrity: subResourceIntegrity,
+  };
 
   let resolved: ResolvedReactRouterConfig = {
     ...DEFAULT_CONFIG,

--- a/src/react-router-config.ts
+++ b/src/react-router-config.ts
@@ -13,8 +13,12 @@ export type BuildEndHook = {
   }): void | Promise<void>;
 }['bivarianceHack'];
 
-export type Config = Omit<ReactRouterConfig, 'buildEnd'> & {
+export type Config = Omit<
+  ReactRouterConfig,
+  'buildEnd' | 'subResourceIntegrity'
+> & {
   buildEnd?: BuildEndHook;
+  subResourceIntegrity?: boolean;
 };
 
 type FutureConfig = {
@@ -49,6 +53,7 @@ export type ResolvedReactRouterConfig = Readonly<{
   serverBuildFile: NonNullable<ReactRouterConfig['serverBuildFile']>;
   serverBundles?: Config['serverBundles'];
   serverModuleFormat: NonNullable<ReactRouterConfig['serverModuleFormat']>;
+  subResourceIntegrity: boolean;
   ssr: NonNullable<ReactRouterConfig['ssr']>;
   allowedActionOrigins: string[] | false;
   unstable_routeConfig: RouteConfigEntry[];
@@ -60,6 +65,7 @@ const DEFAULT_CONFIG = {
   buildDirectory: 'build',
   serverBuildFile: 'index.js',
   serverModuleFormat: 'esm',
+  subResourceIntegrity: false,
   ssr: true,
   future: {
     unstable_optimizeDeps: false,
@@ -151,11 +157,16 @@ export const resolveReactRouterConfig = async (
     ...DEFAULT_CONFIG.future,
     ...(userAndPresetConfigs.future ?? {}),
   };
+  const subResourceIntegrity =
+    userAndPresetConfigs.subResourceIntegrity ??
+    userAndPresetConfigs.future?.unstable_subResourceIntegrity ??
+    DEFAULT_CONFIG.subResourceIntegrity;
 
   let resolved: ResolvedReactRouterConfig = {
     ...DEFAULT_CONFIG,
     ...userAndPresetConfigs,
     future: resolvedFuture,
+    subResourceIntegrity,
     allowedActionOrigins:
       userAndPresetConfigs.allowedActionOrigins ??
       DEFAULT_CONFIG.allowedActionOrigins,

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -5,6 +5,23 @@ import { pluginReactRouter } from '../src';
 type ReactRouterTestGlobal = typeof globalThis & {
   __reactRouterTestConfig?: unknown;
 };
+type PluginSetupApi = Parameters<
+  NonNullable<ReturnType<typeof pluginReactRouter>['setup']>
+>[0];
+type EnvironmentCompileHandler = (args: {
+  environment: { name: string };
+  stats: {
+    toJson: () => {
+      assets: never[];
+      assetsByChunkName: Record<string, string[]>;
+    };
+  };
+}) => void;
+type MockEnvironmentCompileHook = {
+  mock: {
+    calls: Array<[EnvironmentCompileHandler]>;
+  };
+};
 
 describe('pluginReactRouter', () => {
   it('should configure basic plugin options', async () => {
@@ -83,9 +100,10 @@ describe('pluginReactRouter', () => {
       rsbuildConfig: {},
     });
     const plugin = pluginReactRouter();
-    await plugin.setup(rsbuild as any);
+    await plugin.setup(rsbuild as PluginSetupApi);
 
-    const onAfterEnvironmentCompile = rsbuild.onAfterEnvironmentCompile as any;
+    const onAfterEnvironmentCompile =
+      rsbuild.onAfterEnvironmentCompile as MockEnvironmentCompileHook;
     const handler = onAfterEnvironmentCompile.mock.calls[0][0];
     const toJson = rstest.fn().mockReturnValue({
       assets: [],

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,10 @@
 import { createStubRsbuild } from '@scripts/test-helper';
-import { describe, expect, it } from '@rstest/core';
+import { describe, expect, it, rstest } from '@rstest/core';
 import { pluginReactRouter } from '../src';
+
+type ReactRouterTestGlobal = typeof globalThis & {
+  __reactRouterTestConfig?: unknown;
+};
 
 describe('pluginReactRouter', () => {
   it('should configure basic plugin options', async () => {
@@ -46,6 +50,25 @@ describe('pluginReactRouter', () => {
     expect(webConfig.output.module).toBe(true);
   });
 
+  it('should enable Rsbuild SRI for the web environment when configured', async () => {
+    (globalThis as ReactRouterTestGlobal).__reactRouterTestConfig = {
+      subResourceIntegrity: true,
+    };
+    const rsbuild = await createStubRsbuild({
+      rsbuildConfig: {},
+    });
+
+    try {
+      rsbuild.addPlugins([pluginReactRouter()]);
+      const config = await rsbuild.unwrapConfig();
+
+      expect(config.environments?.web?.security?.sri?.enable).toBe(true);
+      expect(config.environments?.node?.security?.sri).toBeUndefined();
+    } finally {
+      delete (globalThis as ReactRouterTestGlobal).__reactRouterTestConfig;
+    }
+  });
+
   it('should configure node environment correctly', async () => {
     const rsbuild = await createStubRsbuild({
       rsbuildConfig: {},
@@ -57,6 +80,32 @@ describe('pluginReactRouter', () => {
     const nodeConfig = config.environments?.node?.tools?.rspack;
     expect(nodeConfig.externals).toContain('express');
     expect(nodeConfig.experiments.outputModule).toBe(true);
+  });
+
+  it('should serialize only asset stats after web compilation', async () => {
+    const rsbuild = await createStubRsbuild({
+      rsbuildConfig: {},
+    });
+    const plugin = pluginReactRouter();
+    await plugin.setup(rsbuild as any);
+
+    const onAfterEnvironmentCompile = rsbuild.onAfterEnvironmentCompile as any;
+    const handler = onAfterEnvironmentCompile.mock.calls[0][0];
+    const toJson = rstest.fn().mockReturnValue({
+      assets: [],
+      assetsByChunkName: {},
+    });
+
+    handler({
+      environment: { name: 'web' },
+      stats: { toJson },
+    });
+
+    expect(toJson).toHaveBeenCalledTimes(1);
+    expect(toJson).toHaveBeenCalledWith({
+      all: false,
+      assets: true,
+    });
   });
 
   it('should use async-node target for federation builds', async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -58,15 +58,11 @@ describe('pluginReactRouter', () => {
       rsbuildConfig: {},
     });
 
-    try {
-      rsbuild.addPlugins([pluginReactRouter()]);
-      const config = await rsbuild.unwrapConfig();
+    rsbuild.addPlugins([pluginReactRouter()]);
+    const config = await rsbuild.unwrapConfig();
 
-      expect(config.environments?.web?.security?.sri?.enable).toBe(true);
-      expect(config.environments?.node?.security?.sri).toBeUndefined();
-    } finally {
-      delete (globalThis as ReactRouterTestGlobal).__reactRouterTestConfig;
-    }
+    expect(config.environments?.web?.security?.sri?.enable).toBe(true);
+    expect(config.environments?.node?.security?.sri).toBeUndefined();
   });
 
   it('should configure node environment correctly', async () => {

--- a/tests/modify-browser-manifest.test.ts
+++ b/tests/modify-browser-manifest.test.ts
@@ -10,6 +10,29 @@ import {
 const BROWSER_MANIFEST_PATH =
   'static/js/virtual/react-router/browser-manifest.js';
 
+type ManifestAsset = {
+  source: () => string;
+};
+type TestCompilation = {
+  assets: Record<string, ManifestAsset>;
+  getStats: () => {
+    toJson: () => {
+      assetsByChunkName: Record<string, string[]>;
+    };
+  };
+};
+type EmitHandler = (
+  compilation: TestCompilation,
+  callback: (error?: Error) => void
+) => Promise<void>;
+type TestCompiler = {
+  hooks: {
+    emit: {
+      tapAsync: (name: string, handler: EmitHandler) => void;
+    };
+  };
+};
+
 describe('collectSubresourceIntegrity', () => {
   it('uses official integrity metadata from stats and compilation assets', () => {
     const sri = collectSubresourceIntegrity(
@@ -87,12 +110,7 @@ describe('collectSubresourceIntegrity', () => {
     );
 
     try {
-      let emit:
-        | ((
-            compilation: any,
-            callback: (error?: Error) => void
-          ) => Promise<void>)
-        | undefined;
+      let emit: EmitHandler | undefined;
       let callbackSri: Record<string, string> | true | undefined;
       const plugin = createModifyBrowserManifestPlugin(
         {
@@ -119,17 +137,18 @@ describe('collectSubresourceIntegrity', () => {
         }
       );
 
-      plugin.apply({
+      const compiler: TestCompiler = {
         hooks: {
           emit: {
-            tapAsync: (_name: string, handler: typeof emit) => {
+            tapAsync: (_name, handler) => {
               emit = handler;
             },
           },
         },
-      } as any);
+      };
+      plugin.apply(compiler as Parameters<typeof plugin.apply>[0]);
 
-      const compilation = {
+      const compilation: TestCompilation = {
         assets: {
           [BROWSER_MANIFEST_PATH]: {
             source: () => 'window.__reactRouterManifest="PLACEHOLDER";',
@@ -145,8 +164,12 @@ describe('collectSubresourceIntegrity', () => {
         }),
       };
 
+      if (!emit) {
+        throw new Error('Expected manifest plugin to register an emit hook.');
+      }
+
       await new Promise<void>((resolve, reject) => {
-        emit?.(compilation, error => {
+        emit(compilation, error => {
           if (error) {
             reject(error);
             return;

--- a/tests/modify-browser-manifest.test.ts
+++ b/tests/modify-browser-manifest.test.ts
@@ -1,5 +1,14 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from '@rstest/core';
-import { collectSubresourceIntegrity } from '../src/modify-browser-manifest';
+import {
+  collectSubresourceIntegrity,
+  createModifyBrowserManifestPlugin,
+} from '../src/modify-browser-manifest';
+
+const BROWSER_MANIFEST_PATH =
+  'static/js/virtual/react-router/browser-manifest.js';
 
 describe('collectSubresourceIntegrity', () => {
   it('uses official integrity metadata from stats and compilation assets', () => {
@@ -66,5 +75,94 @@ describe('collectSubresourceIntegrity', () => {
     );
 
     expect(sri).toBeUndefined();
+  });
+
+  it('emits the browser manifest with the React Router SRI sentinel', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'rr-browser-manifest-'));
+    const appDir = join(root, 'app');
+    mkdirSync(appDir, { recursive: true });
+    writeFileSync(
+      join(appDir, 'root.tsx'),
+      'export default function Root() { return null; }'
+    );
+
+    try {
+      let emit:
+        | ((
+            compilation: any,
+            callback: (error?: Error) => void
+          ) => Promise<void>)
+        | undefined;
+      const plugin = createModifyBrowserManifestPlugin(
+        {
+          root: {
+            id: 'root',
+            file: 'root.tsx',
+            path: '',
+          },
+        },
+        {},
+        appDir,
+        '/',
+        {
+          splitRouteModules: false,
+          rootRouteFile: 'root.tsx',
+          isBuild: true,
+        },
+        {
+          subResourceIntegrity: true,
+          onManifest: manifest => {
+            expect(manifest.sri).toBe(true);
+          },
+        }
+      );
+
+      plugin.apply({
+        hooks: {
+          emit: {
+            tapAsync: (_name: string, handler: typeof emit) => {
+              emit = handler;
+            },
+          },
+        },
+      } as any);
+
+      const compilation = {
+        assets: {
+          [BROWSER_MANIFEST_PATH]: {
+            source: () => 'window.__reactRouterManifest="PLACEHOLDER";',
+          },
+        },
+        getStats: () => ({
+          toJson: () => ({
+            assetsByChunkName: {
+              'entry.client': ['static/js/entry.client.js'],
+              root: ['static/js/root.js'],
+            },
+          }),
+        }),
+      };
+
+      await new Promise<void>((resolve, reject) => {
+        emit?.(compilation, error => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        }).catch(reject);
+      });
+
+      expect(compilation.assets[BROWSER_MANIFEST_PATH].source()).toContain(
+        "'sri':true"
+      );
+
+      const buildManifestAsset = Object.entries(compilation.assets).find(
+        ([name]) => /^static\/js\/manifest-[a-f0-9]+\.js$/.test(name)
+      );
+      expect(buildManifestAsset?.[1].source()).toContain("'sri':true");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/modify-browser-manifest.test.ts
+++ b/tests/modify-browser-manifest.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from '@rstest/core';
+import { collectSubresourceIntegrity } from '../src/modify-browser-manifest';
+
+describe('collectSubresourceIntegrity', () => {
+  it('uses official integrity metadata from stats and compilation assets', () => {
+    const sri = collectSubresourceIntegrity(
+      {
+        assets: [
+          {
+            name: 'static/js/entry.client.js',
+            integrity: 'sha384-entry',
+          },
+          {
+            name: 'static/css/entry.client.css',
+            integrity: 'sha384-css',
+          },
+          {
+            name: 'static/js/no-integrity.js',
+          },
+        ],
+      },
+      {
+        getAssets: () => [
+          {
+            name: 'static/js/route.js',
+            info: {
+              integrity: 'sha384-route',
+            },
+          },
+          {
+            name: '/static/js/already-prefixed.js',
+            info: {
+              integrity: 'sha384-prefixed',
+            },
+          },
+        ],
+      },
+      '/assets/'
+    );
+
+    expect(sri).toEqual({
+      '/assets/static/js/entry.client.js': 'sha384-entry',
+      '/assets/static/css/entry.client.css': 'sha384-css',
+      '/assets/static/js/route.js': 'sha384-route',
+      '/static/js/already-prefixed.js': 'sha384-prefixed',
+    });
+  });
+
+  it('returns undefined when Rspack does not provide integrity metadata', () => {
+    const sri = collectSubresourceIntegrity(
+      {
+        assets: [
+          {
+            name: 'static/js/entry.client.js',
+          },
+        ],
+      },
+      {
+        getAssets: () => [
+          {
+            name: 'static/js/route.js',
+            info: {},
+          },
+        ],
+      }
+    );
+
+    expect(sri).toBeUndefined();
+  });
+});

--- a/tests/modify-browser-manifest.test.ts
+++ b/tests/modify-browser-manifest.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it } from '@rstest/core';
+import { describe, expect, it, rstest } from '@rstest/core';
 import {
   collectSubresourceIntegrity,
   createModifyBrowserManifestPlugin,
@@ -13,12 +13,18 @@ const BROWSER_MANIFEST_PATH =
 type ManifestAsset = {
   source: () => string;
 };
+type StatsJsonOptions = {
+  all: false;
+  assets: true;
+};
+type TestStats = {
+  assets?: Array<{ name?: string; integrity?: unknown }>;
+  assetsByChunkName: Record<string, string[]>;
+};
 type TestCompilation = {
   assets: Record<string, ManifestAsset>;
   getStats: () => {
-    toJson: () => {
-      assetsByChunkName: Record<string, string[]>;
-    };
+    toJson: (options: StatsJsonOptions) => TestStats;
   };
 };
 type EmitHandler = (
@@ -32,6 +38,20 @@ type TestCompiler = {
     };
   };
 };
+
+const runEmit = (
+  emit: EmitHandler,
+  compilation: TestCompilation
+): Promise<void> =>
+  new Promise((resolve, reject) => {
+    emit(compilation, error => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    }).catch(reject);
+  });
 
 describe('collectSubresourceIntegrity', () => {
   it('uses official integrity metadata from stats and compilation assets', () => {
@@ -112,6 +132,12 @@ describe('collectSubresourceIntegrity', () => {
     try {
       let emit: EmitHandler | undefined;
       let callbackSri: Record<string, string> | true | undefined;
+      const toJson = rstest.fn((_options: StatsJsonOptions) => ({
+        assetsByChunkName: {
+          'entry.client': ['static/js/entry.client.js'],
+          root: ['static/js/root.js'],
+        },
+      }));
       const plugin = createModifyBrowserManifestPlugin(
         {
           root: {
@@ -155,12 +181,7 @@ describe('collectSubresourceIntegrity', () => {
           },
         },
         getStats: () => ({
-          toJson: () => ({
-            assetsByChunkName: {
-              'entry.client': ['static/js/entry.client.js'],
-              root: ['static/js/root.js'],
-            },
-          }),
+          toJson,
         }),
       };
 
@@ -168,14 +189,11 @@ describe('collectSubresourceIntegrity', () => {
         throw new Error('Expected manifest plugin to register an emit hook.');
       }
 
-      await new Promise<void>((resolve, reject) => {
-        emit(compilation, error => {
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve();
-        }).catch(reject);
+      await runEmit(emit, compilation);
+
+      expect(toJson).toHaveBeenCalledWith({
+        all: false,
+        assets: true,
       });
 
       expect(compilation.assets[BROWSER_MANIFEST_PATH].source()).toContain(

--- a/tests/modify-browser-manifest.test.ts
+++ b/tests/modify-browser-manifest.test.ts
@@ -93,6 +93,7 @@ describe('collectSubresourceIntegrity', () => {
             callback: (error?: Error) => void
           ) => Promise<void>)
         | undefined;
+      let callbackSri: Record<string, string> | true | undefined;
       const plugin = createModifyBrowserManifestPlugin(
         {
           root: {
@@ -111,8 +112,9 @@ describe('collectSubresourceIntegrity', () => {
         },
         {
           subResourceIntegrity: true,
-          onManifest: manifest => {
+          onManifest: (manifest, sri) => {
             expect(manifest.sri).toBe(true);
+            callbackSri = sri;
           },
         }
       );
@@ -156,6 +158,7 @@ describe('collectSubresourceIntegrity', () => {
       expect(compilation.assets[BROWSER_MANIFEST_PATH].source()).toContain(
         "'sri':true"
       );
+      expect(callbackSri).toBe(true);
 
       const buildManifestAsset = Object.entries(compilation.assets).find(
         ([name]) => /^static\/js\/manifest-[a-f0-9]+\.js$/.test(name)

--- a/tests/react-router-config.test.ts
+++ b/tests/react-router-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@rstest/core';
 import { resolveReactRouterConfig } from '../src/react-router-config';
+import type { Config } from '../src/react-router-config';
 
 describe('resolveReactRouterConfig', () => {
   it('merges presets and combines buildEnd hooks', async () => {
@@ -35,7 +36,7 @@ describe('resolveReactRouterConfig', () => {
     const defaultResult = await resolveReactRouterConfig({});
     const enabledResult = await resolveReactRouterConfig({
       subResourceIntegrity: true,
-    } as any);
+    });
     const futureResult = await resolveReactRouterConfig({
       future: { unstable_subResourceIntegrity: true },
     });
@@ -59,7 +60,7 @@ describe('resolveReactRouterConfig', () => {
         },
       ],
       future: { unstable_subResourceIntegrity: false },
-    } as any);
+    } as Config);
     const disabledByTopLevel = await resolveReactRouterConfig({
       presets: [
         {
@@ -70,7 +71,7 @@ describe('resolveReactRouterConfig', () => {
         },
       ],
       subResourceIntegrity: false,
-    } as any);
+    } as Config);
 
     expect(disabledByFuture.resolved.subResourceIntegrity).toBe(false);
     expect(

--- a/tests/react-router-config.test.ts
+++ b/tests/react-router-config.test.ts
@@ -70,7 +70,7 @@ describe('resolveReactRouterConfig', () => {
   });
 
   it('lets user SRI config override preset aliases', async () => {
-    const disabledByFuture = await resolveReactRouterConfig({
+    const disablesPresetSriWithFuture = {
       presets: [
         {
           name: 'sri-preset',
@@ -80,8 +80,8 @@ describe('resolveReactRouterConfig', () => {
         },
       ],
       future: { unstable_subResourceIntegrity: false },
-    } as Config);
-    const disabledByTopLevel = await resolveReactRouterConfig({
+    } satisfies Config;
+    const disablesPresetSriWithTopLevel = {
       presets: [
         {
           name: 'sri-preset',
@@ -91,8 +91,14 @@ describe('resolveReactRouterConfig', () => {
         },
       ],
       subResourceIntegrity: false,
-    } as Config);
+    } satisfies Config;
 
+    const disabledByFuture = await resolveReactRouterConfig(
+      disablesPresetSriWithFuture
+    );
+    const disabledByTopLevel = await resolveReactRouterConfig(
+      disablesPresetSriWithTopLevel
+    );
     expect(disabledByFuture.resolved.subResourceIntegrity).toBe(false);
     expect(
       disabledByFuture.resolved.future.unstable_subResourceIntegrity

--- a/tests/react-router-config.test.ts
+++ b/tests/react-router-config.test.ts
@@ -43,5 +43,42 @@ describe('resolveReactRouterConfig', () => {
     expect(defaultResult.resolved.subResourceIntegrity).toBe(false);
     expect(enabledResult.resolved.subResourceIntegrity).toBe(true);
     expect(futureResult.resolved.subResourceIntegrity).toBe(true);
+    expect(futureResult.resolved.future.unstable_subResourceIntegrity).toBe(
+      true
+    );
+  });
+
+  it('lets user SRI config override preset aliases', async () => {
+    const disabledByFuture = await resolveReactRouterConfig({
+      presets: [
+        {
+          name: 'sri-preset',
+          reactRouterConfig: async () => ({
+            subResourceIntegrity: true,
+          }),
+        },
+      ],
+      future: { unstable_subResourceIntegrity: false },
+    } as any);
+    const disabledByTopLevel = await resolveReactRouterConfig({
+      presets: [
+        {
+          name: 'sri-preset',
+          reactRouterConfig: async () => ({
+            future: { unstable_subResourceIntegrity: true },
+          }),
+        },
+      ],
+      subResourceIntegrity: false,
+    } as any);
+
+    expect(disabledByFuture.resolved.subResourceIntegrity).toBe(false);
+    expect(
+      disabledByFuture.resolved.future.unstable_subResourceIntegrity
+    ).toBe(false);
+    expect(disabledByTopLevel.resolved.subResourceIntegrity).toBe(false);
+    expect(
+      disabledByTopLevel.resolved.future.unstable_subResourceIntegrity
+    ).toBe(false);
   });
 });

--- a/tests/react-router-config.test.ts
+++ b/tests/react-router-config.test.ts
@@ -30,4 +30,18 @@ describe('resolveReactRouterConfig', () => {
     });
     expect(buildEndCalls).toBe(2);
   });
+
+  it('resolves stable subresource integrity from top-level config', async () => {
+    const defaultResult = await resolveReactRouterConfig({});
+    const enabledResult = await resolveReactRouterConfig({
+      subResourceIntegrity: true,
+    } as any);
+    const futureResult = await resolveReactRouterConfig({
+      future: { unstable_subResourceIntegrity: true },
+    });
+
+    expect(defaultResult.resolved.subResourceIntegrity).toBe(false);
+    expect(enabledResult.resolved.subResourceIntegrity).toBe(true);
+    expect(futureResult.resolved.subResourceIntegrity).toBe(true);
+  });
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,5 +1,13 @@
 import * as fs from 'node:fs';
-import { rstest } from '@rstest/core';
+import { afterEach, rstest } from '@rstest/core';
+
+type ReactRouterTestGlobal = typeof globalThis & {
+  __reactRouterTestConfig?: unknown;
+};
+
+afterEach(() => {
+  delete (globalThis as ReactRouterTestGlobal).__reactRouterTestConfig;
+});
 
 // Mock the file system
 rstest.mock('node:fs', { spy: true });
@@ -19,8 +27,7 @@ rstest.mock('jiti', () => ({
         ]);
       }
       return Promise.resolve(
-        (globalThis as { __reactRouterTestConfig?: unknown })
-          .__reactRouterTestConfig ?? {}
+        (globalThis as ReactRouterTestGlobal).__reactRouterTestConfig ?? {}
       );
     }),
   }),

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -18,7 +18,10 @@ rstest.mock('jiti', () => ({
           },
         ]);
       }
-      return Promise.resolve({});
+      return Promise.resolve(
+        (globalThis as { __reactRouterTestConfig?: unknown })
+          .__reactRouterTestConfig ?? {}
+      );
     }),
   }),
 }));


### PR DESCRIPTION
## Summary\n- accept top-level `subResourceIntegrity` alongside `future.unstable_subResourceIntegrity`\n- pass the resolved stable setting into browser manifest SRI generation\n- add resolver coverage for stable and future config keys\n\n## Verification\n- `pnpm test:core tests/react-router-config.test.ts`\n- `pnpm build`