### PR TITLE
feat: expose guarded lazy compilation option

### DIFF
--- a/.changeset/guarded-lazy-compilation.md
+++ b/.changeset/guarded-lazy-compilation.md
@@ -1,0 +1,6 @@
+---
+'rsbuild-plugin-react-router': minor
+---
+
+Expose a plugin-level `lazyCompilation` option that keeps React Router hydration
+modules eager while preserving user lazy compilation filters.

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ import {
 import { warnOnClientSourceMaps } from './warnings/warn-on-client-source-maps.js';
 import { validatePluginOrderFromConfig } from './validation/validate-plugin-order.js';
 import { getSsrExternals } from './ssr-externals.js';
+import { guardReactRouterLazyCompilation } from './lazy-compilation.js';
 
 const redirectStatusCodes = new Set([301, 302, 303, 307, 308]);
 
@@ -1082,6 +1083,18 @@ export const pluginReactRouter = (
         /\.js$/,
         ''
       );
+      const configuredLazyCompilation =
+        pluginOptions.lazyCompilation === undefined
+          ? config.dev?.lazyCompilation
+          : pluginOptions.lazyCompilation;
+      const guardedLazyCompilation = guardReactRouterLazyCompilation({
+        lazyCompilation: configuredLazyCompilation,
+        entryClientPath: finalEntryClientPath,
+      });
+      const lazyCompilation =
+        guardedLazyCompilation === undefined
+          ? {}
+          : { lazyCompilation: guardedLazyCompilation };
 
       const nodeEntries: Record<string, string> = {
         ...(hasServerApp
@@ -1110,6 +1123,7 @@ export const pluginReactRouter = (
         },
         dev: {
           writeToDisk: true,
+          ...lazyCompilation,
           // Only add SSR middleware if SSR is enabled and not using a custom server
           // In SPA mode (ssr: false), we just serve static files from the client build
           setupMiddlewares:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1083,15 +1083,15 @@ export const pluginReactRouter = (
         /\.js$/,
         ''
       );
-      const configuredLazyCompilation =
+      const requestedLazyCompilation =
         pluginOptions.lazyCompilation === undefined
           ? config.dev?.lazyCompilation
           : pluginOptions.lazyCompilation;
       const guardedLazyCompilation = guardReactRouterLazyCompilation({
-        lazyCompilation: configuredLazyCompilation,
+        lazyCompilation: requestedLazyCompilation,
         entryClientPath: finalEntryClientPath,
       });
-      const lazyCompilation =
+      const devLazyCompilation =
         guardedLazyCompilation === undefined
           ? {}
           : { lazyCompilation: guardedLazyCompilation };
@@ -1123,7 +1123,7 @@ export const pluginReactRouter = (
         },
         dev: {
           writeToDisk: true,
-          ...lazyCompilation,
+          ...devLazyCompilation,
           // Only add SSR middleware if SSR is enabled and not using a custom server
           // In SPA mode (ssr: false), we just serve static files from the client build
           setupMiddlewares:

--- a/src/lazy-compilation.ts
+++ b/src/lazy-compilation.ts
@@ -19,17 +19,15 @@ const normalizeSlashes = (value: string): string => value.replace(/\\/g, '/');
 
 const getLazyCompilationModuleValues = (
   module: LazyCompilationModule
-): string[] => {
-  const values = [
+): string[] =>
+  [
     module.request,
     module.userRequest,
     module.rawRequest,
     module.resource,
     module.identifier?.(),
     module.nameForCondition?.(),
-  ];
-  return values.filter((value): value is string => Boolean(value));
-};
+  ].filter((value): value is string => Boolean(value));
 
 const matchesLazyCompilationTest = (
   test: LazyCompilationOptions['test'] | undefined,

--- a/src/lazy-compilation.ts
+++ b/src/lazy-compilation.ts
@@ -47,10 +47,7 @@ const matchesLazyCompilationTest = (
   return test.test(conditionName);
 };
 
-const isReactRouterHydrationModule = (
-  module: LazyCompilationModule,
-  entryClientPath: string
-): boolean => {
+const createReactRouterHydrationModuleTest = (entryClientPath: string) => {
   const eagerPatterns = [
     normalizeSlashes(entryClientPath),
     'virtual/react-router/browser-manifest',
@@ -58,9 +55,11 @@ const isReactRouterHydrationModule = (
     '?react-router-route',
   ];
 
-  return getLazyCompilationModuleValues(module)
-    .map(normalizeSlashes)
-    .some(value => eagerPatterns.some(pattern => value.includes(pattern)));
+  return (module: LazyCompilationModule): boolean =>
+    getLazyCompilationModuleValues(module).some(value => {
+      const normalizedValue = normalizeSlashes(value);
+      return eagerPatterns.some(pattern => normalizedValue.includes(pattern));
+    });
 };
 
 export const guardReactRouterLazyCompilation = ({
@@ -79,12 +78,14 @@ export const guardReactRouterLazyCompilation = ({
       ? { entries: true, imports: true }
       : lazyCompilation;
   const userTest = options.test;
+  const isReactRouterHydrationModule =
+    createReactRouterHydrationModuleTest(entryClientPath);
 
   return {
     ...options,
     test(module) {
       const lazyModule = module as LazyCompilationModule;
-      if (isReactRouterHydrationModule(lazyModule, entryClientPath)) {
+      if (isReactRouterHydrationModule(lazyModule)) {
         return false;
       }
       return matchesLazyCompilationTest(userTest, lazyModule);

--- a/src/lazy-compilation.ts
+++ b/src/lazy-compilation.ts
@@ -1,0 +1,93 @@
+import { BUILD_CLIENT_ROUTE_QUERY_STRING } from './constants.js';
+import type { PluginOptions } from './types.js';
+
+type LazyCompilationOptions = Exclude<
+  NonNullable<PluginOptions['lazyCompilation']>,
+  boolean
+>;
+
+type LazyCompilationModule = {
+  request?: string;
+  userRequest?: string;
+  rawRequest?: string;
+  resource?: string;
+  identifier?: () => string;
+  nameForCondition?: () => string | null;
+};
+
+const normalizeSlashes = (value: string): string => value.replace(/\\/g, '/');
+
+const getLazyCompilationModuleValues = (
+  module: LazyCompilationModule
+): string[] => {
+  const values = [
+    module.request,
+    module.userRequest,
+    module.rawRequest,
+    module.resource,
+    module.identifier?.(),
+    module.nameForCondition?.(),
+  ];
+  return values.filter((value): value is string => Boolean(value));
+};
+
+const matchesLazyCompilationTest = (
+  test: LazyCompilationOptions['test'] | undefined,
+  module: LazyCompilationModule
+): boolean => {
+  if (!test) {
+    return true;
+  }
+  if (typeof test === 'function') {
+    return test(module as Parameters<typeof test>[0]);
+  }
+  return getLazyCompilationModuleValues(module).some(value => {
+    test.lastIndex = 0;
+    return test.test(value);
+  });
+};
+
+const isReactRouterHydrationModule = (
+  module: LazyCompilationModule,
+  entryClientPath: string
+): boolean => {
+  const eagerPatterns = [
+    normalizeSlashes(entryClientPath),
+    'virtual/react-router/browser-manifest',
+    BUILD_CLIENT_ROUTE_QUERY_STRING,
+    '?react-router-route',
+  ];
+
+  return getLazyCompilationModuleValues(module)
+    .map(normalizeSlashes)
+    .some(value => eagerPatterns.some(pattern => value.includes(pattern)));
+};
+
+export const guardReactRouterLazyCompilation = ({
+  lazyCompilation,
+  entryClientPath,
+}: {
+  lazyCompilation: PluginOptions['lazyCompilation'] | undefined;
+  entryClientPath: string;
+}): PluginOptions['lazyCompilation'] | undefined => {
+  if (lazyCompilation === undefined || lazyCompilation === false) {
+    return lazyCompilation;
+  }
+
+  const options: LazyCompilationOptions =
+    lazyCompilation === true
+      ? { entries: true, imports: true }
+      : lazyCompilation;
+  const userTest = options.test;
+
+  return {
+    ...options,
+    test(module) {
+      const lazyModule = module as LazyCompilationModule;
+      if (isReactRouterHydrationModule(lazyModule, entryClientPath)) {
+        return false;
+      }
+      return matchesLazyCompilationTest(userTest, lazyModule);
+    },
+  };
+};

--- a/src/lazy-compilation.ts
+++ b/src/lazy-compilation.ts
@@ -41,10 +41,12 @@ const matchesLazyCompilationTest = (
   if (typeof test === 'function') {
     return test(module as Parameters<typeof test>[0]);
   }
-  return getLazyCompilationModuleValues(module).some(value => {
-    test.lastIndex = 0;
-    return test.test(value);
-  });
+  const conditionName = module.nameForCondition?.();
+  if (!conditionName) {
+    return false;
+  }
+  test.lastIndex = 0;
+  return test.test(conditionName);
 };
 
 const isReactRouterHydrationModule = (

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { RsbuildConfig } from '@rsbuild/core';
+
 export type Route = {
   id: string;
   parentId?: string;
@@ -27,6 +29,16 @@ export type PluginOptions = {
    * Federation mode configuration
    */
   federation?: boolean;
+
+  /**
+   * Opt in to Rsbuild's dev-only lazy compilation behavior.
+   *
+   * React Router hydration modules remain eager so initial dev requests can
+   * load the browser manifest and route modules without lazy proxy delays.
+   *
+   * @default undefined
+   */
+  lazyCompilation?: NonNullable<RsbuildConfig['dev']>['lazyCompilation'];
 };
 
 /**

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -31,6 +31,104 @@ describe('pluginReactRouter', () => {
     expect(nodeConfig.output.module).toBe(false);
   });
 
+  it('should forward lazy compilation when explicitly configured', async () => {
+    const rsbuild = await createStubRsbuild({
+      rsbuildConfig: {},
+    });
+
+    rsbuild.addPlugins([
+      pluginReactRouter({
+        lazyCompilation: {
+          entries: true,
+          imports: true,
+        },
+      }),
+    ]);
+    const config = await rsbuild.unwrapConfig();
+
+    expect(config.dev.lazyCompilation).toMatchObject({
+      entries: true,
+      imports: true,
+    });
+    expect(
+      config.dev.lazyCompilation.test({
+        resource: '/project/app/root.tsx?__react-router-build-client-route',
+      })
+    ).toBe(false);
+    expect(
+      config.dev.lazyCompilation.test({
+        resource: '/project/app/components/card.tsx',
+      })
+    ).toBe(true);
+  });
+
+  it('should allow lazy compilation to be enabled with a boolean', async () => {
+    const rsbuild = await createStubRsbuild({
+      rsbuildConfig: {},
+    });
+
+    rsbuild.addPlugins([pluginReactRouter({ lazyCompilation: true })]);
+    const config = await rsbuild.unwrapConfig();
+
+    expect(config.dev.lazyCompilation).toMatchObject({
+      entries: true,
+      imports: true,
+    });
+    expect(
+      config.dev.lazyCompilation.test({
+        resource: `${process.cwd()}/app/entry.client.tsx`,
+      })
+    ).toBe(false);
+  });
+
+  it('guards direct Rsbuild lazy compilation config for React Router hydration entries', async () => {
+    const rsbuild = await createStubRsbuild({
+      rsbuildConfig: {
+        dev: {
+          lazyCompilation: {
+            entries: true,
+            imports: false,
+            test: /app/,
+          },
+        },
+      },
+    });
+
+    rsbuild.addPlugins([pluginReactRouter()]);
+    const config = await rsbuild.unwrapConfig();
+
+    expect(config.dev.lazyCompilation).toMatchObject({
+      entries: true,
+      imports: false,
+    });
+    expect(
+      config.dev.lazyCompilation.test({
+        resource: '/project/app/routes/home.tsx?__react-router-build-client-route',
+      })
+    ).toBe(false);
+    expect(
+      config.dev.lazyCompilation.test({
+        resource: '/project/app/components/card.tsx',
+      })
+    ).toBe(true);
+    expect(
+      config.dev.lazyCompilation.test({
+        resource: '/project/vendor/react.tsx',
+      })
+    ).toBe(false);
+  });
+
+  it('should allow lazy compilation to be disabled', async () => {
+    const rsbuild = await createStubRsbuild({
+      rsbuildConfig: {},
+    });
+
+    rsbuild.addPlugins([pluginReactRouter({ lazyCompilation: false })]);
+    const config = await rsbuild.unwrapConfig();
+
+    expect(config.dev.lazyCompilation).toBe(false);
+  });
+
   it('should configure web environment correctly', async () => {
     const rsbuild = await createStubRsbuild({
       rsbuildConfig: {},

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -58,6 +58,7 @@ describe('pluginReactRouter', () => {
     expect(
       config.dev.lazyCompilation.test({
         resource: '/project/app/components/card.tsx',
+        nameForCondition: () => '/project/app/components/card.tsx',
       })
     ).toBe(true);
   });
@@ -109,11 +110,13 @@ describe('pluginReactRouter', () => {
     expect(
       config.dev.lazyCompilation.test({
         resource: '/project/app/components/card.tsx',
+        nameForCondition: () => '/project/app/components/card.tsx',
       })
     ).toBe(true);
     expect(
       config.dev.lazyCompilation.test({
         resource: '/project/vendor/react.tsx',
+        nameForCondition: () => '/project/vendor/react.tsx',
       })
     ).toBe(false);
   });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -2,6 +2,28 @@ import { createStubRsbuild } from '@scripts/test-helper';
 import { describe, expect, it } from '@rstest/core';
 import { pluginReactRouter } from '../src';
 
+type LazyCompilationTestModule = {
+  resource?: string;
+  nameForCondition?: () => string | null;
+};
+
+type LazyCompilationConfig = {
+  test?: (module: LazyCompilationTestModule) => boolean;
+};
+
+const getLazyCompilationTest = (
+  lazyCompilation: boolean | LazyCompilationConfig | undefined
+) => {
+  if (
+    !lazyCompilation ||
+    typeof lazyCompilation === 'boolean' ||
+    typeof lazyCompilation.test !== 'function'
+  ) {
+    throw new Error('Expected lazy compilation to install a test function.');
+  }
+  return lazyCompilation.test;
+};
+
 describe('pluginReactRouter', () => {
   it('should configure basic plugin options', async () => {
     const rsbuild = await createStubRsbuild({
@@ -50,13 +72,14 @@ describe('pluginReactRouter', () => {
       entries: true,
       imports: true,
     });
+    const test = getLazyCompilationTest(config.dev.lazyCompilation);
     expect(
-      config.dev.lazyCompilation.test({
+      test({
         resource: '/project/app/root.tsx?__react-router-build-client-route',
       })
     ).toBe(false);
     expect(
-      config.dev.lazyCompilation.test({
+      test({
         resource: '/project/app/components/card.tsx',
         nameForCondition: () => '/project/app/components/card.tsx',
       })
@@ -75,8 +98,9 @@ describe('pluginReactRouter', () => {
       entries: true,
       imports: true,
     });
+    const test = getLazyCompilationTest(config.dev.lazyCompilation);
     expect(
-      config.dev.lazyCompilation.test({
+      test({
         resource: `${process.cwd()}/app/entry.client.tsx`,
       })
     ).toBe(false);
@@ -102,19 +126,20 @@ describe('pluginReactRouter', () => {
       entries: true,
       imports: false,
     });
+    const test = getLazyCompilationTest(config.dev.lazyCompilation);
     expect(
-      config.dev.lazyCompilation.test({
+      test({
         resource: '/project/app/routes/home.tsx?__react-router-build-client-route',
       })
     ).toBe(false);
     expect(
-      config.dev.lazyCompilation.test({
+      test({
         resource: '/project/app/components/card.tsx',
         nameForCondition: () => '/project/app/components/card.tsx',
       })
     ).toBe(true);
     expect(
-      config.dev.lazyCompilation.test({
+      test({
         resource: '/project/vendor/react.tsx',
         nameForCondition: () => '/project/vendor/react.tsx',
       })

--- a/tests/lazy-compilation.test.ts
+++ b/tests/lazy-compilation.test.ts
@@ -1,6 +1,27 @@
 import { describe, expect, it } from '@rstest/core';
 import { guardReactRouterLazyCompilation } from '../src/lazy-compilation';
 
+type LazyCompilationTestModule = {
+  request?: string;
+  rawRequest?: string;
+  resource?: string;
+  identifier?: () => string;
+  nameForCondition?: () => string | null;
+};
+
+const getGuardedTest = (
+  guarded: ReturnType<typeof guardReactRouterLazyCompilation>
+): ((module: LazyCompilationTestModule) => boolean) => {
+  if (
+    !guarded ||
+    typeof guarded === 'boolean' ||
+    typeof guarded.test !== 'function'
+  ) {
+    throw new Error('Expected a guarded lazy compilation test function.');
+  }
+  return guarded.test;
+};
+
 describe('guardReactRouterLazyCompilation', () => {
   const entryClientPath = '/project/app/entry.client.tsx';
 
@@ -29,16 +50,13 @@ describe('guardReactRouterLazyCompilation', () => {
       entries: true,
       imports: true,
     });
+    const test = getGuardedTest(guarded);
     expect(
-      guarded?.test?.({
+      test({
         resource: `${entryClientPath}!lazy-compilation-proxy`,
       })
     ).toBe(false);
-    expect(
-      guarded?.test?.({
-        resource: '/project/app/components/card.tsx',
-      })
-    ).toBe(true);
+    expect(test({ resource: '/project/app/components/card.tsx' })).toBe(true);
   });
 
   it('preserves user tests for non-React Router hydration modules', () => {
@@ -55,19 +73,20 @@ describe('guardReactRouterLazyCompilation', () => {
       entries: true,
       imports: false,
     });
+    const test = getGuardedTest(guarded);
     expect(
-      guarded?.test?.({
+      test({
         resource: '/project/app/root.tsx?__react-router-build-client-route',
       })
     ).toBe(false);
     expect(
-      guarded?.test?.({
+      test({
         resource: '/project/app/components/card.tsx',
         nameForCondition: () => '/project/app/components/card.tsx',
       })
     ).toBe(true);
     expect(
-      guarded?.test?.({
+      test({
         resource: '/project/vendor/react.tsx',
         nameForCondition: () => '/project/vendor/react.tsx',
       })
@@ -83,16 +102,17 @@ describe('guardReactRouterLazyCompilation', () => {
       },
       entryClientPath,
     });
+    const test = getGuardedTest(guarded);
 
     expect(
-      guarded?.test?.({
+      test({
         rawRequest: 'node_modules-loader!/project/app/page.tsx',
         resource: '/project/app/page.tsx',
         nameForCondition: () => '/project/app/page.tsx',
       })
     ).toBe(false);
     expect(
-      guarded?.test?.({
+      test({
         rawRequest: './react',
         resource: '/project/node_modules/react/index.js',
         nameForCondition: () => '/project/node_modules/react/index.js',
@@ -108,20 +128,21 @@ describe('guardReactRouterLazyCompilation', () => {
       },
       entryClientPath,
     });
+    const test = getGuardedTest(guarded);
 
     expect(
-      guarded?.test?.({
+      test({
         request: 'virtual/react-router/browser-manifest',
       })
     ).toBe(false);
     expect(
-      guarded?.test?.({
+      test({
         identifier: () =>
           '/project/app/routes/home.tsx?__react-router-build-client-route',
       })
     ).toBe(false);
     expect(
-      guarded?.test?.({
+      test({
         nameForCondition: () =>
           '/project/app/routes/home.tsx?react-router-route',
       })

--- a/tests/lazy-compilation.test.ts
+++ b/tests/lazy-compilation.test.ts
@@ -63,13 +63,41 @@ describe('guardReactRouterLazyCompilation', () => {
     expect(
       guarded?.test?.({
         resource: '/project/app/components/card.tsx',
+        nameForCondition: () => '/project/app/components/card.tsx',
       })
     ).toBe(true);
     expect(
       guarded?.test?.({
         resource: '/project/vendor/react.tsx',
+        nameForCondition: () => '/project/vendor/react.tsx',
       })
     ).toBe(false);
+  });
+
+  it('applies RegExp user tests to the module condition name', () => {
+    const guarded = guardReactRouterLazyCompilation({
+      lazyCompilation: {
+        entries: true,
+        imports: true,
+        test: /node_modules/g,
+      },
+      entryClientPath,
+    });
+
+    expect(
+      guarded?.test?.({
+        rawRequest: 'node_modules-loader!/project/app/page.tsx',
+        resource: '/project/app/page.tsx',
+        nameForCondition: () => '/project/app/page.tsx',
+      })
+    ).toBe(false);
+    expect(
+      guarded?.test?.({
+        rawRequest: './react',
+        resource: '/project/node_modules/react/index.js',
+        nameForCondition: () => '/project/node_modules/react/index.js',
+      })
+    ).toBe(true);
   });
 
   it('guards all React Router hydration-critical module shapes', () => {

--- a/tests/lazy-compilation.test.ts
+++ b/tests/lazy-compilation.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from '@rstest/core';
+import { guardReactRouterLazyCompilation } from '../src/lazy-compilation';
+
+describe('guardReactRouterLazyCompilation', () => {
+  const entryClientPath = '/project/app/entry.client.tsx';
+
+  it('leaves disabled and unspecified lazy compilation unchanged', () => {
+    expect(
+      guardReactRouterLazyCompilation({
+        lazyCompilation: undefined,
+        entryClientPath,
+      })
+    ).toBeUndefined();
+    expect(
+      guardReactRouterLazyCompilation({
+        lazyCompilation: false,
+        entryClientPath,
+      })
+    ).toBe(false);
+  });
+
+  it('keeps boolean lazy compilation enabled while guarding hydration modules', () => {
+    const guarded = guardReactRouterLazyCompilation({
+      lazyCompilation: true,
+      entryClientPath,
+    });
+
+    expect(guarded).toMatchObject({
+      entries: true,
+      imports: true,
+    });
+    expect(
+      guarded?.test?.({
+        resource: `${entryClientPath}!lazy-compilation-proxy`,
+      })
+    ).toBe(false);
+    expect(
+      guarded?.test?.({
+        resource: '/project/app/components/card.tsx',
+      })
+    ).toBe(true);
+  });
+
+  it('preserves user tests for non-React Router hydration modules', () => {
+    const guarded = guardReactRouterLazyCompilation({
+      lazyCompilation: {
+        entries: true,
+        imports: false,
+        test: /app/g,
+      },
+      entryClientPath,
+    });
+
+    expect(guarded).toMatchObject({
+      entries: true,
+      imports: false,
+    });
+    expect(
+      guarded?.test?.({
+        resource: '/project/app/root.tsx?__react-router-build-client-route',
+      })
+    ).toBe(false);
+    expect(
+      guarded?.test?.({
+        resource: '/project/app/components/card.tsx',
+      })
+    ).toBe(true);
+    expect(
+      guarded?.test?.({
+        resource: '/project/vendor/react.tsx',
+      })
+    ).toBe(false);
+  });
+
+  it('guards all React Router hydration-critical module shapes', () => {
+    const guarded = guardReactRouterLazyCompilation({
+      lazyCompilation: {
+        entries: true,
+        imports: true,
+      },
+      entryClientPath,
+    });
+
+    expect(
+      guarded?.test?.({
+        request: 'virtual/react-router/browser-manifest',
+      })
+    ).toBe(false);
+    expect(
+      guarded?.test?.({
+        identifier: () =>
+          '/project/app/routes/home.tsx?__react-router-build-client-route',
+      })
+    ).toBe(false);
+    expect(
+      guarded?.test?.({
+        nameForCondition: () =>
+          '/project/app/routes/home.tsx?react-router-route',
+      })
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary\n- add a plugin `lazyCompilation` option that forwards to Rsbuild dev lazy compilation\n- guard React Router hydration-critical modules so browser manifest and route modules stay eager\n- also guard direct `dev.lazyCompilation` config when the plugin is installed\n\n## Verification\n- `pnpm test:core tests/lazy-compilation.test.ts tests/index.test.ts`\n- `pnpm build`