### PR TITLE
docs: simplify configuration docs

### DIFF
--- a/.changeset/quiet-docs-simplify.md
+++ b/.changeset/quiet-docs-simplify.md
@@ -1,0 +1,5 @@
+---
+'rsbuild-plugin-react-router': patch
+---
+
+Simplify the README configuration docs and stabilize `parallelRouteTransform` so `true` forces the default worker count, a positive integer sets the worker count, and `false` disables worker-thread route transforms.

--- a/README.md
+++ b/README.md
@@ -47,164 +47,86 @@ Add the plugin to your `rsbuild.config.ts`:
 
 ```ts
 import { defineConfig } from '@rsbuild/core';
-import { pluginReactRouter } from 'rsbuild-plugin-react-router';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { pluginReactRouter } from 'rsbuild-plugin-react-router';
 
-export default defineConfig(() => {
-  return {
-    plugins: [
-      pluginReactRouter({
-        // Optional: Enable custom server mode
-        customServer: false,
-        // Optional: Specify server output format
-        serverOutput: 'commonjs',
-        // Optional: enable experimental support for module federation
-        federation: false,
-      }),
-      pluginReact(),
-    ],
-  };
+export default defineConfig({
+  plugins: [
+    pluginReactRouter({
+      // options here
+    }),
+    pluginReact(),
+  ],
 });
 ```
 
 ## Configuration
 
-The plugin uses a two-part configuration system:
+React Router application settings live in `react-router.config.*`. The Rsbuild
+plugin only needs options for Rsbuild-specific behavior.
 
-1. **Plugin Options** (in `rsbuild.config.ts`):
+### Plugin Options
 
 ```ts
 pluginReactRouter({
-  /**
-   * Whether to disable automatic middleware setup for custom server implementation.
-   * Enable this when you want to handle server setup manually.
-   * @default false
-   */
-  customServer?: boolean,
-
-  /**
-   * Specify the output format for server-side code.
-   * Options: "commonjs" | "module"
-   * @default "module"
-   */
-  serverOutput?: "commonjs" | "module",
-
-  /**
-   * Rsbuild dev-only lazy compilation behavior.
-   * The plugin guards React Router hydration-critical modules so
-   * `lazyCompilation: { entries: true }` remains enabled without replacing
-   * manifest route modules with lazy entry proxies.
-   * @default undefined
-   */
-  lazyCompilation?: boolean | Rspack.LazyCompilationOptions,
-
-  /**
-   * Emit structured React Router plugin timing logs.
-   * @default false
-   */
-  logPerformance?: boolean,
-
-  /**
-   * Run route transforms in a worker-thread pool.
-   * Pass `false` to disable or `{ maxWorkers }` to override the default worker count.
-   * @default Automatically enabled for 256+ resolved routes. The automatic
-   * pool uses available CPU cores minus 2.
-   */
-  parallelTransforms?: boolean | { maxWorkers?: number },
-
-  /**
-   * Route-topology notification for programmatic/custom dev servers.
-   * Recreate the Rsbuild server when this fires.
-   */
-  onRouteTopologyChange?: () => void | Promise<void>,
-
-  /**
-   * Enable experimental support for module federation
-   * @default false
-   */
-  federation?: boolean
-})
-
-When Module Federation is enabled, configure your Federation plugin with
-`experiments.asyncStartup: true` to avoid requiring entrypoint `import()` hacks.
-See the Module Federation examples under `examples/federation`.
-
-When Module Federation is enabled, some runtimes may expose server build exports
-as async getters. The dev server resolves these exports automatically. For
-production, use a custom server or an adapter that resolves async exports before
-passing the build to React Router's request handler.
+  customServer: false,
+  serverOutput: 'module',
+  lazyCompilation: undefined,
+  logPerformance: false,
+  parallelRouteTransform: undefined,
+  onRouteTopologyChange: undefined,
+  federation: false,
+});
 ```
 
-2. **React Router Configuration** (in `react-router.config.*`):
+| Option                   | Default     | Description                                                                                                                                                                                                                      |
+| ------------------------ | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `customServer`           | `false`     | Disables the built-in development SSR middleware. Enable this when an app owns the server with `createDevServer()` or an adapter.                                                                                                |
+| `serverOutput`           | `'module'`  | Emitted Rsbuild server format: `'module'` or `'commonjs'`. When omitted, React Router's `serverModuleFormat` selects the format (`'esm'` -> `'module'`, `'cjs'` -> `'commonjs'`); setting `serverOutput` overrides it.           |
+| `lazyCompilation`        | `undefined` | Optional Rsbuild dev lazy-compilation config. When enabled here or through `dev.lazyCompilation`, React Router hydration-critical modules stay eager so the browser manifest and route modules are not replaced by lazy proxies. |
+| `logPerformance`         | `false`     | Logs structured React Router plugin timing information through the Rsbuild logger.                                                                                                                                               |
+| `parallelRouteTransform` | `undefined` | Controls worker-thread route transforms. `undefined` auto-enables workers for 256+ routes, `true` forces the default worker count, a positive integer sets the worker count, and `false` keeps transforms inline.                |
+| `onRouteTopologyChange`  | `undefined` | Notification for programmatic/custom dev servers. Recreate the Rsbuild server when route files are added, removed, or moved. The callback is not awaited.                                                                        |
+| `federation`             | `false`     | Enables the plugin's experimental Module Federation integration.                                                                                                                                                                 |
+
+When `federation` is enabled, configure the Module Federation plugin with
+`experiments.asyncStartup: true`. The dev server resolves async server build
+exports automatically; production custom servers or adapters should resolve
+async exports before passing the build to React Router's request handler.
+
+### React Router Config
+
+Put React Router framework settings in `react-router.config.*`:
 
 ```ts
 import type { Config } from '@react-router/dev/config';
 
 export default {
-  /**
-   * Whether to enable Server-Side Rendering (SSR) support.
-   * @default true
-   */
   ssr: true,
-
-  /**
-   * The file name for the server build output.
-   * @default "index.js"
-   */
-  serverBuildFile: 'index.js',
-
-  /**
-   * The output format for the server build.
-   * Options: "esm" | "cjs"
-   * @default "esm"
-   */
-  serverModuleFormat: 'esm',
-
-  /**
-   * Split server bundles by route branch (advanced).
-   */
-  serverBundles: async ({ branch }) => branch[0]?.id ?? 'main',
-
-  /**
-   * Enable Subresource Integrity for browser assets.
-   * @default false
-   */
-  subResourceIntegrity: true,
-
-  /**
-   * Hook called after the build completes.
-   */
-  buildEnd: async ({ buildManifest, reactRouterConfig }) => {
-    console.log(buildManifest, reactRouterConfig);
-  },
-
-  /**
-   * Build directory for output files
-   * @default 'build'
-   */
-  buildDirectory: 'dist',
-
-  /**
-   * Application source directory
-   * @default 'app'
-   */
+  buildDirectory: 'build',
   appDirectory: 'app',
-
-  /**
-   * Base URL path
-   * @default '/'
-   */
-  basename: '/my-app',
-
-  /**
-   * Split client route module exports into separate chunks.
-   * @default true
-   */
+  basename: '/',
   splitRouteModules: true,
+  subResourceIntegrity: false,
 } satisfies Config;
 ```
 
-All configuration options are optional and will use sensible defaults if not specified.
+Commonly used options:
+
+| Option                 | Default      | Notes                                                                                                                     |
+| ---------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| `ssr`                  | `true`       | Set `false` for SPA mode. SPA mode still runs a build-time server render to create `build/client/index.html`.             |
+| `buildDirectory`       | `'build'`    | Output root. Client assets go in `<buildDirectory>/client`; server output goes in `<buildDirectory>/server`.              |
+| `appDirectory`         | `'app'`      | Directory containing `root`, `routes`, and optional `entry.client` / `entry.server` files.                                |
+| `basename`             | `'/'`        | Base URL used for routing, prerender requests, and manifest asset paths.                                                  |
+| `serverBuildFile`      | `'index.js'` | Server build file name. It must end in `.js`.                                                                             |
+| `serverModuleFormat`   | `'esm'`      | React Router server module format: `'esm'` or `'cjs'`. `serverOutput` can override the emitted Rsbuild server format.     |
+| `serverBundles`        | `undefined`  | Advanced server bundle splitting by route branch. Disabled when `ssr: false`.                                             |
+| `routeDiscovery`       | React Router | Defaults to lazy discovery for SSR and initial discovery for SPA mode. `routeDiscovery.mode: 'lazy'` is invalid for SPA.  |
+| `prerender`            | `undefined`  | `true`, an array of paths, a function, or `{ paths, concurrency }` / `{ paths, unstable_concurrency }`.                   |
+| `splitRouteModules`    | `true`       | Splits client route module exports. The legacy `future.v8_splitRouteModules` flag is also accepted.                       |
+| `subResourceIntegrity` | `false`      | Emits SRI metadata for browser scripts. The legacy `future.unstable_subResourceIntegrity` flag is normalized to this key. |
+| `buildEnd`             | `undefined`  | Hook called after the build with the React Router build manifest and resolved config.                                     |
 
 ### Config File Resolution
 
@@ -291,48 +213,19 @@ export default {
 } satisfies Config;
 ```
 
-Prerendering defaults to one path at a time, matching React Router. You can opt
-into concurrent prerendering for large sites:
+Prerendering defaults to one path at a time, matching React Router. Use
+`concurrency` for larger sites; `unstable_concurrency` is still accepted for
+older configs:
 
 ```ts
 export default {
   ssr: false,
   prerender: {
     paths: ['/', '/about'],
-    unstable_concurrency: 4,
+    concurrency: 4,
   },
 } satisfies Config;
 ```
-
-### Default Configuration Values
-
-If no configuration is provided, the following defaults will be used:
-
-```ts
-// Plugin defaults (rsbuild.config.ts)
-{
-  customServer: false,
-  serverOutput: 'module',
-  federation: false,
-  lazyCompilation: undefined, // Rsbuild's dev defaults still apply
-  logPerformance: false,
-  parallelTransforms: undefined // adaptive: workers for 256+ resolved routes
-}
-
-// Router defaults (react-router.config.ts)
-{
-  ssr: true,
-  buildDirectory: 'build',
-  appDirectory: 'app',
-  basename: '/',
-  subResourceIntegrity: false
-}
-```
-
-Route transforms run inline for fewer than 256 resolved routes and use worker
-threads for larger route graphs. The automatic worker count uses available CPU
-cores minus 2. Pass `true` to force workers, `{ maxWorkers }` to override that
-count, or `false` to force inline transforms.
 
 For builds with 256+ routes, detailed file-size reporting is compacted to totals
 by default to avoid gzipping and printing thousands of assets. Set
@@ -341,12 +234,6 @@ by default to avoid gzipping and printing thousands of assets. Set
 Route transform source maps are generated in development only. If you enable
 Rsbuild source maps for faster local debugging, prefer a cheap JS map:
 `output.sourceMap: { js: 'cheap-module-source-map', css: false }`.
-
-Subresource Integrity is disabled by default. Enable it with
-`subResourceIntegrity: true` in `react-router.config.*` when the deployed app
-should emit integrity metadata for browser scripts. The legacy
-`future.unstable_subResourceIntegrity` flag is still accepted and is normalized
-to the stable option.
 
 ### Route Configuration
 
@@ -575,15 +462,6 @@ Then update your `package.json` scripts:
   }
 }
 ```
-
-The custom server setup allows you to:
-
-- Add custom middleware
-- Handle API routes
-- Integrate with databases
-- Implement custom authentication
-- Add server-side caching
-- And more!
 
 ## Cloudflare Workers Deployment
 

--- a/scripts/bench-builds.mjs
+++ b/scripts/bench-builds.mjs
@@ -102,7 +102,7 @@ const parseArgs = argv => {
       },
       clean: { type: 'string', default: 'build' },
       filter: { type: 'string' },
-      'parallel-transforms': { type: 'string' },
+      'parallel-route-transform': { type: 'string' },
       'rspack-profile': { type: 'string' },
       'rspack-trace-output': { type: 'string' },
       'fail-fast': { type: 'boolean', default: false },
@@ -115,7 +115,7 @@ const parseArgs = argv => {
     },
   });
 
-  const parseParallelTransforms = value => {
+  const parseParallelRouteTransform = value => {
     if (value === undefined) {
       return undefined;
     }
@@ -125,16 +125,16 @@ const parseArgs = argv => {
     if (value === 'auto') {
       return undefined;
     }
-    if (value === 'true' || value === '1') {
+    if (value === 'true') {
       return true;
     }
-    const maxWorkers = Number(value);
-    if (!Number.isInteger(maxWorkers) || maxWorkers < 1) {
+    const workerCount = Number(value);
+    if (!Number.isInteger(workerCount) || workerCount < 1) {
       throw new Error(
-        '--parallel-transforms must be true, false, auto, or a positive integer.'
+        '--parallel-route-transform must be true, false, auto, or a positive integer.'
       );
     }
-    return { maxWorkers };
+    return workerCount;
   };
 
   const args = {
@@ -146,7 +146,9 @@ const parseArgs = argv => {
     out: values.out,
     clean: values.clean,
     filter: values.filter ?? null,
-    parallelTransforms: parseParallelTransforms(values['parallel-transforms']),
+    parallelRouteTransform: parseParallelRouteTransform(
+      values['parallel-route-transform']
+    ),
     rspackProfile: values['rspack-profile'] ?? null,
     rspackTraceOutput: values['rspack-trace-output'] ?? null,
     failFast: values['fail-fast'],
@@ -681,7 +683,7 @@ const renderMarkdown = result => {
           `- Dev route timeout: ${result.devRouteTimeoutMs} ms`,
         ]
       : []),
-    `- Parallel transforms: ${formatParallelTransforms(result.parallelTransforms)}`,
+    `- Parallel route transform: ${formatParallelRouteTransform(result.parallelRouteTransform)}`,
     `- Plugin performance logging: ${String(result.logPerformance)}`,
     `- Rspack profile: ${result.rspackProfile ?? 'false'}`,
     ...(result.rspackTraceOutput
@@ -827,17 +829,17 @@ const writeOutputs = async (result, outputPaths) => {
   }
 };
 
-const formatParallelTransforms = parallelTransforms => {
-  if (parallelTransforms === undefined) {
+const formatParallelRouteTransform = parallelRouteTransform => {
+  if (parallelRouteTransform === undefined) {
     return 'adaptive';
   }
-  if (!parallelTransforms) {
+  if (!parallelRouteTransform) {
     return 'false';
   }
-  if (parallelTransforms === true) {
+  if (parallelRouteTransform === true) {
     return 'true';
   }
-  return `maxWorkers=${parallelTransforms.maxWorkers}`;
+  return `workers=${parallelRouteTransform}`;
 };
 
 const git = async args => {
@@ -980,7 +982,7 @@ const main = async () => {
       fixture: benchmark.fixture ?? 'default',
       pluginImportPath,
       pluginReactImportPath,
-      parallelTransforms: args.parallelTransforms,
+      parallelRouteTransform: args.parallelRouteTransform,
     });
 
     const runs = [];
@@ -1119,7 +1121,7 @@ const main = async () => {
       ...benchmark,
       fixture: fixtureResult.fixture,
       fixtureStats: fixtureResult.stats ?? null,
-      parallelTransforms: args.parallelTransforms,
+      parallelRouteTransform: args.parallelRouteTransform,
       devRoutePaths,
       cwd: path.relative(rootDir, fixtureRoot),
       command:
@@ -1151,7 +1153,7 @@ const main = async () => {
     logPerformance: args.logPerformance,
     devRoutes: args.mode === 'dev' ? args.devRoutes : null,
     devRouteTimeoutMs: args.mode === 'dev' ? args.devRouteTimeoutMs : null,
-    parallelTransforms: args.parallelTransforms,
+    parallelRouteTransform: args.parallelRouteTransform,
     rspackProfile: args.rspackProfile,
     rspackTraceOutput: args.rspackTraceOutput,
     failed,

--- a/scripts/benchmark/fixture.mjs
+++ b/scripts/benchmark/fixture.mjs
@@ -237,19 +237,17 @@ const createRoutesConfig = routeCount => {
   ].join('\n');
 };
 
-const renderParallelTransformsOption = parallelTransforms => {
-  if (parallelTransforms === undefined) {
+const renderParallelRouteTransformOption = parallelRouteTransform => {
+  if (parallelRouteTransform === undefined) {
     return [];
   }
-  if (parallelTransforms === false) {
-    return [`      parallelTransforms: false,`];
+  if (parallelRouteTransform === false) {
+    return [`      parallelRouteTransform: false,`];
   }
-  if (parallelTransforms === true) {
-    return [`      parallelTransforms: true,`];
+  if (parallelRouteTransform === true) {
+    return [`      parallelRouteTransform: true,`];
   }
-  return [
-    `      parallelTransforms: { maxWorkers: ${parallelTransforms.maxWorkers} },`,
-  ];
+  return [`      parallelRouteTransform: ${parallelRouteTransform},`];
 };
 
 const createRsbuildConfig = ({
@@ -257,7 +255,7 @@ const createRsbuildConfig = ({
   sourceMap,
   pluginImportPath,
   pluginReactImportPath,
-  parallelTransforms,
+  parallelRouteTransform,
 }) => {
   const ssr = variant !== 'spa';
   const lazyCompilationOption =
@@ -276,7 +274,7 @@ const createRsbuildConfig = ({
     '    pluginReact(),',
     '    pluginReactRouter({',
     ...(ssr ? [`      serverOutput: 'module',`] : []),
-    ...renderParallelTransformsOption(parallelTransforms),
+    ...renderParallelRouteTransformOption(parallelRouteTransform),
     lazyCompilationOption,
     `      logPerformance: process.env.REACT_ROUTER_BENCHMARK_LOG_PERFORMANCE === '1',`,
     '    }),',
@@ -655,7 +653,7 @@ const generateLargeFixture = async ({
   sourceMap,
   pluginImportPath,
   pluginReactImportPath,
-  parallelTransforms,
+  parallelRouteTransform,
   largeConfig,
 }) => {
   const config = normalizeLargeConfig(routeCount, largeConfig);
@@ -688,7 +686,7 @@ const generateLargeFixture = async ({
         sourceMap,
         pluginImportPath,
         pluginReactImportPath,
-        parallelTransforms,
+        parallelRouteTransform,
       }),
     ],
     [
@@ -800,7 +798,7 @@ const generateLargeFixture = async ({
     variant,
     sourceMap,
     fixture: 'large',
-    parallelTransforms,
+    parallelRouteTransform,
     stats: createLargeStats(config),
   };
 };
@@ -813,7 +811,7 @@ export async function generateSyntheticFixture({
   pluginImportPath = 'rsbuild-plugin-react-router',
   pluginReactImportPath = '@rsbuild/plugin-react',
   fixture = 'default',
-  parallelTransforms,
+  parallelRouteTransform,
   largeConfig,
 }) {
   if (!stressFixtureNames.has(fixture)) {
@@ -830,7 +828,7 @@ export async function generateSyntheticFixture({
       sourceMap,
       pluginImportPath,
       pluginReactImportPath,
-      parallelTransforms,
+      parallelRouteTransform,
       largeConfig,
     });
   }
@@ -851,7 +849,7 @@ export async function generateSyntheticFixture({
       sourceMap,
       pluginImportPath,
       pluginReactImportPath,
-      parallelTransforms,
+      parallelRouteTransform,
     })
   );
   await writeFile(
@@ -912,6 +910,6 @@ export async function generateSyntheticFixture({
     variant,
     sourceMap,
     fixture,
-    parallelTransforms,
+    parallelRouteTransform,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -437,8 +437,8 @@ export const pluginReactRouter = (
     };
     const routeChunkCache: RouteChunkCache = new Map();
     const routeTransformExecutor = createRouteTransformExecutor({
-      parallelTransforms:
-        pluginOptions.parallelTransforms ??
+      parallelRouteTransform:
+        pluginOptions.parallelRouteTransform ??
         shouldParallelizeRouteTransforms(routeCount),
       routeChunkCache,
       splitRouteModules: Boolean(splitRouteModules),

--- a/src/parallel-route-transforms.ts
+++ b/src/parallel-route-transforms.ts
@@ -14,13 +14,13 @@ import type {
   WorkerResponse,
 } from './parallel-route-transform-protocol.js';
 
-export type ParallelTransformsConfig =
-  NonNullable<PluginOptions['parallelTransforms']> extends infer Config
+export type ParallelRouteTransformConfig =
+  NonNullable<PluginOptions['parallelRouteTransform']> extends infer Config
     ? Exclude<Config, false>
     : never;
 
 export type RouteTransformExecutorOptions = RouteTransformTaskOptions & {
-  parallelTransforms?: PluginOptions['parallelTransforms'];
+  parallelRouteTransform?: PluginOptions['parallelRouteTransform'];
   splitRouteModules?: boolean;
 };
 
@@ -57,22 +57,18 @@ export const shouldParallelizeRouteTransforms = (routeCount: number): boolean =>
   routeCount >= AUTO_PARALLEL_ROUTE_THRESHOLD;
 
 const getConfiguredWorkerCount = (
-  parallelTransforms: ParallelTransformsConfig
+  parallelRouteTransform: ParallelRouteTransformConfig
 ): number => {
-  if (parallelTransforms === true) {
+  if (parallelRouteTransform === true) {
     return getDefaultWorkerCount();
   }
 
-  const configured = parallelTransforms.maxWorkers;
-  if (configured === undefined) {
-    return getDefaultWorkerCount();
-  }
-  if (!Number.isInteger(configured) || configured < 1) {
+  if (!Number.isInteger(parallelRouteTransform) || parallelRouteTransform < 1) {
     throw new Error(
-      '[react-router] parallelTransforms.maxWorkers must be a positive integer.'
+      '[react-router] parallelRouteTransform must be true, false, or a positive integer.'
     );
   }
-  return configured;
+  return parallelRouteTransform;
 };
 
 const hashString = (value: string): number => {
@@ -305,20 +301,22 @@ class ParallelRouteTransformExecutor implements RouteTransformExecutor {
 }
 
 export const createRouteTransformExecutor = ({
-  parallelTransforms,
+  parallelRouteTransform,
   routeChunkCache,
   splitRouteModules,
 }: RouteTransformExecutorOptions = {}): RouteTransformExecutor => {
   const options = { routeChunkCache };
-  const effectiveParallelTransforms = parallelTransforms ?? false;
-  if (!effectiveParallelTransforms) {
+  if (
+    parallelRouteTransform === undefined ||
+    parallelRouteTransform === false
+  ) {
     return {
       run: task => executeRouteTransformTask(task, options),
       close: async () => {},
     };
   }
 
-  const workerCount = getConfiguredWorkerCount(effectiveParallelTransforms);
+  const workerCount = getConfiguredWorkerCount(parallelRouteTransform);
   if (workerCount < 1) {
     return {
       run: task => executeRouteTransformTask(task, options),

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,15 +48,12 @@ export type PluginOptions = {
 
   /**
    * Run route transforms in a worker-thread pool.
-   * Pass `false` to disable or `{ maxWorkers }` to override the default worker count.
+   * Pass `true` to force the default worker count, a positive integer to set
+   * the worker count, or `false` to disable.
    * @default Automatically enabled for 256+ resolved routes. The automatic
    * pool uses available CPU cores minus 2.
    */
-  parallelTransforms?:
-    | boolean
-    | {
-        maxWorkers?: number;
-      };
+  parallelRouteTransform?: boolean | number;
 
   /**
    * Called when the route graph changes during development.

--- a/tests/benchmark-fixture.test.ts
+++ b/tests/benchmark-fixture.test.ts
@@ -49,7 +49,7 @@ describe('benchmark fixture generator', () => {
       expect(rsbuildConfig).toContain(
         "sourceMap: { js: 'cheap-module-source-map', css: false }"
       );
-      expect(rsbuildConfig).not.toContain('parallelTransforms:');
+      expect(rsbuildConfig).not.toContain('parallelRouteTransform:');
 
       const reactRouterConfig = readFileSync(
         join(root, 'react-router.config.ts'),
@@ -96,14 +96,12 @@ describe('benchmark fixture generator', () => {
         root,
         routeCount: 1,
         variant: 'ssr-esm',
-        parallelTransforms: { maxWorkers: 3 },
+        parallelRouteTransform: 3,
       });
 
       const rsbuildConfig = readFileSync(join(root, 'rsbuild.config.mjs'), 'utf8');
-      expect(result.parallelTransforms).toEqual({ maxWorkers: 3 });
-      expect(rsbuildConfig).toContain(
-        'parallelTransforms: { maxWorkers: 3 },'
-      );
+      expect(result.parallelRouteTransform).toBe(3);
+      expect(rsbuildConfig).toContain('parallelRouteTransform: 3,');
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -120,12 +118,12 @@ describe('benchmark fixture generator', () => {
         root,
         routeCount: 1,
         variant: 'ssr-esm',
-        parallelTransforms: false,
+        parallelRouteTransform: false,
       });
 
       const rsbuildConfig = readFileSync(join(root, 'rsbuild.config.mjs'), 'utf8');
-      expect(result.parallelTransforms).toBe(false);
-      expect(rsbuildConfig).toContain('parallelTransforms: false,');
+      expect(result.parallelRouteTransform).toBe(false);
+      expect(rsbuildConfig).toContain('parallelRouteTransform: false,');
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/tests/parallel-route-transforms.test.ts
+++ b/tests/parallel-route-transforms.test.ts
@@ -83,17 +83,50 @@ describe('parallel route transforms', () => {
     expect(maxActive).toBeLessThanOrEqual(2);
   });
 
-  it('rejects invalid explicit worker counts', () => {
-    expect(() =>
-      createRouteTransformExecutor({
-        parallelTransforms: { maxWorkers: 1.5 },
-      })
-    ).toThrow('must be a positive integer');
+  it.each([0, Number.NaN, 1.5])(
+    'rejects invalid explicit worker count %s',
+    workerCount => {
+      expect(() =>
+        createRouteTransformExecutor({
+          parallelRouteTransform: workerCount,
+        })
+      ).toThrow('must be true, false, or a positive integer');
+    }
+  );
+
+  it('allows one explicit worker', async () => {
+    const executor = createRouteTransformExecutor({
+      parallelRouteTransform: 1,
+    });
+
+    try {
+      const result = await executor.run(createRouteModuleTask());
+
+      expect(result.code).toContain('export default _withComponentProps');
+      expect(result.code).not.toContain('loader');
+    } finally {
+      await executor.close();
+    }
   });
 
-  it('honors explicit maxWorkers', async () => {
+  it('honors an explicit worker count', async () => {
     const executor = createRouteTransformExecutor({
-      parallelTransforms: { maxWorkers: 2 },
+      parallelRouteTransform: 2,
+    });
+
+    try {
+      const result = await executor.run(createRouteModuleTask());
+
+      expect(result.code).toContain('export default _withComponentProps');
+      expect(result.code).not.toContain('loader');
+    } finally {
+      await executor.close();
+    }
+  });
+
+  it('forces the default worker count with true', async () => {
+    const executor = createRouteTransformExecutor({
+      parallelRouteTransform: true,
     });
 
     try {
@@ -108,7 +141,7 @@ describe('parallel route transforms', () => {
 
   it('runs route builds inline when parallel transforms are disabled', async () => {
     const executor = createRouteTransformExecutor({
-      parallelTransforms: false,
+      parallelRouteTransform: false,
     });
 
     try {
@@ -142,7 +175,7 @@ describe('parallel route transforms', () => {
 
   it('can execute route module tasks through worker-backed parallelism', async () => {
     const executor = createRouteTransformExecutor({
-      parallelTransforms: { maxWorkers: 2 },
+      parallelRouteTransform: 2,
     });
 
     try {
@@ -157,7 +190,7 @@ describe('parallel route transforms', () => {
 
   it('produces identical build route modules when environments need the same output', async () => {
     const executor = createRouteTransformExecutor({
-      parallelTransforms: { maxWorkers: 2 },
+      parallelRouteTransform: 2,
       splitRouteModules: true,
     });
     const task = createRouteModuleTask({
@@ -184,7 +217,7 @@ describe('parallel route transforms', () => {
 
   it('keeps environment-specific build route module output isolated', async () => {
     const executor = createRouteTransformExecutor({
-      parallelTransforms: { maxWorkers: 2 },
+      parallelRouteTransform: 2,
       splitRouteModules: true,
     });
     const task = createRouteModuleTask({
@@ -212,7 +245,7 @@ describe('parallel route transforms', () => {
 
   it('isolates escaped server exports across build environments', async () => {
     const executor = createRouteTransformExecutor({
-      parallelTransforms: { maxWorkers: 2 },
+      parallelRouteTransform: 2,
       splitRouteModules: true,
     });
     const task = createRouteModuleTask({
@@ -232,8 +265,12 @@ describe('parallel route transforms', () => {
         environmentName: 'web',
       });
 
-      expect(nodeResult.code).toContain('loader');
-      expect(webResult.code).not.toContain('loader');
+      await expect(getExportNames(nodeResult.code)).resolves.toContain(
+        'loader'
+      );
+      await expect(getExportNames(webResult.code)).resolves.not.toContain(
+        'loader'
+      );
     } finally {
       await executor.close();
     }


### PR DESCRIPTION
## Summary
- simplify the README usage/configuration sections
- document every current plugin option in one table
- stabilize the public route-transform worker option as `parallelRouteTransform`: `true` forces the default worker count, a positive integer sets the worker count, and `false` disables route transform workers
- update benchmark fixture/config helpers and tests to emit `parallelRouteTransform`
- clarify React Router config defaults, including SRI and route transform worker behavior
- remove redundant/defaults prose and fix the malformed configuration code fence

## Verification
- pnpm exec prettier --check README.md .changeset/quiet-docs-simplify.md src/types.ts src/index.ts src/parallel-route-transforms.ts scripts/bench-builds.mjs scripts/benchmark/fixture.mjs tests/parallel-route-transforms.test.ts tests/benchmark-fixture.test.ts
- pnpm test:core tests/parallel-route-transforms.test.ts tests/benchmark-fixture.test.ts
- pnpm test:core
- pnpm build
- pnpm changeset status --since origin/main
- TraceDecay diff context for the changed files