### PR TITLE
fix(bench): skip dev route fetches for SPA fixtures via per-profile devRoutes

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -63,6 +63,13 @@ node scripts/bench-builds.mts --profile=large --mode=dev --dev-routes=/,/route-0
 Numeric route indexes are ordinal benchmark positions: `0` is `/`, and `1` is
 the first non-index generated route for that fixture.
 
+Profile entries can pin dev-route behavior with a `devRoutes` field that takes
+precedence over the CLI flag. SPA fixtures (`ssr: false`) set
+`devRoutes: 'none'` because the dev server has no HTML document to serve for
+route paths (no SSR middleware, and all web entries disable HTML generation),
+so those fixtures measure dev readiness and update rebuild timings without
+issuing route requests.
+
 Route requests automatically add `--experimental-vm-modules` to `NODE_OPTIONS`
 for SSR ESM evaluation.
 

--- a/scripts/bench-builds.mts
+++ b/scripts/bench-builds.mts
@@ -415,6 +415,7 @@ const runBenchmarkIteration = (benchmarkContext, index) =>
       benchmark,
       benchmarkIndex,
       devRoutePaths,
+      devUpdateRoutePaths,
       fixtureResult,
       fixtureRoot,
       measuredIterations,
@@ -500,7 +501,7 @@ const runBenchmarkIteration = (benchmarkContext, index) =>
               routePaths: devRoutePaths,
               routeTimeoutMs: args.devRouteTimeoutMs,
               updateFile: fixtureResult.updateFile,
-              updateRoutePaths: fixtureResult.updateRoutePaths ?? ['/'],
+              updateRoutePaths: devUpdateRoutePaths,
               timeoutMs: args.devTimeoutMs,
             });
           })
@@ -591,9 +592,12 @@ const runBenchmark = ({
   Effect.gen(function* () {
     const measuredIterations = getMeasuredIterationCount(benchmark, args);
     const fixtureRoot = path.join(benchmarkRoot, 'fixtures', benchmark.id);
+    // Profile entries can pin dev-route behavior (e.g. `devRoutes: 'none'`
+    // for SPA fixtures, which serve no HTML document per route in dev).
+    const devRoutesValue = benchmark.devRoutes ?? args.devRoutes;
     const devRoutePaths =
       args.mode === 'dev'
-        ? resolveDevRoutePaths(args.devRoutes, benchmark)
+        ? resolveDevRoutePaths(devRoutesValue, benchmark)
         : [];
     const fixtureResult = yield* tryPromise(() =>
       generateSyntheticFixture({
@@ -609,11 +613,16 @@ const runBenchmark = ({
       })
     );
     const totalRuns = args.warmup + measuredIterations;
+    const devUpdateRoutePaths =
+      args.mode === 'dev' && devRoutesValue !== 'none'
+        ? (fixtureResult.updateRoutePaths ?? ['/'])
+        : [];
     const benchmarkContext = {
       args,
       benchmark,
       benchmarkIndex,
       devRoutePaths,
+      devUpdateRoutePaths,
       fixtureResult,
       fixtureRoot,
       measuredIterations,

--- a/scripts/benchmark/dev-server.mjs
+++ b/scripts/benchmark/dev-server.mjs
@@ -293,7 +293,7 @@ export const runDevServerBenchmark = async ({
         }
       }
 
-      if (updateFile && updateRoutePaths.length > 0) {
+      if (updateFile) {
         let restoreUpdateFile = null;
         const updateStartedAt = performance.now();
         const baselineCounts = new Map(readyCounts);
@@ -305,16 +305,18 @@ export const runDevServerBenchmark = async ({
           await waitForNextReady(baselineCounts);
           updateMs = performance.now() - updateStartedAt;
 
-          const updateRouteStartedAt = performance.now();
-          updateRouteRequests = await fetchDevRoutes({
-            origin,
-            routePaths: updateRoutePaths,
-            timeoutMs: routeTimeoutMs,
-            retryDelayMs: routeRetryDelayMs,
-          });
-          updateRouteTotalMs = performance.now() - updateRouteStartedAt;
-          if (updateRouteRequests.some(request => !request.ok)) {
-            statusAfterReady = 1;
+          if (updateRoutePaths.length > 0) {
+            const updateRouteStartedAt = performance.now();
+            updateRouteRequests = await fetchDevRoutes({
+              origin,
+              routePaths: updateRoutePaths,
+              timeoutMs: routeTimeoutMs,
+              retryDelayMs: routeRetryDelayMs,
+            });
+            updateRouteTotalMs = performance.now() - updateRouteStartedAt;
+            if (updateRouteRequests.some(request => !request.ok)) {
+              statusAfterReady = 1;
+            }
           }
         } catch (error) {
           statusAfterReady = 1;

--- a/scripts/benchmark/profiles.mjs
+++ b/scripts/benchmark/profiles.mjs
@@ -7,7 +7,16 @@ export const profiles = {
       routeCount: 256,
       variant: 'ssr-esm-split',
     },
-    { id: 'synthetic-256-spa', routeCount: 256, variant: 'spa' },
+    {
+      id: 'synthetic-256-spa',
+      routeCount: 256,
+      variant: 'spa',
+      // SPA fixtures (`ssr: false`) have no dev-server HTML document for
+      // route paths: the plugin registers no SSR middleware in dev and all
+      // web entries disable HTML generation, so every route fetch would 404.
+      // Measure dev readiness and update rebuilds only.
+      devRoutes: 'none',
+    },
     {
       id: 'synthetic-256-sourcemaps',
       routeCount: 256,


### PR DESCRIPTION
## Summary

The `synthetic-256-spa` fixture always fails dev-mode benchmark runs (`--mode dev`, `default` profile): every route fetch returns HTTP 404, so the run exits with "One or more measured benchmark builds failed". This is a pre-existing harness gap on `main`, not a plugin regression — in dev the plugin registers no SSR middleware for `ssr: false` apps and every web entry sets `html: false`, so there is no HTML document to serve per route. The real `examples/spa-mode` app behaves identically in dev (its e2e suite only exercises `build` + static serve, which is why this never surfaced).

Treat SPA fixtures as readiness/update-timing-only in dev:

- `scripts/benchmark/profiles.mjs`: pin `devRoutes: 'none'` on the `synthetic-256-spa` entry (with a comment).
- `scripts/bench-builds.mts`: a profile entry's `devRoutes` now takes precedence over the `--dev-routes` CLI flag, and `'none'` also skips post-update route fetches instead of requesting `/`.
- `scripts/benchmark/dev-server.mjs`: measure the update rebuild (`updateMs`) even when no update route paths are configured, so SPA fixtures keep HMR timings.
- `benchmarks/README.md`: document the per-fixture override.

SSR fixtures are unchanged: same auto-selected routes, same post-update fetches, non-2xx still fails the run.

## Validation

- `node scripts/bench-builds.mts --profile default --mode dev --iterations 2 --warmup 0 --dev-routes auto --clean build --format json` → exit 0, `failed: false`; `synthetic-256-spa` reports readiness + updateMs with zero route fetches; the three SSR fixtures fetch 8/8 routes (2xx) plus post-update routes as before
- `node scripts/bench-builds.mts --profile smoke --mode dev --iterations 1 --warmup 0` → exit 0
- `pnpm test:core` → 440/440
- `node --test benchmarks/synthetic-web-bundler-benchmark/scripts/benchmark-rsbuild.test.mjs` → 12/12 (shared dev-server.mjs consumer)

## Follow-up (out of scope)

Real SPA (`ssr: false`) apps get 404s for route paths in `rsbuild dev` — arguably a plugin dev-server gap worth its own issue/fix; this PR only makes the benchmark harness measure what dev SPA can actually serve today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)