### PR TITLE
fix: migrate dev middleware registration to server.setup

### DIFF
--- a/.changeset/fresh-dev-server-setup.md
+++ b/.changeset/fresh-dev-server-setup.md
@@ -1,0 +1,5 @@
+---
+'rsbuild-plugin-react-router': patch
+---
+
+Migrate the dev middleware hook from `dev.setupMiddlewares` to `server.setup`.

--- a/src/dev-server.ts
+++ b/src/dev-server.ts
@@ -1,5 +1,11 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { RsbuildConfig } from '@rsbuild/core';
 import type { ServerBuild } from 'react-router';
+
+export type ServerSetup = Exclude<
+  NonNullable<NonNullable<RsbuildConfig['server']>['setup']>,
+  unknown[]
+>;
 
 export type DevServerMiddleware = (
   req: IncomingMessage,
@@ -63,3 +69,20 @@ export const createDevServerMiddleware = (
     }
   };
 };
+
+export const createReactRouterDevServerSetup = ({
+  loadBuild,
+}: {
+  loadBuild: BuildProvider;
+}): ServerSetup =>
+  function reactRouterDevServerSetup(context) {
+    if (context.action !== 'dev') {
+      return;
+    }
+    // The returned callback runs after Rsbuild registers its built-in
+    // middlewares, so static assets are served before the React Router
+    // request handler.
+    return () => {
+      context.server.middlewares.use(createDevServerMiddleware({ loadBuild }));
+    };
+  };

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import {
   PLUGIN_NAME,
 } from './constants.js';
 import { guardReactRouterLazyCompilation } from './lazy-compilation.js';
-import { createDevServerMiddleware } from './dev-server.js';
+import { createReactRouterDevServerSetup } from './dev-server.js';
 import {
   generateWithProps,
   findEntryFile,
@@ -768,19 +768,19 @@ export const pluginReactRouter = (
           writeToDisk: true,
           ...lazyCompilation,
           watchFiles: mergeWatchFiles(config.dev?.watchFiles, routeWatchFiles),
-          setupMiddlewares:
-            pluginOptions.customServer || !ssr
-              ? []
-              : [
-                  middlewares => {
-                    middlewares.push(
-                      createDevServerMiddleware({
-                        loadBuild: devRuntime.createBuildLoader(),
-                      })
-                    );
-                  },
-                ],
         },
+        ...(pluginOptions.customServer || !ssr
+          ? {}
+          : {
+              server: {
+                setup: [
+                  createReactRouterDevServerSetup({
+                    // Lazy: the dev runtime binding does not exist yet here.
+                    loadBuild: () => devRuntime.createBuildLoader()(),
+                  }),
+                ],
+              },
+            }),
         tools: {
           rspack: {
             plugins: [vmodPlugin],

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -6,6 +6,20 @@ import path from 'node:path';
 import { pluginReactRouter } from '../src';
 import { getVirtualModuleFilePath } from '../src/virtual-modules';
 
+type ReactRouterTestGlobal = typeof globalThis & {
+  __reactRouterTestConfig?: unknown;
+};
+
+const testGlobal = globalThis as ReactRouterTestGlobal;
+
+const getServerSetupNames = (config: {
+  server?: { setup?: unknown };
+}): string[] =>
+  [config.server?.setup]
+    .flat()
+    .filter((fn): fn is (...args: unknown[]) => unknown => Boolean(fn))
+    .map(fn => fn.name);
+
 describe('pluginReactRouter', () => {
   describe('basic configuration', () => {
     it('should apply default options when no options provided', async () => {
@@ -22,6 +36,21 @@ describe('pluginReactRouter', () => {
       expect(config.dev.writeToDisk).toBe(true);
     });
 
+    it('should register the dev server middleware via server.setup', async () => {
+      const rsbuild = await createStubRsbuild({
+        rsbuildConfig: {},
+      });
+
+      rsbuild.addPlugins([pluginReactRouter()]);
+      const config = await rsbuild.unwrapConfig();
+
+      // The deprecated `dev.setupMiddlewares` API must stay untouched.
+      expect(config.dev.setupMiddlewares).toBeUndefined();
+      expect(getServerSetupNames(config)).toContain(
+        'reactRouterDevServerSetup'
+      );
+    });
+
     it('should respect customServer option', async () => {
       const rsbuild = await createStubRsbuild({
         rsbuildConfig: {},
@@ -30,7 +59,25 @@ describe('pluginReactRouter', () => {
       rsbuild.addPlugins([pluginReactRouter({ customServer: true })]);
       const config = await rsbuild.unwrapConfig();
 
-      expect(config.dev.setupMiddlewares).toEqual([]);
+      expect(config.dev.setupMiddlewares).toBeUndefined();
+      expect(getServerSetupNames(config)).not.toContain(
+        'reactRouterDevServerSetup'
+      );
+    });
+
+    it('should not register the dev server middleware in SPA mode', async () => {
+      testGlobal.__reactRouterTestConfig = { ssr: false };
+      const rsbuild = await createStubRsbuild({
+        rsbuildConfig: {},
+      });
+
+      rsbuild.addPlugins([pluginReactRouter()]);
+      const config = await rsbuild.unwrapConfig();
+
+      expect(config.dev.setupMiddlewares).toBeUndefined();
+      expect(getServerSetupNames(config)).not.toContain(
+        'reactRouterDevServerSetup'
+      );
     });
 
     it('should configure server output format correctly', async () => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -105,7 +105,6 @@ rstest.mock('@scripts/test-helper', () => ({
         hmr: true,
         liveReload: true,
         writeToDisk: false,
-        setupMiddlewares: [],
       },
       environments: {
         web: {


### PR DESCRIPTION
## Summary

Rsbuild 2.1 logs `warn [rsbuild] \`dev.setupMiddlewares\` is deprecated, use \`server.setup\` instead` whenever the plugin registers its dev middleware. This migrates the registration in `src/index.ts` to the `server.setup` API.

- The plugin now contributes a named `reactRouterDevServerSetup` function under `server.setup`. It guards on `context.action === 'dev'` and **returns a callback**, which Rsbuild runs only after its built-in middlewares are registered — the documented equivalent of the old `middlewares.push()` semantics, so static assets are still tried before the React Router request handler.
- `customServer` and SPA (`ssr: false`) modes contribute nothing, matching the previous empty-array behavior.
- A local `ServerSetup` type is derived from `RsbuildConfig` (same pattern as `src/dev-runtime-controller.ts`, since `@rsbuild/core` doesn't export `ServerSetupFn`). Merging is safe alongside the controller's existing close-observer because `mergeRsbuildConfig` flattens function-plus-array `setup` values into one array.
- Tests: `features.test.ts` customServer assertion updated to check `server.setup`, plus new tests for the default SSR case (setup function present) and SPA mode (absent). Removed the dead `setupMiddlewares: []` from the test stub base config.

## Verification

- `pnpm test`: 41 files, 442 tests pass; `tsc --noEmit` clean.
- Manual `rsbuild dev` of `examples/default-template`: SSR home route 200 with rendered HTML, `/static/js/entry.client.js` 200 with `text/javascript` (asset middleware still wins), **no deprecation warning**.
- Manual `rsbuild dev` of `examples/spa-mode`: no deprecation warning. `/` returns 404 in dev, but unmodified `main` behaves identically (SPA e2e runs against a static production build), so this is pre-existing, not a regression.
- Baseline: the same default-template run on unmodified `main` does emit the deprecation warning, confirming this change removes exactly that warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)