### PR TITLE
fix: recover manifest chunks from iteration

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -171,6 +171,7 @@ export const createReactRouterManifestStats = (
     | undefined;
 
   if (chunkNames && typeof namedChunks.get === 'function') {
+    const missingChunkNames = new Set(chunkNames);
     for (const chunkName of chunkNames) {
       const chunk = namedChunks.get(chunkName);
       if (!chunk) {
@@ -178,6 +179,20 @@ export const createReactRouterManifestStats = (
       }
       const files = Array.from(chunk.files ?? []);
       assetsByChunkName[chunkName] = orderChunkFiles(chunkName, files);
+      missingChunkNames.delete(chunkName);
+    }
+    if (missingChunkNames.size > 0) {
+      for (const [chunkName, chunk] of namedChunks) {
+        if (!missingChunkNames.has(chunkName)) {
+          continue;
+        }
+        const files = Array.from(chunk.files ?? []);
+        assetsByChunkName[chunkName] = orderChunkFiles(chunkName, files);
+        missingChunkNames.delete(chunkName);
+        if (missingChunkNames.size === 0) {
+          break;
+        }
+      }
     }
   } else {
     for (const [chunkName, chunk] of namedChunks) {
@@ -191,6 +206,7 @@ export const createReactRouterManifestStats = (
 
   if (entrypoints) {
     if (chunkNames && typeof entrypoints.get === 'function') {
+      const missingEntrypointNames = new Set(chunkNames);
       for (const entrypointName of chunkNames) {
         const entrypoint = entrypoints.get(entrypointName);
         if (!entrypoint) {
@@ -199,6 +215,21 @@ export const createReactRouterManifestStats = (
         entrypointFilesByName[entrypointName] = Array.from(
           entrypoint.getFiles?.() ?? []
         );
+        missingEntrypointNames.delete(entrypointName);
+      }
+      if (missingEntrypointNames.size > 0) {
+        for (const [entrypointName, entrypoint] of entrypoints) {
+          if (!missingEntrypointNames.has(entrypointName)) {
+            continue;
+          }
+          entrypointFilesByName[entrypointName] = Array.from(
+            entrypoint.getFiles?.() ?? []
+          );
+          missingEntrypointNames.delete(entrypointName);
+          if (missingEntrypointNames.size === 0) {
+            break;
+          }
+        }
       }
     } else {
       for (const [entrypointName, entrypoint] of entrypoints) {

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -136,6 +136,36 @@ describe('manifest', () => {
     });
   });
 
+  it('falls back to named chunk iteration when direct lookup misses requested chunks', () => {
+    const chunks = new Map([
+      ['entry.client', { files: new Set(['static/js/entry.client.js']) }],
+      ['routes/page', { files: new Set(['static/js/routes/page.js']) }],
+      ['vendor', { files: new Set(['static/js/vendor.js']) }],
+    ]);
+    const compilation = {
+      namedChunks: {
+        get: () => undefined,
+        *[Symbol.iterator](): IterableIterator<
+          [string, { files: Set<string> }]
+        > {
+          yield* chunks;
+        },
+      },
+    };
+
+    expect(
+      createReactRouterManifestStats(
+        compilation,
+        new Set(['entry.client', 'routes/page'])
+      )
+    ).toEqual({
+      assetsByChunkName: {
+        'entry.client': ['static/js/entry.client.js'],
+        'routes/page': ['static/js/routes/page.js'],
+      },
+    });
+  });
+
   it('collects only manifest-readable chunk names', () => {
     expect(Array.from(getReactRouterManifestChunkNames(routes, false))).toEqual(
       ['entry.client', 'root', 'routes/page']


### PR DESCRIPTION
## Summary
- recover requested manifest chunks by iterating namedChunks when direct lookup misses
- cover natural-id-like lookup misses in manifest stats tests

## Tests
- pnpm test:core tests/manifest.test.ts
- pnpm test:core
- pnpm build
- pnpm format:check