### PR TITLE
refactor: simplify manifest stat collection

### DIFF
--- a/.changeset/natural-manifest-fallback.md
+++ b/.changeset/natural-manifest-fallback.md
@@ -1,0 +1,5 @@
+---
+'rsbuild-plugin-react-router': patch
+---
+
+Preserve React Router manifest assets when Rspack natural chunk or module ids make direct chunk lookup incomplete.

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -122,22 +122,13 @@ type ReactRouterManifestStatsEntrypoint = {
   getFiles?: () => Iterable<string>;
 };
 
-type ReactRouterManifestStatsCompilation = {
-  namedChunks: Iterable<[string, ReactRouterManifestStatsChunk]>;
-  entrypoints?: Iterable<[string, ReactRouterManifestStatsEntrypoint]>;
+type ReactRouterManifestStatsLookup<T> = Iterable<[string, T]> & {
+  get?: (name: string) => T | undefined;
 };
 
-type ReactRouterManifestStatsNamedChunks =
-  ReactRouterManifestStatsCompilation['namedChunks'] & {
-    get?: (chunkName: string) => ReactRouterManifestStatsChunk | undefined;
-  };
-
-type ReactRouterManifestStatsEntrypoints = NonNullable<
-  ReactRouterManifestStatsCompilation['entrypoints']
-> & {
-  get?: (
-    entrypointName: string
-  ) => ReactRouterManifestStatsEntrypoint | undefined;
+type ReactRouterManifestStatsCompilation = {
+  namedChunks: ReactRouterManifestStatsLookup<ReactRouterManifestStatsChunk>;
+  entrypoints?: ReactRouterManifestStatsLookup<ReactRouterManifestStatsEntrypoint>;
 };
 
 const orderChunkFiles = (chunkName: string, files: string[]): string[] => {
@@ -154,6 +145,49 @@ const orderChunkFiles = (chunkName: string, files: string[]): string[] => {
   ];
 };
 
+const collectManifestFilesByName = <T>(
+  items: ReactRouterManifestStatsLookup<T>,
+  names: ReadonlySet<string> | undefined,
+  getFiles: (name: string, item: T) => string[]
+): Record<string, string[]> => {
+  const filesByName: Record<string, string[]> = {};
+  if (!names) {
+    for (const [name, item] of items) {
+      filesByName[name] = getFiles(name, item);
+    }
+    return filesByName;
+  }
+
+  const missingNames = new Set(names);
+  if (typeof items.get === 'function') {
+    for (const name of names) {
+      const item = items.get(name);
+      if (!item) {
+        continue;
+      }
+      filesByName[name] = getFiles(name, item);
+      missingNames.delete(name);
+    }
+  }
+
+  if (missingNames.size === 0) {
+    return filesByName;
+  }
+
+  for (const [name, item] of items) {
+    if (!missingNames.has(name)) {
+      continue;
+    }
+    filesByName[name] = getFiles(name, item);
+    missingNames.delete(name);
+    if (missingNames.size === 0) {
+      break;
+    }
+  }
+
+  return filesByName;
+};
+
 export const createReactRouterManifestStats = (
   compilation: ReactRouterManifestStatsCompilation | undefined,
   chunkNames?: ReadonlySet<string>
@@ -162,86 +196,19 @@ export const createReactRouterManifestStats = (
     return undefined;
   }
 
-  const assetsByChunkName: Record<string, string[]> = {};
-  const entrypointFilesByName: Record<string, string[]> = {};
-  const namedChunks =
-    compilation.namedChunks as ReactRouterManifestStatsNamedChunks;
-  const entrypoints = compilation.entrypoints as
-    | ReactRouterManifestStatsEntrypoints
-    | undefined;
-
-  if (chunkNames && typeof namedChunks.get === 'function') {
-    const missingChunkNames = new Set(chunkNames);
-    for (const chunkName of chunkNames) {
-      const chunk = namedChunks.get(chunkName);
-      if (!chunk) {
-        continue;
-      }
-      const files = Array.from(chunk.files ?? []);
-      assetsByChunkName[chunkName] = orderChunkFiles(chunkName, files);
-      missingChunkNames.delete(chunkName);
-    }
-    if (missingChunkNames.size > 0) {
-      for (const [chunkName, chunk] of namedChunks) {
-        if (!missingChunkNames.has(chunkName)) {
-          continue;
-        }
-        const files = Array.from(chunk.files ?? []);
-        assetsByChunkName[chunkName] = orderChunkFiles(chunkName, files);
-        missingChunkNames.delete(chunkName);
-        if (missingChunkNames.size === 0) {
-          break;
-        }
-      }
-    }
-  } else {
-    for (const [chunkName, chunk] of namedChunks) {
-      if (chunkNames && !chunkNames.has(chunkName)) {
-        continue;
-      }
-      const files = Array.from(chunk.files ?? []);
-      assetsByChunkName[chunkName] = orderChunkFiles(chunkName, files);
-    }
-  }
-
-  if (entrypoints) {
-    if (chunkNames && typeof entrypoints.get === 'function') {
-      const missingEntrypointNames = new Set(chunkNames);
-      for (const entrypointName of chunkNames) {
-        const entrypoint = entrypoints.get(entrypointName);
-        if (!entrypoint) {
-          continue;
-        }
-        entrypointFilesByName[entrypointName] = Array.from(
-          entrypoint.getFiles?.() ?? []
-        );
-        missingEntrypointNames.delete(entrypointName);
-      }
-      if (missingEntrypointNames.size > 0) {
-        for (const [entrypointName, entrypoint] of entrypoints) {
-          if (!missingEntrypointNames.has(entrypointName)) {
-            continue;
-          }
-          entrypointFilesByName[entrypointName] = Array.from(
-            entrypoint.getFiles?.() ?? []
-          );
-          missingEntrypointNames.delete(entrypointName);
-          if (missingEntrypointNames.size === 0) {
-            break;
-          }
-        }
-      }
-    } else {
-      for (const [entrypointName, entrypoint] of entrypoints) {
-        if (chunkNames && !chunkNames.has(entrypointName)) {
-          continue;
-        }
-        entrypointFilesByName[entrypointName] = Array.from(
-          entrypoint.getFiles?.() ?? []
-        );
-      }
-    }
-  }
+  const assetsByChunkName = collectManifestFilesByName(
+    compilation.namedChunks,
+    chunkNames,
+    (chunkName, chunk) =>
+      orderChunkFiles(chunkName, Array.from(chunk.files ?? []))
+  );
+  const entrypointFilesByName = compilation.entrypoints
+    ? collectManifestFilesByName(
+        compilation.entrypoints,
+        chunkNames,
+        (_name, entrypoint) => Array.from(entrypoint.getFiles?.() ?? [])
+      )
+    : {};
 
   return Object.keys(entrypointFilesByName).length > 0
     ? { assetsByChunkName, entrypointFilesByName }

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -136,11 +136,16 @@ describe('manifest', () => {
     });
   });
 
-  it('falls back to named chunk iteration when direct lookup misses requested chunks', () => {
+  it('falls back to iteration when direct lookup misses requested manifest chunks', () => {
     const chunks = new Map([
       ['entry.client', { files: new Set(['static/js/entry.client.js']) }],
       ['routes/page', { files: new Set(['static/js/routes/page.js']) }],
       ['vendor', { files: new Set(['static/js/vendor.js']) }],
+    ]);
+    const entrypoints = new Map([
+      ['entry.client', { getFiles: () => ['static/css/entry.client.css'] }],
+      ['routes/page', { getFiles: () => ['static/css/routes/page.css'] }],
+      ['vendor', { getFiles: () => ['static/css/vendor.css'] }],
     ]);
     const compilation = {
       namedChunks: {
@@ -149,6 +154,14 @@ describe('manifest', () => {
           [string, { files: Set<string> }]
         > {
           yield* chunks;
+        },
+      },
+      entrypoints: {
+        get: () => undefined,
+        *[Symbol.iterator](): IterableIterator<
+          [string, { getFiles: () => string[] }]
+        > {
+          yield* entrypoints;
         },
       },
     };
@@ -162,6 +175,10 @@ describe('manifest', () => {
       assetsByChunkName: {
         'entry.client': ['static/js/entry.client.js'],
         'routes/page': ['static/js/routes/page.js'],
+      },
+      entrypointFilesByName: {
+        'entry.client': ['static/css/entry.client.css'],
+        'routes/page': ['static/css/routes/page.css'],
       },
     });
   });


### PR DESCRIPTION
## Summary
- centralize manifest stat lookup fallback for chunks and entrypoints
- remove duplicated missing-name traversal and casts from manifest stats
- add entrypoint fallback coverage for natural-id-compatible manifest collection
- add patch changeset

## Tests
- pnpm test:core tests/manifest.test.ts
- tracedecay_diagnostics
- pnpm test:core
- pnpm build
- pnpm format:check
- pnpm changeset status --since=origin/main