### PR TITLE
[codex] fix route export parsing and manifest replacement

### DIFF
--- a/.changeset/swift-routes-sip.md
+++ b/.changeset/swift-routes-sip.md
@@ -1,0 +1,5 @@
+---
+'rsbuild-plugin-react-router': patch
+---
+
+Fix route export analysis for valid TypeScript route modules that Yuku cannot parse, and preserve literal browser manifest replacement values containing `$`.

--- a/src/export-utils.ts
+++ b/src/export-utils.ts
@@ -35,27 +35,57 @@ const routeModuleAnalysisCache = new Map<
 
 const MAX_EXPORT_UTILS_CACHE_ENTRIES = 2048;
 
+type TypeScriptParseLang = Extract<
+  NonNullable<ParseOptions['lang']>,
+  'ts' | 'tsx'
+>;
+
 const getExportAnalysisCode = (
   code: string,
-  resourcePath?: string
-): { code: string; lang: NonNullable<ParseOptions['lang']> } => {
+  resourcePath: string,
+  lang: TypeScriptParseLang
+): string =>
+  rspack.experiments.swc.transformSync(code, {
+    filename: resourcePath,
+    jsc: {
+      parser: {
+        syntax: 'typescript',
+        tsx: lang === 'tsx',
+      },
+    },
+  }).code;
+
+const getParseErrors = (result: ReturnType<typeof parse>) =>
+  result.diagnostics.filter(diagnostic => diagnostic.severity === 'error');
+
+const getParseErrorMessage = (
+  errors: ReturnType<typeof getParseErrors>
+): string => errors.map(error => error.message).join('\n');
+
+const parseProgram = (code: string, resourcePath?: string): ProgramNode => {
   const lang = resourcePath ? langFromPath(resourcePath) : 'tsx';
+  const result = parse(code, {
+    sourceType: 'module',
+    lang,
+  });
+  const errors = getParseErrors(result);
+  if (errors.length === 0) {
+    return getProgram(result);
+  }
   if (!resourcePath || (lang !== 'ts' && lang !== 'tsx')) {
-    return { code, lang };
+    throw new Error(getParseErrorMessage(errors));
   }
 
-  return {
-    code: rspack.experiments.swc.transformSync(code, {
-      filename: resourcePath,
-      jsc: {
-        parser: {
-          syntax: 'typescript',
-          tsx: lang === 'tsx',
-        },
-      },
-    }).code,
+  const normalizedCode = getExportAnalysisCode(code, resourcePath, lang);
+  const normalizedResult = parse(normalizedCode, {
+    sourceType: 'module',
     lang: 'js',
-  };
+  });
+  const normalizedErrors = getParseErrors(normalizedResult);
+  if (normalizedErrors.length > 0) {
+    throw new Error(getParseErrorMessage(normalizedErrors));
+  }
+  return getProgram(normalizedResult);
 };
 
 const getExportInfoCacheKey = (
@@ -74,21 +104,6 @@ const cachePromiseOnReject = <T>(
     invalidate();
     throw error;
   });
-
-const parseProgram = (code: string, resourcePath?: string): ProgramNode => {
-  const analysis = getExportAnalysisCode(code, resourcePath);
-  const result = parse(analysis.code, {
-    sourceType: 'module',
-    lang: analysis.lang,
-  });
-  const errors = result.diagnostics.filter(
-    diagnostic => diagnostic.severity === 'error'
-  );
-  if (errors.length > 0) {
-    throw new Error(errors.map(error => error.message).join('\n'));
-  }
-  return getProgram(result);
-};
 
 const isTypeOnlyExport = (node: AnyNode): boolean =>
   node.exportKind === 'type' ||

--- a/src/export-utils.ts
+++ b/src/export-utils.ts
@@ -1,5 +1,6 @@
 import { readFile, stat } from 'node:fs/promises';
-import { langFromPath, parse } from 'yuku-parser';
+import { rspack } from '@rsbuild/core';
+import { langFromPath, parse, type ParseOptions } from 'yuku-parser';
 import { setBoundedCacheEntry } from './bounded-cache.js';
 import {
   getExportedName,
@@ -34,6 +35,37 @@ const routeModuleAnalysisCache = new Map<
 
 const MAX_EXPORT_UTILS_CACHE_ENTRIES = 2048;
 
+const getExportAnalysisCode = (
+  code: string,
+  resourcePath?: string
+): { code: string; lang: NonNullable<ParseOptions['lang']> } => {
+  const lang = resourcePath ? langFromPath(resourcePath) : 'tsx';
+  if (!resourcePath || (lang !== 'ts' && lang !== 'tsx')) {
+    return { code, lang };
+  }
+
+  return {
+    code: rspack.experiments.swc.transformSync(code, {
+      filename: resourcePath,
+      jsc: {
+        parser: {
+          syntax: 'typescript',
+          tsx: lang === 'tsx',
+        },
+      },
+    }).code,
+    lang: 'js',
+  };
+};
+
+const getExportInfoCacheKey = (
+  code: string,
+  resourcePath?: string
+): string => {
+  const lang = resourcePath ? langFromPath(resourcePath) : 'inline';
+  return `${lang}\0${code}`;
+};
+
 const cachePromiseOnReject = <T>(
   promise: Promise<T>,
   invalidate: () => void
@@ -44,9 +76,10 @@ const cachePromiseOnReject = <T>(
   });
 
 const parseProgram = (code: string, resourcePath?: string): ProgramNode => {
-  const result = parse(code, {
+  const analysis = getExportAnalysisCode(code, resourcePath);
+  const result = parse(analysis.code, {
     sourceType: 'module',
-    lang: resourcePath ? langFromPath(resourcePath) : 'tsx',
+    lang: analysis.lang,
   });
   const errors = result.diagnostics.filter(
     diagnostic => diagnostic.severity === 'error'
@@ -140,21 +173,24 @@ const collectExportAllModules = (program: AnyNode): string[] => {
 };
 
 export const getExportNames = async (
-  code: string
+  code: string,
+  resourcePath?: string
 ): Promise<readonly string[]> => {
-  return (await getExportNamesAndExportAll(code)).exportNames;
+  return (await getExportNamesAndExportAll(code, resourcePath)).exportNames;
 };
 
 export const getExportNamesAndExportAll = async (
-  code: string
+  code: string,
+  resourcePath?: string
 ): Promise<ExportInfo> => {
-  const cached = exportInfoCache.get(code);
+  const cacheKey = getExportInfoCacheKey(code, resourcePath);
+  const cached = exportInfoCache.get(cacheKey);
   if (cached) {
     return cached;
   }
 
   const exportInfo = (async () => {
-    const program = parseProgram(code);
+    const program = parseProgram(code, resourcePath);
     return {
       exportNames: collectProgramExportNames(program),
       exportAllModules: collectExportAllModules(program),
@@ -163,14 +199,14 @@ export const getExportNamesAndExportAll = async (
 
   let trackedExportInfo: Promise<ExportInfo>;
   trackedExportInfo = cachePromiseOnReject(exportInfo, () => {
-    if (exportInfoCache.get(code) === trackedExportInfo) {
-      exportInfoCache.delete(code);
+    if (exportInfoCache.get(cacheKey) === trackedExportInfo) {
+      exportInfoCache.delete(cacheKey);
     }
   });
 
   setBoundedCacheEntry(
     exportInfoCache,
-    code,
+    cacheKey,
     trackedExportInfo,
     MAX_EXPORT_UTILS_CACHE_ENTRIES
   );

--- a/src/export-utils.ts
+++ b/src/export-utils.ts
@@ -35,6 +35,9 @@ const routeModuleAnalysisCache = new Map<
 
 const MAX_EXPORT_UTILS_CACHE_ENTRIES = 2048;
 
+const stripResourcePathQuery = (resourcePath: string): string =>
+  resourcePath.replace(/[?#].*$/, '');
+
 type TypeScriptParseLang = Extract<
   NonNullable<ParseOptions['lang']>,
   'ts' | 'tsx'
@@ -63,7 +66,10 @@ const getParseErrorMessage = (
 ): string => errors.map(error => error.message).join('\n');
 
 const parseProgram = (code: string, resourcePath?: string): ProgramNode => {
-  const lang = resourcePath ? langFromPath(resourcePath) : 'tsx';
+  const sourcePath = resourcePath
+    ? stripResourcePathQuery(resourcePath)
+    : undefined;
+  const lang = sourcePath ? langFromPath(sourcePath) : 'tsx';
   const result = parse(code, {
     sourceType: 'module',
     lang,
@@ -72,11 +78,11 @@ const parseProgram = (code: string, resourcePath?: string): ProgramNode => {
   if (errors.length === 0) {
     return getProgram(result);
   }
-  if (!resourcePath || (lang !== 'ts' && lang !== 'tsx')) {
+  if (!sourcePath || (lang !== 'ts' && lang !== 'tsx')) {
     throw new Error(getParseErrorMessage(errors));
   }
 
-  const normalizedCode = getExportAnalysisCode(code, resourcePath, lang);
+  const normalizedCode = getExportAnalysisCode(code, sourcePath, lang);
   const normalizedResult = parse(normalizedCode, {
     sourceType: 'module',
     lang: 'js',
@@ -92,7 +98,9 @@ const getExportInfoCacheKey = (
   code: string,
   resourcePath?: string
 ): string => {
-  const lang = resourcePath ? langFromPath(resourcePath) : 'inline';
+  const lang = resourcePath
+    ? langFromPath(stripResourcePathQuery(resourcePath))
+    : 'inline';
   return `${lang}\0${code}`;
 };
 

--- a/src/modify-browser-manifest.ts
+++ b/src/modify-browser-manifest.ts
@@ -163,9 +163,10 @@ export function registerModifyBrowserManifestAssets(
       const browserManifestAsset = assets[BROWSER_MANIFEST_ASSET];
       if (browserManifestAsset) {
         const originalSource = browserManifestAsset.source().toString();
+        const serializedManifest = jsesc(manifestForBrowser, { es6: true });
         const newSource = originalSource.replace(
           /["'`]PLACEHOLDER["'`]/,
-          jsesc(manifestForBrowser, { es6: true })
+          () => serializedManifest
         );
         compilation.updateAsset(
           BROWSER_MANIFEST_ASSET,

--- a/src/route-artifacts.ts
+++ b/src/route-artifacts.ts
@@ -92,7 +92,7 @@ export const createRouteClientEntryArtifact = async ({
       )
     : null;
   const exportNames =
-    routeChunkInfo?.exportNames ?? (await getExportNames(code));
+    routeChunkInfo?.exportNames ?? (await getExportNames(code, resourcePath));
   const chunkedExports = routeChunkInfo?.chunkedExports ?? [];
   return {
     code: buildRouteClientEntryCode({
@@ -140,7 +140,7 @@ export const createRouteChunkArtifact = async ({
   );
 
   if (splitRouteModules === 'enforce' && chunkName === 'main' && chunk) {
-    const exportNames = await getExportNames(chunk);
+    const exportNames = await getExportNames(chunk, resourcePath);
     validateRouteChunks({
       config: routeChunkConfig,
       id: resourcePath,

--- a/src/route-export-resolution.ts
+++ b/src/route-export-resolution.ts
@@ -276,7 +276,7 @@ export const collectClientOnlyStubExportNames = async (
   resolveModule: RouteExportResolver = resolveExportAllModule
 ): Promise<Set<string>> => {
   const { exportNames: directExportNames, exportAllModules } =
-    await getExportNamesAndExportAll(code);
+    await getExportNamesAndExportAll(code, resourcePath);
   const exportNames = new Set(directExportNames);
   const unresolvedExportAll = new Set<string>();
   const visitedModules = new Set<string>();

--- a/tests/dev-runtime.integration.test.ts
+++ b/tests/dev-runtime.integration.test.ts
@@ -420,7 +420,7 @@ const expectInitialCompilationFailure = async (
   await expect(
     withTimeout(harness.loadBuild(), 20_000, 'the initial compilation failure')
   ).rejects.toThrow('development compilation failed');
-  expect(harness.hasConsoleError('Unexpected token')).toBe(true);
+  expect(harness.hasConsoleError('Expression expected')).toBe(true);
   expect(harness.compileAttempts).toBeGreaterThan(0);
   expect(harness.completedCompiles).toBeGreaterThan(0);
 };

--- a/tests/export-utils.test.ts
+++ b/tests/export-utils.test.ts
@@ -29,6 +29,25 @@ describe('getExportNamesAndExportAll', () => {
     });
   });
 
+  it('collects exports when route TypeScript contains typed arrows in conditionals', async () => {
+    await expect(
+      getExportNamesAndExportAll(
+        `
+          const ok = true;
+          const values: unknown[] = [];
+          ok
+            ? values.filter((value): value is string => Boolean(value))
+            : [];
+          export default function Route() { return null; }
+        `,
+        'routes/page.tsx'
+      )
+    ).resolves.toEqual({
+      exportNames: ['default'],
+      exportAllModules: [],
+    });
+  });
+
   it('ignores erased default interfaces', async () => {
     await expect(
       getExportNamesAndExportAll(

--- a/tests/export-utils.test.ts
+++ b/tests/export-utils.test.ts
@@ -106,6 +106,18 @@ describe('getExportNamesAndExportAll', () => {
         exportNames: ['loader', 'default'],
         exportAllModules: [],
       });
+      await expect(
+        getExportNamesAndExportAll(
+          `
+            export const action = () => null;
+            export default function Route() { return <form />; }
+          `,
+          'routes/simple.tsx?react-router-route'
+        )
+      ).resolves.toEqual({
+        exportNames: ['action', 'default'],
+        exportAllModules: [],
+      });
       expect(transformCalls).toBe(0);
     } finally {
       rspack.experiments.swc.transformSync = originalTransform;

--- a/tests/export-utils.test.ts
+++ b/tests/export-utils.test.ts
@@ -71,7 +71,7 @@ describe('getExportNamesAndExportAll', () => {
     });
   });
 
-  it('uses Yuku directly when route TypeScript parses without normalization', async () => {
+  it('uses Yuku directly when route TypeScript and TSX parse without normalization', async () => {
     const originalTransform = rspack.experiments.swc.transformSync;
     let transformCalls = 0;
     try {
@@ -82,6 +82,18 @@ describe('getExportNamesAndExportAll', () => {
         return originalTransform(...args);
       }) as typeof originalTransform;
 
+      await expect(
+        getExportNamesAndExportAll(
+          `
+            export const loader = () => null;
+            export default function Route() { return <main />; }
+          `,
+          'routes/simple.tsx'
+        )
+      ).resolves.toEqual({
+        exportNames: ['loader', 'default'],
+        exportAllModules: [],
+      });
       await expect(
         getExportNamesAndExportAll(
           `

--- a/tests/export-utils.test.ts
+++ b/tests/export-utils.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from '@rstest/core';
+import { rspack } from '@rsbuild/core';
 import { getExportNamesAndExportAll } from '../src/export-utils';
 
 describe('getExportNamesAndExportAll', () => {
@@ -46,6 +47,57 @@ describe('getExportNamesAndExportAll', () => {
       exportNames: ['default'],
       exportAllModules: [],
     });
+  });
+
+  it('collects exports when route TSX contains typed arrows in conditional JSX data', async () => {
+    await expect(
+      getExportNamesAndExportAll(
+        `
+          const ok = true;
+          const values: unknown[] = [];
+          export const clientLoader = () =>
+            ok
+              ? values.filter((value): value is string => Boolean(value))
+              : [];
+          export default function Route() {
+            return <main>{clientLoader().map(value => <span key={value}>{value}</span>)}</main>;
+          }
+        `,
+        'routes/page.tsx'
+      )
+    ).resolves.toEqual({
+      exportNames: ['clientLoader', 'default'],
+      exportAllModules: [],
+    });
+  });
+
+  it('uses Yuku directly when route TypeScript parses without normalization', async () => {
+    const originalTransform = rspack.experiments.swc.transformSync;
+    let transformCalls = 0;
+    try {
+      rspack.experiments.swc.transformSync = ((
+        ...args: Parameters<typeof originalTransform>
+      ) => {
+        transformCalls += 1;
+        return originalTransform(...args);
+      }) as typeof originalTransform;
+
+      await expect(
+        getExportNamesAndExportAll(
+          `
+            export const loader = () => null;
+            export default function Route() { return null; }
+          `,
+          'routes/simple.ts'
+        )
+      ).resolves.toEqual({
+        exportNames: ['loader', 'default'],
+        exportAllModules: [],
+      });
+      expect(transformCalls).toBe(0);
+    } finally {
+      rspack.experiments.swc.transformSync = originalTransform;
+    }
   });
 
   it('ignores erased default interfaces', async () => {

--- a/tests/modify-browser-manifest.test.ts
+++ b/tests/modify-browser-manifest.test.ts
@@ -239,6 +239,11 @@ describe('modify browser manifest plugin', () => {
     const root = mkdtempSync(join(tmpdir(), 'rr-modify-manifest-'));
     const appDir = join(root, 'app');
     const routeFile = join(appDir, 'routes/dollar.tsx');
+    const specialRouteIds = [
+      'routes/dollar$',
+      'routes/match$&',
+      'routes/literal$$',
+    ] as const;
     mkdirSync(join(appDir, 'routes'), { recursive: true });
     writeFileSync(
       join(appDir, 'root.tsx'),
@@ -259,7 +264,10 @@ describe('modify browser manifest plugin', () => {
       [
         ['entry.client', { files: new Set(['static/js/entry.client.js']) }],
         ['root', { files: new Set(['static/js/root.js']) }],
-        ['routes/dollar$', { files: new Set(['static/js/dollar.js']) }],
+        ...specialRouteIds.map((routeId, index) => [
+          routeId,
+          { files: new Set([`static/js/special-${index}.js`]) },
+        ]),
       ],
       assets
     );
@@ -269,12 +277,17 @@ describe('modify browser manifest plugin', () => {
         harness.api as never,
         {
           root: rootRoute,
-          'routes/dollar$': {
-            id: 'routes/dollar$',
-            parentId: 'root',
-            file: 'routes/dollar.tsx',
-            path: 'dollar',
-          },
+          ...Object.fromEntries(
+            specialRouteIds.map((routeId, index) => [
+              routeId,
+              {
+                id: routeId,
+                parentId: 'root',
+                file: 'routes/dollar.tsx',
+                path: `special-${index}`,
+              },
+            ])
+          ),
         },
         {},
         appDir
@@ -283,7 +296,10 @@ describe('modify browser manifest plugin', () => {
       await harness.run({ assets, compilation });
 
       const source = assets[BROWSER_MANIFEST_PATH].source();
-      expect(source).toContain("'routes/dollar$'");
+      for (const routeId of specialRouteIds) {
+        expect(source).toContain(`'${routeId}'`);
+      }
+      expect(source).not.toContain('PLACEHOLDER');
       expect(source.match(/window\.afterPlaceholder=true/g)).toHaveLength(1);
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/tests/modify-browser-manifest.test.ts
+++ b/tests/modify-browser-manifest.test.ts
@@ -235,6 +235,61 @@ describe('modify browser manifest plugin', () => {
     }
   });
 
+  it('treats serialized browser manifest values as literal replacement text', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'rr-modify-manifest-'));
+    const appDir = join(root, 'app');
+    const routeFile = join(appDir, 'routes/dollar.tsx');
+    mkdirSync(join(appDir, 'routes'), { recursive: true });
+    writeFileSync(
+      join(appDir, 'root.tsx'),
+      `export default function Root() { return null; }`
+    );
+    writeFileSync(
+      routeFile,
+      `export default function Dollar() { return null; }`
+    );
+    const harness = createProcessAssetsHarness();
+    const suffix = ';window.afterPlaceholder=true;';
+    const assets = {
+      [BROWSER_MANIFEST_PATH]: createAsset(
+        `window.__reactRouterManifest="PLACEHOLDER"${suffix}`
+      ),
+    };
+    const compilation = createCompilation(
+      [
+        ['entry.client', { files: new Set(['static/js/entry.client.js']) }],
+        ['root', { files: new Set(['static/js/root.js']) }],
+        ['routes/dollar$', { files: new Set(['static/js/dollar.js']) }],
+      ],
+      assets
+    );
+
+    try {
+      registerModifyBrowserManifestAssets(
+        harness.api as never,
+        {
+          root: rootRoute,
+          'routes/dollar$': {
+            id: 'routes/dollar$',
+            parentId: 'root',
+            file: 'routes/dollar.tsx',
+            path: 'dollar',
+          },
+        },
+        {},
+        appDir
+      );
+
+      await harness.run({ assets, compilation });
+
+      const source = assets[BROWSER_MANIFEST_PATH].source();
+      expect(source).toContain("'routes/dollar$'");
+      expect(source.match(/window\.afterPlaceholder=true/g)).toHaveLength(1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('reports the exact compilation that produced the manifest', async () => {
     const { root, appDir } = createTempApp();
     const harness = createProcessAssetsHarness();


### PR DESCRIPTION
## Summary

- try Yuku first for route-file export analysis, then normalize TS/TSX through Rspack SWC only when Yuku reports parse errors
- strip query/hash suffixes before export-analysis language detection so `*.tsx?route-query` stays on the TSX fast path when Yuku can parse it
- replace the browser manifest placeholder with a callback so serialized `$` replacement tokens stay literal
- add regressions for conditional typed-arrow TS/TSX route code, direct-Yuku fast path coverage for TSX query resources, and route IDs containing `$`, `$&`, and `$$`

## Validation

- `pnpm exec rstest run -c ./rstest.config.ts tests/export-utils.test.ts tests/modify-browser-manifest.test.ts`
- `pnpm build && pnpm test:core && git diff --check`
- `pnpm exec changeset status --since origin/main`
- red check on `origin/main` with updated tests: expected failures for typed-arrow route parsing and `$` manifest replacement corruption
- CPU profile of built route-client-entry export analysis:
  - direct Yuku path: `5000` unique modules, `175.2ms`, `0.0350ms/module`, `swc=0`
  - SWC fallback path: `500` unique modules, `132.5ms`, `0.2650ms/module`, `swc=500`
  - attempted diagnostic-array allocation micro-optimization was measured and not kept (`0.0350ms -> 0.0351ms` direct path)
- local PR benchmark: `node scripts/bench-builds.mts --profile full --mode dev --iterations 3 --large-iterations 2 --warmup 0 --dev-routes auto --clean build --format json --log-performance`
  - before fallback optimization: wall `26.60s -> 29.36s` (`+10.4%`), ready `14.02s -> 15.95s` (`+13.8%`)
  - after fallback optimization: wall `26.50s -> 27.08s` (`+2.2%`), ready `13.76s -> 13.91s` (`+1.0%`), update `3.03s -> 3.05s` (`+0.7%`)
  - local rerun after changeset on this machine: wall `26.38s -> 25.92s` (`-1.7%`), ready `13.89s -> 14.05s` (`+1.2%`), update `3.09s -> 3.06s` (`-0.8%`); report `.benchmark/local-pr-benchmark/pr83-changeset-rerun-20260708030642/report.md`
- CI benchmark for `ebc1d6e`: all dev fixtures wall `29.37s -> 28.99s` (`-1.3%`), ready `19.51s -> 19.39s` (`-0.6%`)
  - `large-355-ssr-esm`: dev wall `13.84s -> 13.66s` (`-1.3%`); production build `8.59s -> 8.63s` (`+0.5%`)
  - embedded synthetic app (`benchmarks/synthetic-web-bundler-benchmark`): production samples `117.02s -> 112.19s` (`-4.1%`) and `79.10s -> 78.84s` (`-0.3%`); dev `96.40s -> 96.65s` (`+0.3%`)
- local embedded synthetic app one-run samples were noisy; the post-query-strip run had cold `64.25s -> 70.52s` (`+9.8%`) and a dev outlier, so the CI multi-run result above is the better signal
