### PR TITLE
fix: prerender legacy handler root data and warning path format

### DIFF
--- a/.changeset/prerender-legacy-and-warning-paths.md
+++ b/.changeset/prerender-legacy-and-warning-paths.md
@@ -1,0 +1,7 @@
+---
+'rsbuild-plugin-react-router': patch
+---
+
+Prerender fixes: root route data now flows through the legacy handler path,
+and the dynamic/splat prerender warning strips the leading slash only for
+top-level dynamic segments so nested paths are reported correctly.

--- a/src/prerender-build.ts
+++ b/src/prerender-build.ts
@@ -132,6 +132,30 @@ const createDataRequestPath = (
     : `${prerenderPath.replace(/\/$/, '')}.data`;
 };
 
+const createDataOutputPath = (
+  prerenderPath: string,
+  trailingSlashAwareDataRequests: boolean
+): string => {
+  if (trailingSlashAwareDataRequests) {
+    return prerenderPath.endsWith('/')
+      ? `${prerenderPath}_.data`
+      : `${prerenderPath}.data`;
+  }
+
+  return createDataRequestPath(prerenderPath, trailingSlashAwareDataRequests);
+};
+
+const createDataHandlerRequestPath = (
+  prerenderPath: string,
+  trailingSlashAwareDataRequests: boolean
+): string => {
+  if (trailingSlashAwareDataRequests && prerenderPath === '/') {
+    return '/_root.data';
+  }
+
+  return createDataRequestPath(prerenderPath, trailingSlashAwareDataRequests);
+};
+
 export const createBuildRequestEffect = <T>(
   input: string | URL,
   init: RequestInit | undefined,
@@ -179,11 +203,19 @@ const prerenderData = async ({
   api: PrerenderBuildApi;
   requestInit?: RequestInit;
 }): Promise<string> => {
-  const dataRequestPath = createDataRequestPath(
+  const dataRequestPath = createDataHandlerRequestPath(
+    prerenderPath,
+    trailingSlashAwareDataRequests
+  );
+  const dataOutputPath = createDataOutputPath(
     prerenderPath,
     trailingSlashAwareDataRequests
   );
   const normalizedPath = `${basename}${dataRequestPath}`.replace(/\/\/+/g, '/');
+  const outputNormalizedPath = `${basename}${dataOutputPath}`.replace(
+    /\/\/+/g,
+    '/'
+  );
   const url = new URL(`http://localhost${normalizedPath}`);
   if (onlyRoutes?.length) {
     url.searchParams.set('_routes', onlyRoutes.join(','));
@@ -201,7 +233,10 @@ const prerenderData = async ({
       );
     }
 
-    const outputPath = resolve(clientBuildDir, ...normalizedPath.split('/'));
+    const outputPath = resolve(
+      clientBuildDir,
+      ...outputNormalizedPath.split('/')
+    );
     await mkdir(dirname(outputPath), { recursive: true });
     await writeFile(outputPath, data);
     api.logger.info(
@@ -527,16 +562,23 @@ const createPrerenderPathEffect = ({
         clientBuildDir,
         basename,
         api,
-        requestInit: data
-          ? {
-              headers: {
-                'X-React-Router-Prerender-Data': encodeURI(data),
-              },
-            }
-          : undefined,
+        requestInit: data ? createPrerenderDataRequestInit(data) : undefined,
       })
     );
   });
+
+const createPrerenderDataRequestInit = (
+  data: string
+): RequestInit | undefined => {
+  const encodedData = encodeURI(data);
+  return encodedData.length < 8 * 1024
+    ? {
+        headers: {
+          'X-React-Router-Prerender-Data': encodedData,
+        },
+      }
+    : undefined;
+};
 
 const runPrerenderPaths = async ({
   build,

--- a/src/prerender-build.ts
+++ b/src/prerender-build.ts
@@ -135,15 +135,8 @@ const createDataRequestPath = (
 const createDataOutputPath = (
   prerenderPath: string,
   trailingSlashAwareDataRequests: boolean
-): string => {
-  if (trailingSlashAwareDataRequests) {
-    return prerenderPath.endsWith('/')
-      ? `${prerenderPath}_.data`
-      : `${prerenderPath}.data`;
-  }
-
-  return createDataRequestPath(prerenderPath, trailingSlashAwareDataRequests);
-};
+): string =>
+  createDataRequestPath(prerenderPath, trailingSlashAwareDataRequests);
 
 const createDataHandlerRequestPath = (
   prerenderPath: string,

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -249,7 +249,7 @@ export const resolvePrerenderPaths = async (
         [
           'Warning: Paths with dynamic/splat params cannot be prerendered when using `prerender: true`.',
           'You may want to use the `prerender()` API to prerender the following paths:',
-          ...paramRoutes.map(path => `  - ${path.replace(/^\//, '')}`),
+          ...paramRoutes.map(path => `  - ${path.replace(/^\/(?=[:*])/, '')}`),
         ].join('\n')
       );
     }

--- a/src/prerender.ts
+++ b/src/prerender.ts
@@ -249,7 +249,7 @@ export const resolvePrerenderPaths = async (
         [
           'Warning: Paths with dynamic/splat params cannot be prerendered when using `prerender: true`.',
           'You may want to use the `prerender()` API to prerender the following paths:',
-          ...paramRoutes.map(path => `  - ${path}`),
+          ...paramRoutes.map(path => `  - ${path.replace(/^\//, '')}`),
         ].join('\n')
       );
     }


### PR DESCRIPTION
## Summary

Three prerender fixes cherry-picked from the React Router 8 branch (`codex/react-router-8-compat-v2`) that apply to the current RR7 code and can ship ahead of it:

- **fix: prerender root data through legacy handler path** — root route data is now included when prerendering via the legacy request handler path.
- **fix: match prerender warning path format** — the dynamic/splat `prerender: true` warning no longer prints a leading slash on suggested paths.
- **fix: preserve nested prerender warning paths** — the slash is only stripped for top-level dynamic/splat segments (`/^\/(?=[:*])/`), so nested paths keep their full form.

Includes a patch changeset.

## Testing

- `tsc --noEmit` clean
- `rstest run tests/prerender.test.ts` — 17/17 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)