### PR TITLE
feat: export ReactRouterRsbuildConfig config type

### DIFF
--- a/.changeset/export-config-type.md
+++ b/.changeset/export-config-type.md
@@ -5,4 +5,6 @@
 Export `ReactRouterRsbuildConfig`, the plugin's typed `react-router.config.*`
 shape (React Router's `Config` plus plugin-supported options such as
 `splitRouteModules`), so projects no longer need to import types from
-`@react-router/dev/config` or hand-roll intersections.
+`@react-router/dev/config` or hand-roll intersections. `@react-router/dev` is now declared as an
+optional peer dependency since the exported config and route types resolve
+from it.

--- a/.changeset/export-config-type.md
+++ b/.changeset/export-config-type.md
@@ -1,10 +1,11 @@
 ---
-'rsbuild-plugin-react-router': minor
+'rsbuild-plugin-react-router': patch
 ---
 
 Export `ReactRouterRsbuildConfig`, the plugin's typed `react-router.config.*`
 shape (React Router's `Config` plus plugin-supported options such as
 `splitRouteModules`), so projects no longer need to import types from
-`@react-router/dev/config` or hand-roll intersections. `@react-router/dev` is now declared as an
-optional peer dependency since the exported config and route types resolve
-from it.
+`@react-router/dev/config` or hand-roll intersections. `@react-router/dev`
+is declared as an optional peer dependency since the exported config and
+route types resolve from it; this is not a breaking change — nothing new is
+required at install or runtime.

--- a/.changeset/export-config-type.md
+++ b/.changeset/export-config-type.md
@@ -1,0 +1,8 @@
+---
+'rsbuild-plugin-react-router': minor
+---
+
+Export `ReactRouterRsbuildConfig`, the plugin's typed `react-router.config.*`
+shape (React Router's `Config` plus plugin-supported options such as
+`splitRouteModules`), so projects no longer need to import types from
+`@react-router/dev/config` or hand-roll intersections.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ async exports before passing the build to React Router's request handler.
 Put React Router framework settings in `react-router.config.*`:
 
 ```ts
-import type { Config } from '@react-router/dev/config';
+import type { ReactRouterRsbuildConfig } from 'rsbuild-plugin-react-router';
 
 export default {
   ssr: true,
@@ -107,8 +107,12 @@ export default {
   basename: '/',
   splitRouteModules: true,
   subResourceIntegrity: false,
-} satisfies Config;
+} satisfies ReactRouterRsbuildConfig;
 ```
+
+Use `ReactRouterRsbuildConfig` for Rsbuild projects so plugin-supported
+configuration such as `splitRouteModules` stays typed without reaching into
+`@react-router/dev` internals.
 
 Commonly used options:
 
@@ -178,7 +182,7 @@ For static sites with multiple pages, you can prerender specific routes at build
 
 ```ts
 // react-router.config.ts
-import type { Config } from '@react-router/dev/config';
+import type { ReactRouterRsbuildConfig } from 'rsbuild-plugin-react-router';
 
 export default {
   ssr: false,
@@ -190,7 +194,7 @@ export default {
     '/docs/advanced',
     '/projects',
   ],
-} satisfies Config;
+} satisfies ReactRouterRsbuildConfig;
 ```
 
 When `prerender` is specified:
@@ -209,7 +213,7 @@ export default {
   ssr: false,
   prerender: ({ getStaticPaths }) =>
     getStaticPaths().filter(path => path !== '/admin'),
-} satisfies Config;
+} satisfies ReactRouterRsbuildConfig;
 ```
 
 Prerendering defaults to one path at a time, matching React Router. Use
@@ -223,7 +227,7 @@ export default {
     paths: ['/', '/about'],
     concurrency: 4,
   },
-} satisfies Config;
+} satisfies ReactRouterRsbuildConfig;
 ```
 
 For builds with 256+ routes, detailed file-size reporting is compacted to totals

--- a/README.md
+++ b/README.md
@@ -111,8 +111,10 @@ export default {
 ```
 
 Use `ReactRouterRsbuildConfig` for Rsbuild projects so plugin-supported
-configuration such as `splitRouteModules` stays typed without reaching into
-`@react-router/dev` internals.
+configuration such as `splitRouteModules` stays typed. The underlying route
+and config types come from `@react-router/dev`, which framework-mode apps
+already install for `routes.ts` helpers and typegen; it is declared as an
+optional peer dependency.
 
 Commonly used options:
 

--- a/benchmarks/synthetic-web-bundler-benchmark/react-router.config.ts
+++ b/benchmarks/synthetic-web-bundler-benchmark/react-router.config.ts
@@ -1,8 +1,4 @@
-import type { Config } from '@react-router/dev/config';
-
-type SyntheticReactRouterConfig = Config & {
-  splitRouteModules?: boolean | 'enforce';
-};
+import type { ReactRouterRsbuildConfig } from 'rsbuild-plugin-react-router';
 
 export default {
   appDirectory: 'app',
@@ -15,4 +11,4 @@ export default {
   serverModuleFormat: 'esm',
   splitRouteModules: true,
   ssr: true,
-} satisfies SyntheticReactRouterConfig;
+} satisfies ReactRouterRsbuildConfig;

--- a/package.json
+++ b/package.json
@@ -117,7 +117,13 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
+    "@react-router/dev": "^7.13.0 || ^8.0.0",
     "@rsbuild/core": "^2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@react-router/dev": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/scripts/benchmark/fixture.mts
+++ b/scripts/benchmark/fixture.mts
@@ -308,12 +308,12 @@ const createReactRouterConfig = variant => {
   const splitRouteModules = variant.includes('split');
 
   return [
-    `import type { Config } from '@react-router/dev/config';`,
+    `import type { ReactRouterRsbuildConfig } from 'rsbuild-plugin-react-router';`,
     '',
     'export default {',
     `  ssr: ${ssr ? 'true' : 'false'},`,
     `  splitRouteModules: ${splitRouteModules ? 'true' : 'false'},`,
-    '} satisfies Config;',
+    '} satisfies ReactRouterRsbuildConfig;',
     '',
   ].join('\n');
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,7 @@ import {
   registerReactRouterDevBackgroundResources,
 } from './dev-background-resources.js';
 
+export type { Config as ReactRouterRsbuildConfig } from './react-router-config.js';
 export { loadReactRouterServerBuild } from './dev-generation.js';
 export { resolveReactRouterServerBuild };
 


### PR DESCRIPTION
## Summary

Split out of the React Router 8 branch (`codex/react-router-8-compat-v2`) — a small DX improvement that can land ahead of it:

- Export `ReactRouterRsbuildConfig` from the plugin (a re-export of the internal `Config` type: React Router's `Config` plus plugin-supported options like `splitRouteModules`).
- Update the README config examples to `satisfies ReactRouterRsbuildConfig` instead of importing from `@react-router/dev/config`.
- Use it in the synthetic benchmark config and the benchmark fixture generator, dropping the hand-rolled `SyntheticReactRouterConfig` intersection.

Includes a patch changeset (non-breaking: the new `@react-router/dev` peer is optional).

## Testing

- `tsc --noEmit` clean
- `rstest run tests/benchmark-fixture.test.ts` — all 8 fixture-generator tests pass; the 3 CLI-spawn tests fail on Node 20 with the pre-existing `.mts` extension error that #90 skips (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
