### PR TITLE
test: follow route restart marker move

### DIFF
--- a/examples/default-template/tests/e2e/dev-route-watch.test.ts
+++ b/examples/default-template/tests/e2e/dev-route-watch.test.ts
@@ -11,10 +11,7 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const appDirectory = join(__dirname, '../../app');
-const restartMarkerPath = join(
-  __dirname,
-  '../../build/client/.react-router/route-watch'
-);
+const restartMarkerPath = join(appDirectory, '..', '.react-router/route-watch');
 const devRoutesConfigPath = join(appDirectory, 'dev-routes.ts');
 const addedRoutePath = join(appDirectory, 'routes/dev-added-route.tsx');
 const addedRouteUrl = '/dev-added-route';


### PR DESCRIPTION
Fix the post-#82 Build Test failure by reading the route restart marker from its new project-root location.

The runtime path moved from `build/client/.react-router/route-watch` to `.react-router/route-watch`; the E2E assertion still used the old path.

Verification: focused `dev-route-watch.test.ts` passes.