### PR TITLE
ci: shard benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -261,7 +261,7 @@ jobs:
 
       - name: Test benchmark scripts
         if: steps.synthetic-benchmark.outputs.SKIP == 'false'
-        working-directory: ${{ steps.synthetic-benchmark.outputs.TOOL_ROOT }}
+        working-directory: head/benchmarks/synthetic-web-bundler-benchmark
         run: pnpm test:benchmark
 
       - name: Restore base synthetic benchmark results

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -315,7 +315,9 @@ jobs:
 
       - name: Ensure skipped synthetic artifact path exists
         if: steps.synthetic-benchmark.outputs.SKIP == 'true'
-        run: mkdir -p benchmark-output/synthetic
+        run: |
+          mkdir -p benchmark-output/synthetic
+          touch benchmark-output/synthetic/SKIPPED
 
       - name: Upload synthetic benchmark shard
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -345,6 +347,15 @@ jobs:
         with:
           node-version-file: head/.nvmrc
           package-manager-cache: false
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
+        with:
+          package_json_file: head/package.json
+
+      - name: Install head runtime dependencies
+        working-directory: head
+        run: pnpm install --filter rsbuild-plugin-react-router --prod --frozen-lockfile
 
       - name: Download small benchmark shard
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,23 +13,198 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  benchmark:
-    name: Compare full build and dev benchmark
+  build-dev-benchmark:
+    name: Benchmark build/dev (${{ matrix.label }})
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 40
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: small
+            label: small fixtures
+            profile: ci-small
+          - shard: large
+            label: large fixtures
+            profile: ci-large
 
     env:
-      BENCHMARK_PROFILE: full
-      BENCHMARK_BUILD_ITERATIONS: '10'
-      BENCHMARK_LARGE_ITERATIONS: '5'
+      BENCHMARK_PROFILE: ${{ matrix.profile }}
+      BENCHMARK_BUILD_ITERATIONS: '3'
+      BENCHMARK_LARGE_ITERATIONS: '3'
       BENCHMARK_MODE: dev
-      BENCHMARK_ITERATIONS: '10'
+      BENCHMARK_ITERATIONS: '3'
       BENCHMARK_WARMUP: '0'
       BENCHMARK_DEV_ROUTES: auto
       BENCHMARK_LOG_PERFORMANCE: '1'
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          path: head
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Checkout PR base
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          path: base
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version-file: head/.nvmrc
+          package-manager-cache: false
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
+        with:
+          package_json_file: head/package.json
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup pnpm cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-benchmark-pnpm-${{ hashFiles('head/pnpm-lock.yaml', 'base/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-benchmark-pnpm-
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install head dependencies
+        working-directory: head
+        run: pnpm install --frozen-lockfile
+
+      - name: Install base dependencies
+        working-directory: base
+        run: pnpm install --frozen-lockfile
+
+      - name: Resolve benchmark-only React plugin
+        id: benchmark-imports
+        shell: bash
+        run: |
+          node -e "const { pathToFileURL } = require('node:url'); console.log('PLUGIN_REACT_IMPORT=' + pathToFileURL(process.argv[1]).href)" \
+            "$GITHUB_WORKSPACE/head/node_modules/@rsbuild/plugin-react/dist/index.js" >> "$GITHUB_OUTPUT"
+
+      - name: Restore base benchmark results
+        id: base-benchmark-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: |
+            benchmark-output/${{ matrix.shard }}/build/base
+            benchmark-output/${{ matrix.shard }}/dev/base
+          key: >-
+            ${{ runner.os }}-benchmark-base-${{ matrix.shard }}-${{
+            github.event.pull_request.base.sha }}-${{
+            hashFiles(
+              'head/.nvmrc',
+              'head/package.json',
+              'head/pnpm-lock.yaml',
+              'head/scripts/bench-builds.mts',
+              'head/scripts/benchmark/**',
+              'base/package.json',
+              'base/pnpm-lock.yaml'
+            ) }}-${{ env.BENCHMARK_PROFILE }}-${{ env.BENCHMARK_BUILD_ITERATIONS }}-${{
+            env.BENCHMARK_LARGE_ITERATIONS }}-${{ env.BENCHMARK_MODE }}-${{
+            env.BENCHMARK_ITERATIONS }}-${{ env.BENCHMARK_WARMUP }}-${{
+            env.BENCHMARK_DEV_ROUTES }}-${{ env.BENCHMARK_LOG_PERFORMANCE }}
+
+      - name: Validate cached base benchmark results
+        if: steps.base-benchmark-cache.outputs.cache-hit == 'true'
+        run: |
+          set -euo pipefail
+          test -f "$GITHUB_WORKSPACE/benchmark-output/${{ matrix.shard }}/build/base/baseline.json"
+          test -f "$GITHUB_WORKSPACE/benchmark-output/${{ matrix.shard }}/dev/base/baseline.json"
+
+      - name: Benchmark base production build
+        if: steps.base-benchmark-cache.outputs.cache-hit != 'true'
+        working-directory: base
+        env:
+          REACT_ROUTER_BENCHMARK_PLUGIN_REACT_IMPORT: ${{ steps.benchmark-imports.outputs.PLUGIN_REACT_IMPORT }}
+        run: |
+          node "$GITHUB_WORKSPACE/head/scripts/bench-builds.mts" \
+            --profile "$BENCHMARK_PROFILE" \
+            --mode build \
+            --iterations "$BENCHMARK_BUILD_ITERATIONS" \
+            --large-iterations "$BENCHMARK_LARGE_ITERATIONS" \
+            --warmup "$BENCHMARK_WARMUP" \
+            --clean build \
+            --format both \
+            $(if [ "$BENCHMARK_LOG_PERFORMANCE" = "1" ]; then printf '%s\n' --log-performance; fi) \
+            --out "$GITHUB_WORKSPACE/benchmark-output/${{ matrix.shard }}/build/base"
+
+      - name: Benchmark head production build
+        working-directory: head
+        run: |
+          node scripts/bench-builds.mts \
+            --profile "$BENCHMARK_PROFILE" \
+            --mode build \
+            --iterations "$BENCHMARK_BUILD_ITERATIONS" \
+            --large-iterations "$BENCHMARK_LARGE_ITERATIONS" \
+            --warmup "$BENCHMARK_WARMUP" \
+            --clean build \
+            --format both \
+            $(if [ "$BENCHMARK_LOG_PERFORMANCE" = "1" ]; then printf '%s\n' --log-performance; fi) \
+            --out "$GITHUB_WORKSPACE/benchmark-output/${{ matrix.shard }}/build/head"
+
+      - name: Benchmark base dev
+        if: steps.base-benchmark-cache.outputs.cache-hit != 'true'
+        working-directory: base
+        env:
+          REACT_ROUTER_BENCHMARK_PLUGIN_REACT_IMPORT: ${{ steps.benchmark-imports.outputs.PLUGIN_REACT_IMPORT }}
+        run: |
+          node "$GITHUB_WORKSPACE/head/scripts/bench-builds.mts" \
+            --profile "$BENCHMARK_PROFILE" \
+            --mode "$BENCHMARK_MODE" \
+            --iterations "$BENCHMARK_ITERATIONS" \
+            --large-iterations "$BENCHMARK_LARGE_ITERATIONS" \
+            --warmup "$BENCHMARK_WARMUP" \
+            --dev-routes "$BENCHMARK_DEV_ROUTES" \
+            --clean build \
+            --format both \
+            $(if [ "$BENCHMARK_LOG_PERFORMANCE" = "1" ]; then printf '%s\n' --log-performance; fi) \
+            --out "$GITHUB_WORKSPACE/benchmark-output/${{ matrix.shard }}/dev/base"
+
+      - name: Benchmark head dev
+        working-directory: head
+        run: |
+          node scripts/bench-builds.mts \
+            --profile "$BENCHMARK_PROFILE" \
+            --mode "$BENCHMARK_MODE" \
+            --iterations "$BENCHMARK_ITERATIONS" \
+            --large-iterations "$BENCHMARK_LARGE_ITERATIONS" \
+            --warmup "$BENCHMARK_WARMUP" \
+            --dev-routes "$BENCHMARK_DEV_ROUTES" \
+            --clean build \
+            --format both \
+            $(if [ "$BENCHMARK_LOG_PERFORMANCE" = "1" ]; then printf '%s\n' --log-performance; fi) \
+            --out "$GITHUB_WORKSPACE/benchmark-output/${{ matrix.shard }}/dev/head"
+
+      - name: Upload benchmark shard
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: benchmark-${{ matrix.shard }}-${{ github.event.pull_request.head.sha }}
+          path: benchmark-output/${{ matrix.shard }}
+          if-no-files-found: error
+
+  synthetic-benchmark:
+    name: Benchmark synthetic app
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    env:
       BENCHMARK_HISTORY_BRANCH: benchmark-results
       SYNTHETIC_BENCHMARK_PROFILE: all
-      SYNTHETIC_BENCHMARK_RUNS: '2'
+      SYNTHETIC_BENCHMARK_RUNS: '3'
 
     steps:
       - name: Checkout PR head
@@ -85,118 +260,34 @@ jobs:
         run: node head/scripts/benchmark/ci-resolve-synthetic.mjs
 
       - name: Test benchmark scripts
-        working-directory: head/benchmarks/synthetic-web-bundler-benchmark
+        if: steps.synthetic-benchmark.outputs.SKIP == 'false'
+        working-directory: ${{ steps.synthetic-benchmark.outputs.TOOL_ROOT }}
         run: pnpm test:benchmark
 
-      - name: Resolve benchmark-only React plugin
-        id: benchmark-imports
-        shell: bash
-        run: |
-          node -e "const { pathToFileURL } = require('node:url'); console.log('PLUGIN_REACT_IMPORT=' + pathToFileURL(process.argv[1]).href)" \
-            "$GITHUB_WORKSPACE/head/node_modules/@rsbuild/plugin-react/dist/index.js" >> "$GITHUB_OUTPUT"
-
-      - name: Restore base benchmark results
+      - name: Restore base synthetic benchmark results
         id: base-benchmark-cache
+        if: steps.synthetic-benchmark.outputs.SKIP == 'false'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
-          path: |
-            benchmark-output/build/base
-            benchmark-output/dev/base
-            benchmark-output/synthetic/base
+          path: benchmark-output/synthetic/base
           key: >-
-            ${{ runner.os }}-benchmark-base-${{ github.event.pull_request.base.sha }}-${{
+            ${{ runner.os }}-benchmark-base-synthetic-${{
+            github.event.pull_request.base.sha }}-${{
             hashFiles(
               'head/.nvmrc',
               'head/package.json',
               'head/pnpm-lock.yaml',
-              'head/scripts/bench-builds.mts',
               'head/scripts/bench-synthetic-app.mjs',
               'head/scripts/benchmark/**',
               'head/benchmarks/synthetic-web-bundler-benchmark/**',
               'base/package.json',
               'base/pnpm-lock.yaml'
-            ) }}-${{ env.BENCHMARK_PROFILE }}-${{ env.BENCHMARK_BUILD_ITERATIONS }}-${{
-            env.BENCHMARK_LARGE_ITERATIONS }}-${{ env.BENCHMARK_MODE }}-${{
-            env.BENCHMARK_ITERATIONS }}-${{ env.BENCHMARK_WARMUP }}-${{
-            env.BENCHMARK_DEV_ROUTES }}-${{ env.BENCHMARK_LOG_PERFORMANCE }}-${{
-            env.SYNTHETIC_BENCHMARK_PROFILE }}-${{
+            ) }}-${{ env.SYNTHETIC_BENCHMARK_PROFILE }}-${{
             env.SYNTHETIC_BENCHMARK_RUNS }}
 
-      - name: Validate cached base benchmark results
-        if: steps.base-benchmark-cache.outputs.cache-hit == 'true'
-        env:
-          SYNTHETIC_BENCHMARK_SKIP: ${{ steps.synthetic-benchmark.outputs.SKIP }}
-        run: |
-          set -euo pipefail
-          test -f "$GITHUB_WORKSPACE/benchmark-output/build/base/baseline.json"
-          test -f "$GITHUB_WORKSPACE/benchmark-output/dev/base/baseline.json"
-          if [ "$SYNTHETIC_BENCHMARK_SKIP" = "false" ]; then
-            test -f "$GITHUB_WORKSPACE/benchmark-output/synthetic/base/latest.json"
-          fi
-
-      - name: Benchmark base production build
-        if: steps.base-benchmark-cache.outputs.cache-hit != 'true'
-        working-directory: base
-        env:
-          REACT_ROUTER_BENCHMARK_PLUGIN_REACT_IMPORT: ${{ steps.benchmark-imports.outputs.PLUGIN_REACT_IMPORT }}
-        run: |
-          node "$GITHUB_WORKSPACE/head/scripts/bench-builds.mts" \
-            --profile "$BENCHMARK_PROFILE" \
-            --mode build \
-            --iterations "$BENCHMARK_BUILD_ITERATIONS" \
-            --large-iterations "$BENCHMARK_LARGE_ITERATIONS" \
-            --warmup "$BENCHMARK_WARMUP" \
-            --clean build \
-            --format both \
-            $(if [ "$BENCHMARK_LOG_PERFORMANCE" = "1" ]; then printf '%s\n' --log-performance; fi) \
-            --out "$GITHUB_WORKSPACE/benchmark-output/build/base"
-
-      - name: Benchmark head production build
-        working-directory: head
-        run: |
-          node scripts/bench-builds.mts \
-            --profile "$BENCHMARK_PROFILE" \
-            --mode build \
-            --iterations "$BENCHMARK_BUILD_ITERATIONS" \
-            --large-iterations "$BENCHMARK_LARGE_ITERATIONS" \
-            --warmup "$BENCHMARK_WARMUP" \
-            --clean build \
-            --format both \
-            $(if [ "$BENCHMARK_LOG_PERFORMANCE" = "1" ]; then printf '%s\n' --log-performance; fi) \
-            --out "$GITHUB_WORKSPACE/benchmark-output/build/head"
-
-      - name: Benchmark base dev
-        if: steps.base-benchmark-cache.outputs.cache-hit != 'true'
-        working-directory: base
-        env:
-          REACT_ROUTER_BENCHMARK_PLUGIN_REACT_IMPORT: ${{ steps.benchmark-imports.outputs.PLUGIN_REACT_IMPORT }}
-        run: |
-          node "$GITHUB_WORKSPACE/head/scripts/bench-builds.mts" \
-            --profile "$BENCHMARK_PROFILE" \
-            --mode "$BENCHMARK_MODE" \
-            --iterations "$BENCHMARK_ITERATIONS" \
-            --large-iterations "$BENCHMARK_LARGE_ITERATIONS" \
-            --warmup "$BENCHMARK_WARMUP" \
-            --dev-routes "$BENCHMARK_DEV_ROUTES" \
-            --clean build \
-            --format both \
-            $(if [ "$BENCHMARK_LOG_PERFORMANCE" = "1" ]; then printf '%s\n' --log-performance; fi) \
-            --out "$GITHUB_WORKSPACE/benchmark-output/dev/base"
-
-      - name: Benchmark head dev
-        working-directory: head
-        run: |
-          node scripts/bench-builds.mts \
-            --profile "$BENCHMARK_PROFILE" \
-            --mode "$BENCHMARK_MODE" \
-            --iterations "$BENCHMARK_ITERATIONS" \
-            --large-iterations "$BENCHMARK_LARGE_ITERATIONS" \
-            --warmup "$BENCHMARK_WARMUP" \
-            --dev-routes "$BENCHMARK_DEV_ROUTES" \
-            --clean build \
-            --format both \
-            $(if [ "$BENCHMARK_LOG_PERFORMANCE" = "1" ]; then printf '%s\n' --log-performance; fi) \
-            --out "$GITHUB_WORKSPACE/benchmark-output/dev/head"
+      - name: Validate cached base synthetic benchmark results
+        if: steps.synthetic-benchmark.outputs.SKIP == 'false' && steps.base-benchmark-cache.outputs.cache-hit == 'true'
+        run: test -f "$GITHUB_WORKSPACE/benchmark-output/synthetic/base/latest.json"
 
       - name: Benchmark embedded synthetic app with base plugin
         if: steps.synthetic-benchmark.outputs.SKIP == 'false' && steps.base-benchmark-cache.outputs.cache-hit != 'true'
@@ -221,6 +312,76 @@ jobs:
             --out "$GITHUB_WORKSPACE/benchmark-output/synthetic/head" \
             --runs "$SYNTHETIC_BENCHMARK_RUNS" \
             --profile "$SYNTHETIC_BENCHMARK_PROFILE"
+
+      - name: Ensure skipped synthetic artifact path exists
+        if: steps.synthetic-benchmark.outputs.SKIP == 'true'
+        run: mkdir -p benchmark-output/synthetic
+
+      - name: Upload synthetic benchmark shard
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: benchmark-synthetic-${{ github.event.pull_request.head.sha }}
+          path: benchmark-output/synthetic
+          if-no-files-found: error
+
+  benchmark:
+    name: Compare full build and dev benchmark
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs:
+      - build-dev-benchmark
+      - synthetic-benchmark
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          path: head
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version-file: head/.nvmrc
+          package-manager-cache: false
+
+      - name: Download small benchmark shard
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: benchmark-small-${{ github.event.pull_request.head.sha }}
+          path: benchmark-output/shards/small
+
+      - name: Download large benchmark shard
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: benchmark-large-${{ github.event.pull_request.head.sha }}
+          path: benchmark-output/shards/large
+
+      - name: Download synthetic benchmark shard
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: benchmark-synthetic-${{ github.event.pull_request.head.sha }}
+          path: benchmark-output/synthetic
+
+      - name: Merge benchmark shards
+        run: |
+          node head/scripts/benchmark/ci-merge-results.mjs \
+            --out "$GITHUB_WORKSPACE/benchmark-output/build/base/baseline.json" \
+            "$GITHUB_WORKSPACE/benchmark-output/shards/small/build/base/baseline.json" \
+            "$GITHUB_WORKSPACE/benchmark-output/shards/large/build/base/baseline.json"
+          node head/scripts/benchmark/ci-merge-results.mjs \
+            --out "$GITHUB_WORKSPACE/benchmark-output/build/head/baseline.json" \
+            "$GITHUB_WORKSPACE/benchmark-output/shards/small/build/head/baseline.json" \
+            "$GITHUB_WORKSPACE/benchmark-output/shards/large/build/head/baseline.json"
+          node head/scripts/benchmark/ci-merge-results.mjs \
+            --out "$GITHUB_WORKSPACE/benchmark-output/dev/base/baseline.json" \
+            "$GITHUB_WORKSPACE/benchmark-output/shards/small/dev/base/baseline.json" \
+            "$GITHUB_WORKSPACE/benchmark-output/shards/large/dev/base/baseline.json"
+          node head/scripts/benchmark/ci-merge-results.mjs \
+            --out "$GITHUB_WORKSPACE/benchmark-output/dev/head/baseline.json" \
+            "$GITHUB_WORKSPACE/benchmark-output/shards/small/dev/head/baseline.json" \
+            "$GITHUB_WORKSPACE/benchmark-output/shards/large/dev/head/baseline.json"
 
       - name: Generate benchmark report
         working-directory: head

--- a/scripts/benchmark/ci-merge-results.mjs
+++ b/scripts/benchmark/ci-merge-results.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { parseArgs } from 'node:util';
+
+const { values, positionals } = parseArgs({
+  allowPositionals: true,
+  strict: true,
+  options: {
+    out: { type: 'string' },
+  },
+});
+
+if (!values.out || positionals.length === 0) {
+  throw new Error(
+    'Usage: node scripts/benchmark/ci-merge-results.mjs --out <baseline.json> <shard.json>...'
+  );
+}
+
+const readJson = async file => JSON.parse(await readFile(file, 'utf8'));
+const inputs = await Promise.all(positionals.map(readJson));
+const [first] = inputs;
+const benchmarks = inputs.flatMap(input => input.benchmarks ?? []);
+const failed = inputs.some(input => input.failed === true);
+const profiles = inputs
+  .map(input => input.profile)
+  .filter((profile, index, all) => profile && all.indexOf(profile) === index);
+
+const merged = {
+  ...first,
+  profile: profiles.join('+'),
+  failed,
+  benchmarks,
+};
+
+const outPath = path.resolve(values.out);
+await mkdir(path.dirname(outPath), { recursive: true });
+await writeFile(outPath, `${JSON.stringify(merged, null, 2)}\n`);
+console.log(`Merged ${positionals.length} benchmark shard(s) into ${outPath}`);

--- a/scripts/benchmark/profiles.mjs
+++ b/scripts/benchmark/profiles.mjs
@@ -27,6 +27,36 @@ export const profiles = {
       variant: 'ssr-esm-split',
     },
   ],
+  'ci-small': [
+    { id: 'synthetic-48-ssr-esm', routeCount: 48, variant: 'ssr-esm' },
+    { id: 'synthetic-256-ssr-esm', routeCount: 256, variant: 'ssr-esm' },
+    {
+      id: 'synthetic-256-ssr-esm-split',
+      routeCount: 256,
+      variant: 'ssr-esm-split',
+    },
+    {
+      id: 'synthetic-256-sourcemaps',
+      routeCount: 256,
+      variant: 'ssr-esm',
+      sourceMap: true,
+    },
+  ],
+  'ci-large': [
+    { id: 'synthetic-1024-ssr-esm', routeCount: 1024, variant: 'ssr-esm' },
+    {
+      id: 'synthetic-1024-ssr-esm-split',
+      routeCount: 1024,
+      variant: 'ssr-esm-split',
+    },
+    {
+      id: 'large-355-ssr-esm',
+      routeCount: 355,
+      variant: 'ssr-esm',
+      fixture: 'large',
+      devRoutePathOffset: 0,
+    },
+  ],
   full: [
     { id: 'synthetic-48-ssr-esm', routeCount: 48, variant: 'ssr-esm' },
     { id: 'synthetic-256-ssr-esm', routeCount: 256, variant: 'ssr-esm' },

--- a/tests/benchmark-fixture.test.ts
+++ b/tests/benchmark-fixture.test.ts
@@ -407,6 +407,52 @@ describe('benchmark fixture generator', () => {
     expect(result.stderr).not.toContain('Unknown profile "large"');
   });
 
+  it('merges benchmark result shards for CI reporting', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rr-benchmark-merge-'));
+
+    try {
+      writeJson(join(root, 'small.json'), {
+        profile: 'ci-small',
+        failed: false,
+        benchmarks: [{ id: 'synthetic-48-ssr-esm' }],
+      });
+      writeJson(join(root, 'large.json'), {
+        profile: 'ci-large',
+        failed: true,
+        benchmarks: [{ id: 'large-355-ssr-esm' }],
+      });
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          'scripts/benchmark/ci-merge-results.mjs',
+          '--out',
+          join(root, 'out/baseline.json'),
+          join(root, 'small.json'),
+          join(root, 'large.json'),
+        ],
+        {
+          cwd: process.cwd(),
+          encoding: 'utf8',
+        }
+      );
+
+      expect(result.status, result.stderr || result.stdout).toBe(0);
+      expect(
+        JSON.parse(readFileSync(join(root, 'out/baseline.json'), 'utf8'))
+      ).toMatchObject({
+        profile: 'ci-small+ci-large',
+        failed: true,
+        benchmarks: [
+          { id: 'synthetic-48-ssr-esm' },
+          { id: 'large-355-ssr-esm' },
+        ],
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('renders the embedded synthetic app benchmark row in CI reports', () => {
     const root = mkdtempSync(join(tmpdir(), 'rr-benchmark-report-'));
 


### PR DESCRIPTION
## Summary
- split benchmark CI into small fixture, large fixture, and embedded synthetic app shards
- reduce CI benchmark samples to 3 runs per shard
- merge shard artifacts before generating the existing benchmark report/comment/history

## Verification
- actionlint .github/workflows/benchmark.yml
- pnpm test:core tests/benchmark-fixture.test.ts
- pnpm exec tsc --noEmit --pretty false
- python3 YAML parse smoke
