### PR TITLE
ci: stabilize benchmark comparisons

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,19 +25,22 @@ jobs:
           - shard: small
             label: small fixtures
             profile: ci-small
+            build_order: base,head
+            dev_order: head,base
           - shard: large
             label: large fixtures
             profile: ci-large
+            build_order: head,base
+            dev_order: base,head
 
     env:
       BENCHMARK_PROFILE: ${{ matrix.profile }}
-      BENCHMARK_BUILD_ITERATIONS: '3'
+      BENCHMARK_BUILD_ITERATIONS: '5'
       BENCHMARK_LARGE_ITERATIONS: '3'
       BENCHMARK_MODE: dev
-      BENCHMARK_ITERATIONS: '3'
-      BENCHMARK_WARMUP: '0'
+      BENCHMARK_ITERATIONS: '5'
+      BENCHMARK_WARMUP: '1'
       BENCHMARK_DEV_ROUTES: auto
-      BENCHMARK_LOG_PERFORMANCE: '1'
 
     steps:
       - name: Checkout PR head
@@ -95,99 +98,67 @@ jobs:
           node -e "const { pathToFileURL } = require('node:url'); console.log('PLUGIN_REACT_IMPORT=' + pathToFileURL(process.argv[1]).href)" \
             "$GITHUB_WORKSPACE/head/node_modules/@rsbuild/plugin-react/dist/index.js" >> "$GITHUB_OUTPUT"
 
-      - name: Restore base benchmark results
-        id: base-benchmark-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: |
-            benchmark-output/${{ matrix.shard }}/build/base
-            benchmark-output/${{ matrix.shard }}/dev/base
-          key: >-
-            ${{ runner.os }}-benchmark-base-${{ matrix.shard }}-${{
-            github.event.pull_request.base.sha }}-${{
-            hashFiles(
-              'head/.nvmrc',
-              'head/package.json',
-              'head/pnpm-lock.yaml',
-              'head/scripts/bench-builds.mts',
-              'head/scripts/benchmark/**',
-              'base/package.json',
-              'base/pnpm-lock.yaml'
-            ) }}-${{ env.BENCHMARK_PROFILE }}-${{ env.BENCHMARK_BUILD_ITERATIONS }}-${{
-            env.BENCHMARK_LARGE_ITERATIONS }}-${{ env.BENCHMARK_MODE }}-${{
-            env.BENCHMARK_ITERATIONS }}-${{ env.BENCHMARK_WARMUP }}-${{
-            env.BENCHMARK_DEV_ROUTES }}-${{ env.BENCHMARK_LOG_PERFORMANCE }}
-
-      - name: Validate cached base benchmark results
-        if: steps.base-benchmark-cache.outputs.cache-hit == 'true'
+      # Keep both sides on the same runner and counterbalance which side runs
+      # first across shard/mode pairs. Timing artifacts are deliberately not
+      # cached because a cached base cannot control for the current runner.
+      - name: Benchmark production builds
+        env:
+          PLUGIN_REACT_IMPORT: ${{ steps.benchmark-imports.outputs.PLUGIN_REACT_IMPORT }}
+          RUN_ORDER: ${{ matrix.build_order }}
         run: |
           set -euo pipefail
-          test -f "$GITHUB_WORKSPACE/benchmark-output/${{ matrix.shard }}/build/base/baseline.json"
-          test -f "$GITHUB_WORKSPACE/benchmark-output/${{ matrix.shard }}/dev/base/baseline.json"
+          run_benchmark() {
+            local side="$1"
+            (
+              cd "$GITHUB_WORKSPACE/$side"
+              if [ "$side" = base ]; then
+                export REACT_ROUTER_BENCHMARK_PLUGIN_REACT_IMPORT="$PLUGIN_REACT_IMPORT"
+              fi
+              node "$GITHUB_WORKSPACE/head/scripts/bench-builds.mts" \
+                --profile "$BENCHMARK_PROFILE" \
+                --mode build \
+                --iterations "$BENCHMARK_BUILD_ITERATIONS" \
+                --large-iterations "$BENCHMARK_LARGE_ITERATIONS" \
+                --warmup "$BENCHMARK_WARMUP" \
+                --clean build \
+                --format both \
+                --log-performance \
+                --out "$GITHUB_WORKSPACE/benchmark-output/${{ matrix.shard }}/build/$side"
+            )
+          }
+          IFS=, read -r first second <<< "$RUN_ORDER"
+          run_benchmark "$first"
+          run_benchmark "$second"
 
-      - name: Benchmark base production build
-        if: steps.base-benchmark-cache.outputs.cache-hit != 'true'
-        working-directory: base
+      - name: Benchmark dev servers
         env:
-          REACT_ROUTER_BENCHMARK_PLUGIN_REACT_IMPORT: ${{ steps.benchmark-imports.outputs.PLUGIN_REACT_IMPORT }}
+          PLUGIN_REACT_IMPORT: ${{ steps.benchmark-imports.outputs.PLUGIN_REACT_IMPORT }}
+          RUN_ORDER: ${{ matrix.dev_order }}
         run: |
-          node "$GITHUB_WORKSPACE/head/scripts/bench-builds.mts" \
-            --profile "$BENCHMARK_PROFILE" \
-            --mode build \
-            --iterations "$BENCHMARK_BUILD_ITERATIONS" \
-            --large-iterations "$BENCHMARK_LARGE_ITERATIONS" \
-            --warmup "$BENCHMARK_WARMUP" \
-            --clean build \
-            --format both \
-            $(if [ "$BENCHMARK_LOG_PERFORMANCE" = "1" ]; then printf '%s\n' --log-performance; fi) \
-            --out "$GITHUB_WORKSPACE/benchmark-output/${{ matrix.shard }}/build/base"
-
-      - name: Benchmark head production build
-        working-directory: head
-        run: |
-          node scripts/bench-builds.mts \
-            --profile "$BENCHMARK_PROFILE" \
-            --mode build \
-            --iterations "$BENCHMARK_BUILD_ITERATIONS" \
-            --large-iterations "$BENCHMARK_LARGE_ITERATIONS" \
-            --warmup "$BENCHMARK_WARMUP" \
-            --clean build \
-            --format both \
-            $(if [ "$BENCHMARK_LOG_PERFORMANCE" = "1" ]; then printf '%s\n' --log-performance; fi) \
-            --out "$GITHUB_WORKSPACE/benchmark-output/${{ matrix.shard }}/build/head"
-
-      - name: Benchmark base dev
-        if: steps.base-benchmark-cache.outputs.cache-hit != 'true'
-        working-directory: base
-        env:
-          REACT_ROUTER_BENCHMARK_PLUGIN_REACT_IMPORT: ${{ steps.benchmark-imports.outputs.PLUGIN_REACT_IMPORT }}
-        run: |
-          node "$GITHUB_WORKSPACE/head/scripts/bench-builds.mts" \
-            --profile "$BENCHMARK_PROFILE" \
-            --mode "$BENCHMARK_MODE" \
-            --iterations "$BENCHMARK_ITERATIONS" \
-            --large-iterations "$BENCHMARK_LARGE_ITERATIONS" \
-            --warmup "$BENCHMARK_WARMUP" \
-            --dev-routes "$BENCHMARK_DEV_ROUTES" \
-            --clean build \
-            --format both \
-            $(if [ "$BENCHMARK_LOG_PERFORMANCE" = "1" ]; then printf '%s\n' --log-performance; fi) \
-            --out "$GITHUB_WORKSPACE/benchmark-output/${{ matrix.shard }}/dev/base"
-
-      - name: Benchmark head dev
-        working-directory: head
-        run: |
-          node scripts/bench-builds.mts \
-            --profile "$BENCHMARK_PROFILE" \
-            --mode "$BENCHMARK_MODE" \
-            --iterations "$BENCHMARK_ITERATIONS" \
-            --large-iterations "$BENCHMARK_LARGE_ITERATIONS" \
-            --warmup "$BENCHMARK_WARMUP" \
-            --dev-routes "$BENCHMARK_DEV_ROUTES" \
-            --clean build \
-            --format both \
-            $(if [ "$BENCHMARK_LOG_PERFORMANCE" = "1" ]; then printf '%s\n' --log-performance; fi) \
-            --out "$GITHUB_WORKSPACE/benchmark-output/${{ matrix.shard }}/dev/head"
+          set -euo pipefail
+          run_benchmark() {
+            local side="$1"
+            (
+              cd "$GITHUB_WORKSPACE/$side"
+              if [ "$side" = base ]; then
+                export REACT_ROUTER_BENCHMARK_PLUGIN_REACT_IMPORT="$PLUGIN_REACT_IMPORT"
+              fi
+              node "$GITHUB_WORKSPACE/head/scripts/bench-builds.mts" \
+                --profile "$BENCHMARK_PROFILE" \
+                --mode "$BENCHMARK_MODE" \
+                --iterations "$BENCHMARK_ITERATIONS" \
+                --large-iterations "$BENCHMARK_LARGE_ITERATIONS" \
+                --warmup "$BENCHMARK_WARMUP" \
+                --dev-routes "$BENCHMARK_DEV_ROUTES" \
+                --clean build \
+                --format both \
+                --log-performance \
+                --out "$GITHUB_WORKSPACE/benchmark-output/${{ matrix.shard }}/dev/$side"
+            )
+          }
+          IFS=, read -r first second <<< "$RUN_ORDER"
+          run_benchmark "$first"
+          run_benchmark "$second"
 
       - name: Upload benchmark shard
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -264,54 +235,30 @@ jobs:
         working-directory: head/benchmarks/synthetic-web-bundler-benchmark
         run: pnpm test:benchmark
 
-      - name: Restore base synthetic benchmark results
-        id: base-benchmark-cache
-        if: steps.synthetic-benchmark.outputs.SKIP == 'false'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: benchmark-output/synthetic/base
-          key: >-
-            ${{ runner.os }}-benchmark-base-synthetic-${{
-            github.event.pull_request.base.sha }}-${{
-            hashFiles(
-              'head/.nvmrc',
-              'head/package.json',
-              'head/pnpm-lock.yaml',
-              'head/scripts/bench-synthetic-app.mjs',
-              'head/scripts/benchmark/**',
-              'head/benchmarks/synthetic-web-bundler-benchmark/**',
-              'base/package.json',
-              'base/pnpm-lock.yaml'
-            ) }}-${{ env.SYNTHETIC_BENCHMARK_PROFILE }}-${{
-            env.SYNTHETIC_BENCHMARK_RUNS }}
-
-      - name: Validate cached base synthetic benchmark results
-        if: steps.synthetic-benchmark.outputs.SKIP == 'false' && steps.base-benchmark-cache.outputs.cache-hit == 'true'
-        run: test -f "$GITHUB_WORKSPACE/benchmark-output/synthetic/base/latest.json"
-
-      - name: Benchmark embedded synthetic app with base plugin
-        if: steps.synthetic-benchmark.outputs.SKIP == 'false' && steps.base-benchmark-cache.outputs.cache-hit != 'true'
-        working-directory: ${{ steps.synthetic-benchmark.outputs.TOOL_ROOT }}
-        run: |
-          node scripts/bench-synthetic-app.mjs \
-            --app "${{ steps.synthetic-benchmark.outputs.APP_ROOT }}" \
-            --plugin-root "$GITHUB_WORKSPACE/base" \
-            --skip-install \
-            --out "$GITHUB_WORKSPACE/benchmark-output/synthetic/base" \
-            --runs "$SYNTHETIC_BENCHMARK_RUNS" \
-            --profile "$SYNTHETIC_BENCHMARK_PROFILE"
-
-      - name: Benchmark embedded synthetic app with head plugin
+      - name: Benchmark embedded synthetic app
         if: steps.synthetic-benchmark.outputs.SKIP == 'false'
         working-directory: ${{ steps.synthetic-benchmark.outputs.TOOL_ROOT }}
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          node scripts/bench-synthetic-app.mjs \
-            --app "${{ steps.synthetic-benchmark.outputs.APP_ROOT }}" \
-            --plugin-root "$GITHUB_WORKSPACE/head" \
-            --skip-install \
-            --out "$GITHUB_WORKSPACE/benchmark-output/synthetic/head" \
-            --runs "$SYNTHETIC_BENCHMARK_RUNS" \
-            --profile "$SYNTHETIC_BENCHMARK_PROFILE"
+          set -euo pipefail
+          run_benchmark() {
+            local side="$1"
+            node scripts/bench-synthetic-app.mjs \
+              --app "${{ steps.synthetic-benchmark.outputs.APP_ROOT }}" \
+              --plugin-root "$GITHUB_WORKSPACE/$side" \
+              --skip-install \
+              --out "$GITHUB_WORKSPACE/benchmark-output/synthetic/$side" \
+              --runs "$SYNTHETIC_BENCHMARK_RUNS" \
+              --profile "$SYNTHETIC_BENCHMARK_PROFILE"
+          }
+          if (( PR_NUMBER % 2 == 0 )); then
+            order=(base head)
+          else
+            order=(head base)
+          fi
+          run_benchmark "${order[0]}"
+          run_benchmark "${order[1]}"
 
       - name: Ensure skipped synthetic artifact path exists
         if: steps.synthetic-benchmark.outputs.SKIP == 'true'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -240,12 +240,13 @@ jobs:
         working-directory: ${{ steps.synthetic-benchmark.outputs.TOOL_ROOT }}
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          APP_ROOT: ${{ steps.synthetic-benchmark.outputs.APP_ROOT }}
         run: |
           set -euo pipefail
           run_benchmark() {
             local side="$1"
             node scripts/bench-synthetic-app.mjs \
-              --app "${{ steps.synthetic-benchmark.outputs.APP_ROOT }}" \
+              --app "$APP_ROOT" \
               --plugin-root "$GITHUB_WORKSPACE/$side" \
               --skip-install \
               --out "$GITHUB_WORKSPACE/benchmark-output/synthetic/$side" \

--- a/README.md
+++ b/README.md
@@ -667,7 +667,23 @@ pnpm bench:synthetic-app -- --profile all --runs 2
 ```
 
 The PR benchmark workflow reports production build, dev route-load, HMR/update,
-and embedded synthetic app timings in the same benchmark comment.
+and embedded synthetic app timings in the same benchmark comment. It measures
+the PR and its base on the same runner instead of reusing cached timing data,
+counterbalances which side runs first, and excludes one warmup iteration. Small
+fixtures use five measured iterations; expensive large fixtures use three.
+
+Every raw median delta remains visible. The comment also reports each side's
+relative median absolute deviation (rMAD), a conservative noise band, and a
+signal label:
+
+- `regression` or `improvement` means the median delta exceeds the observed
+  run-to-run noise band.
+- `inconclusive` means the raw delta is not clearly separated from that noise.
+- `insufficient data` means either side has fewer than three finite samples.
+
+The labels are triage aids, not pass/fail gates. Use the uploaded diagnostics
+and raw per-run samples to investigate important changes, and rerun an
+inconclusive comparison before treating it as a performance result.
 
 ## React Router Framework Mode
 

--- a/scripts/benchmark/ci-report-markdown.mjs
+++ b/scripts/benchmark/ci-report-markdown.mjs
@@ -13,6 +13,17 @@ const formatDurationSeconds = value =>
 const formatMilliseconds = value =>
   typeof value === 'number' ? `${value.toFixed(1)}ms` : '-';
 const formatCount = value => (typeof value === 'number' ? String(value) : '-');
+const formatNoiseBand = value =>
+  typeof value === 'number' ? `±${value.toFixed(1)}%` : '-';
+const formatUnsignedPercent = value =>
+  typeof value === 'number' ? `${value.toFixed(1)}%` : '-';
+const formatSignal = value =>
+  ({
+    regression: '🔴 regression',
+    improvement: '🟢 improvement',
+    inconclusive: '⚪ inconclusive',
+    'insufficient-data': '⚠️ insufficient data',
+  })[value] ?? '⚠️ insufficient data';
 
 const productionBenchmarkTableHeader = [
   '| Benchmark | Runs | Base total | Head total | Delta | Head mean | Head p95 | Speedup | Head RSS p95 |',
@@ -26,6 +37,59 @@ const devBenchmarkTableHeader = [
 
 const benchmarkRunCount = benchmark =>
   benchmark.headRunCount ?? benchmark.baseRunCount;
+
+const appendSignalSummary = (lines, report) => {
+  const benchmarkRows = [
+    ...report.buildBenchmarks.map(benchmark => ({
+      label: `${benchmark.id} (build)`,
+      runs: benchmarkRunCount(benchmark),
+      base: benchmark.baseWallMs,
+      head: benchmark.headWallMs,
+      delta: benchmark.wallDeltaPercent,
+      stability: benchmark.stability,
+      format: formatSeconds,
+    })),
+    ...report.benchmarks.map(benchmark => ({
+      label: `${benchmark.id} (dev)`,
+      runs: benchmarkRunCount(benchmark),
+      base: benchmark.baseWallMs,
+      head: benchmark.headWallMs,
+      delta: benchmark.wallDeltaPercent,
+      stability: benchmark.stability,
+      format: formatSeconds,
+    })),
+    ...report.syntheticBenchmarks.map(benchmark => ({
+      label: `complex app (${benchmark.profile})`,
+      runs: benchmark.runs,
+      base: benchmark.baseMedianSeconds,
+      head: benchmark.headMedianSeconds,
+      delta: benchmark.deltaPercent,
+      stability: benchmark.stability,
+      format: formatDurationSeconds,
+    })),
+  ];
+
+  if (benchmarkRows.length === 0) {
+    return;
+  }
+
+  lines.push(
+    '### Reading benchmark confidence',
+    '',
+    'Raw deltas are always shown. The signal label only indicates whether the observed median delta is larger than a robust run-to-run noise band; it does not erase or replace the measurement.',
+    '',
+    "The noise band is the larger of 2% or two combined robust standard deviations estimated from each side's relative median absolute deviation (rMAD). Fewer than three finite samples is reported as insufficient data. An inconclusive result should be rerun or investigated from the uploaded raw samples before drawing a performance conclusion.",
+    '',
+    '| Benchmark | Runs | Base total | Head total | Delta | Base rMAD | Head rMAD | Noise band | Signal |',
+    '|---|---:|---:|---:|---:|---:|---:|---:|---|'
+  );
+  for (const row of benchmarkRows) {
+    lines.push(
+      `| \`${row.label}\` | ${formatCount(row.runs)} | ${row.format(row.base)} | ${row.format(row.head)} | ${formatPercent(row.delta)} | ${formatUnsignedPercent(row.stability.baseRelativeMadPercent)} | ${formatUnsignedPercent(row.stability.headRelativeMadPercent)} | ${formatNoiseBand(row.stability.noiseBandPercent)} | ${formatSignal(row.stability.classification)} |`
+    );
+  }
+  lines.push('');
+};
 
 const renderBuildBenchmarkRow = benchmark =>
   `| \`${benchmark.id}\` | ${formatCount(benchmarkRunCount(benchmark))} | ${formatSeconds(benchmark.baseWallMs)} | ${formatSeconds(benchmark.headWallMs)} | ${formatPercent(benchmark.wallDeltaPercent)} | ${formatSeconds(benchmark.headWallMeanMs)} | ${formatSeconds(benchmark.headWallP95Ms)} | ${formatSpeedup(benchmark.wallSpeedup)} | ${formatRss(benchmark.headRssKb)} |`;
@@ -159,6 +223,7 @@ export const renderBenchmarkComment = report => {
     '',
   ];
 
+  appendSignalSummary(lines, report);
   appendDevRollup(lines, report);
   appendProductionBenchmarks(
     lines,

--- a/scripts/benchmark/ci-report-model.mjs
+++ b/scripts/benchmark/ci-report-model.mjs
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
+import { classifyBenchmarkSignal } from './statistics.mjs';
 
 export const readJson = async file => JSON.parse(await readFile(file, 'utf8'));
 
@@ -144,6 +145,10 @@ const compareBenchmarks = (baseResult, headResult) => {
     const headRouteTotalMs = medianRouteTotal(headBenchmark);
     const baseUpdateMs = medianUpdate(baseBenchmark);
     const headUpdateMs = medianUpdate(headBenchmark);
+    const stability = classifyBenchmarkSignal(
+      (baseBenchmark?.runs ?? []).map(run => run.wallMs),
+      (headBenchmark?.runs ?? []).map(run => run.wallMs)
+    );
 
     return {
       id,
@@ -170,6 +175,7 @@ const compareBenchmarks = (baseResult, headResult) => {
       headRunCount: headBenchmark?.runs?.length ?? null,
       headWallMeanMs: headBenchmark?.summary?.wallMs?.mean ?? null,
       headWallP95Ms: headBenchmark?.summary?.wallMs?.p95 ?? null,
+      stability,
       devRouteSummaries: compareRouteSummaries(
         baseBenchmark?.devRouteSummary,
         headBenchmark?.devRouteSummary
@@ -216,6 +222,10 @@ const compareSyntheticBenchmarks = (basePayloads, headPayloads) => {
     const headRouteTotalMs = headSummary?.routeTotalMs?.median ?? null;
     const baseUpdateMs = baseSummary?.updateMs?.median ?? null;
     const headUpdateMs = headSummary?.updateMs?.median ?? null;
+    const stability = classifyBenchmarkSignal(
+      baseSummary?.samples ?? [],
+      headSummary?.samples ?? []
+    );
 
     return {
       profile,
@@ -237,6 +247,7 @@ const compareSyntheticBenchmarks = (basePayloads, headPayloads) => {
       runs: headSummary?.runs ?? baseSummary?.runs ?? null,
       node: headSummary?.node ?? baseSummary?.node ?? null,
       platform: headSummary?.platform ?? baseSummary?.platform ?? null,
+      stability,
     };
   });
 };

--- a/scripts/benchmark/statistics.mjs
+++ b/scripts/benchmark/statistics.mjs
@@ -1,0 +1,60 @@
+const median = values => {
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle];
+};
+
+const sampleStats = samples => {
+  const values = samples.filter(Number.isFinite);
+  if (values.length < 3) {
+    return null;
+  }
+
+  const center = median(values);
+  if (center <= 0) {
+    return null;
+  }
+
+  const mad = median(values.map(value => Math.abs(value - center)));
+  return {
+    median: center,
+    relativeMadPercent: (mad / center) * 100,
+  };
+};
+
+export const classifyBenchmarkSignal = (baseSamples, headSamples) => {
+  const base = sampleStats(baseSamples);
+  const head = sampleStats(headSamples);
+  if (!base || !head) {
+    return {
+      deltaPercent: null,
+      baseRelativeMadPercent: base?.relativeMadPercent ?? null,
+      headRelativeMadPercent: head?.relativeMadPercent ?? null,
+      noiseBandPercent: null,
+      classification: 'insufficient-data',
+    };
+  }
+
+  const deltaPercent = ((head.median - base.median) / base.median) * 100;
+  const robustSigmaPercent = Math.hypot(
+    base.relativeMadPercent * 1.4826,
+    head.relativeMadPercent * 1.4826
+  );
+  const noiseBandPercent = Math.max(2, robustSigmaPercent * 2);
+  const classification =
+    deltaPercent > noiseBandPercent
+      ? 'regression'
+      : deltaPercent < -noiseBandPercent
+        ? 'improvement'
+        : 'inconclusive';
+
+  return {
+    deltaPercent,
+    baseRelativeMadPercent: base.relativeMadPercent,
+    headRelativeMadPercent: head.relativeMadPercent,
+    noiseBandPercent,
+    classification,
+  };
+};

--- a/tests/benchmark-statistics.test.ts
+++ b/tests/benchmark-statistics.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from '@rstest/core';
+import { classifyBenchmarkSignal } from '../scripts/benchmark/statistics.mjs';
+import { createBenchmarkReport } from '../scripts/benchmark/ci-report-model.mjs';
+import { renderBenchmarkComment } from '../scripts/benchmark/ci-report-markdown.mjs';
+
+describe('benchmark signal classification', () => {
+  it('treats identical zero-variance samples as inconclusive', () => {
+    expect(
+      classifyBenchmarkSignal([100, 100, 100, 100, 100], [100, 100, 100, 100, 100])
+    ).toMatchObject({
+      deltaPercent: 0,
+      baseRelativeMadPercent: 0,
+      headRelativeMadPercent: 0,
+      noiseBandPercent: 2,
+      classification: 'inconclusive',
+    });
+  });
+
+  it('does not call a delta outside noisy samples a regression', () => {
+    const result = classifyBenchmarkSignal(
+      [90, 95, 100, 105, 110],
+      [100, 105, 110, 115, 120]
+    );
+
+    expect(result.deltaPercent).toBe(10);
+    expect(result.noiseBandPercent).toBeGreaterThan(10);
+    expect(result.classification).toBe('inconclusive');
+  });
+
+  it('classifies a clear stable regression', () => {
+    const result = classifyBenchmarkSignal(
+      [99, 100, 101, 100, 100],
+      [119, 120, 121, 120, 120]
+    );
+
+    expect(result.deltaPercent).toBe(20);
+    expect(result.noiseBandPercent).toBeLessThan(20);
+    expect(result.classification).toBe('regression');
+  });
+
+  it('classifies a clear stable improvement', () => {
+    const result = classifyBenchmarkSignal(
+      [119, 120, 121, 120, 120],
+      [99, 100, 101, 100, 100]
+    );
+
+    expect(result.deltaPercent).toBeCloseTo(-16.6666667);
+    expect(result.noiseBandPercent).toBeLessThan(16);
+    expect(result.classification).toBe('improvement');
+  });
+
+  it.each([
+    { base: [], head: [100, 100, 100] },
+    { base: [100, 100], head: [110, 110] },
+    { base: [100, Number.NaN, 100], head: [110, 110, 110] },
+  ])('requires at least three finite samples on each side', ({ base, head }) => {
+    expect(classifyBenchmarkSignal(base, head)).toMatchObject({
+      classification: 'insufficient-data',
+      noiseBandPercent: null,
+    });
+  });
+});
+
+describe('benchmark report stability metadata', () => {
+  it('attaches raw wall-time stability evidence to fixture comparisons', () => {
+    const benchmark = (commit: string, samples: number[]) => ({
+      commit,
+      profile: 'ci-small',
+      mode: 'build',
+      iterations: samples.length,
+      warmup: 1,
+      benchmarks: [
+        {
+          id: 'fixture',
+          routeCount: 1,
+          summary: {
+            wallMs: { median: samples[Math.floor(samples.length / 2)] },
+          },
+          runs: samples.map(wallMs => ({ wallMs })),
+        },
+      ],
+    });
+
+    const report = createBenchmarkReport({
+      base: benchmark('base', [99, 100, 101, 100, 100]),
+      head: benchmark('head', [119, 120, 121, 120, 120]),
+      buildBase: null,
+      buildHead: null,
+      syntheticBasePayloads: [],
+      syntheticHeadPayloads: [],
+      metadata: {},
+    });
+
+    expect(report.benchmarks[0].stability).toMatchObject({
+      deltaPercent: 20,
+      classification: 'regression',
+      baseRelativeMadPercent: 0,
+      headRelativeMadPercent: 0,
+      noiseBandPercent: 2,
+    });
+  });
+
+  it('attaches stability evidence to synthetic samples', () => {
+    const payload = (samples: number[]) => [
+      {
+        manifest: {},
+        payload: {
+          runs: samples.length,
+          summaries: [
+            {
+              profile: 'cold',
+              median: samples[Math.floor(samples.length / 2)],
+              samples,
+            },
+          ],
+        },
+      },
+    ];
+
+    const report = createBenchmarkReport({
+      base: { benchmarks: [] },
+      head: { benchmarks: [] },
+      buildBase: null,
+      buildHead: null,
+      syntheticBasePayloads: payload([99, 100, 101, 100, 100]),
+      syntheticHeadPayloads: payload([89, 90, 91, 90, 90]),
+      metadata: {},
+    });
+
+    expect(report.syntheticBenchmarks[0].stability).toMatchObject({
+      classification: 'improvement',
+      deltaPercent: -10,
+    });
+  });
+
+  it('keeps raw deltas visible while explaining signal confidence', () => {
+    const report = createBenchmarkReport({
+      base: {
+        mode: 'build',
+        benchmarks: [
+          {
+            id: 'fixture',
+            summary: { wallMs: { median: 100 } },
+            runs: [99, 100, 101, 100, 100].map(wallMs => ({ wallMs })),
+          },
+        ],
+      },
+      head: {
+        mode: 'build',
+        benchmarks: [
+          {
+            id: 'fixture',
+            summary: { wallMs: { median: 120 } },
+            runs: [119, 120, 121, 120, 120].map(wallMs => ({ wallMs })),
+          },
+        ],
+      },
+      buildBase: null,
+      buildHead: null,
+      syntheticBasePayloads: [],
+      syntheticHeadPayloads: [],
+      metadata: {},
+    });
+
+    const comment = renderBenchmarkComment(report);
+    expect(comment).toContain('### Reading benchmark confidence');
+    expect(comment).toContain('Raw deltas are always shown');
+    expect(comment).toContain('| Benchmark | Runs | Base total | Head total | Delta | Base rMAD | Head rMAD | Noise band | Signal |');
+    expect(comment).toContain('| `fixture (dev)` | 5 | 0.10s | 0.12s | +20.0% | 0.0% | 0.0% | ±2.0% | 🔴 regression |');
+  });
+});


### PR DESCRIPTION
## Summary

- measure PR head and base on the same GitHub runner instead of comparing the head against cached timing data from an earlier runner
- deterministically counterbalance base/head execution order across build/dev shards and alternate the synthetic-app order by PR number
- restore one excluded warmup and five measured samples for small fixtures while retaining three samples for expensive large fixtures
- keep every raw median delta visible while adding robust rMAD-based noise bands and `regression`, `improvement`, `inconclusive`, or `insufficient data` triage labels

## Why

PR #95 provided a useful negative control because it changed benchmark orchestration rather than plugin runtime behavior. Two runs against the same base reused byte-identical cached baseline artifacts, but the newly measured head changed enough to produce contradictory conclusions: one run was near neutral while another reported 18–30% regressions for small fixtures and 7–18% improvements for large fixtures.

That showed the cached baseline was not controlling for the current runner. It also exposed two secondary issues: three un-warmed samples were too sparse to characterize spread, and the report presented point deltas without telling reviewers whether they were larger than observed run-to-run noise.

## Methodology

For each fixture, the report computes the median and relative median absolute deviation (rMAD) independently for base and head. It converts rMAD to a robust standard-deviation estimate using the normal-consistency factor `1.4826`, combines both sides with root-sum-of-squares, and uses twice that estimate as a conservative noise band with a 2% minimum floor.

The label is only a triage aid:

- a positive delta outside the band is a `regression`
- a negative delta outside the band is an `improvement`
- a delta inside the band is `inconclusive`
- fewer than three finite samples on either side is `insufficient data`

The raw base/head medians and delta remain present regardless of the label. These labels are not a pass/fail gate and do not hide regressions.

## Runtime tradeoff

Reliability costs runner time. Cache-hit PR #95 jobs measured only the head: build/dev shards completed in roughly 2–3 minutes and the synthetic job in roughly 18 minutes. This change always measures both sides; expected build/dev shard time is roughly 5–10 minutes and the synthetic job roughly 36 minutes. The jobs remain sharded and within the existing 40-minute timeout, but the synthetic job has less spare margin than before.

## Validation

- `pnpm test` — 44 files, 481 tests passed
- `pnpm build` — passed
- `pnpm --dir benchmarks/synthetic-web-bundler-benchmark test:benchmark` — 12 tests passed
- focused benchmark statistics/report tests — 10 tests passed
- Prettier check — passed
- `git diff --check` — passed
- actionlint — zero errors with the repository's existing `SC2046` suppression

## Limitations

- GitHub-hosted runners still have unavoidable VM and neighbor variability.
- Counterbalancing controls systematic first/second bias across the suite, but this does not yet interleave every individual base/head iteration.
- The rMAD band is a robust heuristic for triage, not a formal hypothesis test or a replacement for inspecting raw samples.
- Three samples for expensive large and synthetic fixtures provide less resolution than five samples; reports explicitly expose that limitation rather than manufacturing confidence.
