### PR TITLE
fix: preserve in-memory dev output

### DIFF
--- a/.changeset/quiet-disks-rest.md
+++ b/.changeset/quiet-disks-rest.md
@@ -1,0 +1,5 @@
+---
+'rsbuild-plugin-react-router': patch
+---
+
+Stop forcing development output to disk so `dev.writeToDisk: false` and Rsbuild's in-memory default are preserved.

--- a/examples/default-template/tests/e2e/dev-route-watch.test.ts
+++ b/examples/default-template/tests/e2e/dev-route-watch.test.ts
@@ -144,7 +144,6 @@ test.describe('dev route watch', () => {
   }) => {
     await page.goto('/');
     await expect(page.locator('h1')).toContainText('Welcome to React Router');
-    const restartMarkerBeforeAdd = readRestartMarkerVersion();
 
     writeFileSync(
       addedRoutePath,
@@ -161,9 +160,6 @@ test.describe('dev route watch', () => {
     await page.goto(addedRouteUrl);
     await expect(page.locator('h1')).toHaveText(addedRouteText);
 
-    await expect
-      .poll(readRestartMarkerVersion, { timeout: 10000 })
-      .not.toBe(restartMarkerBeforeAdd);
     const restartMarkerBefore = readRestartMarkerVersion();
     writeFileSync(
       addedRoutePath,

--- a/src/index.ts
+++ b/src/index.ts
@@ -800,7 +800,6 @@ export const pluginReactRouter = (
           assetPrefix: config.output?.assetPrefix || '/',
         },
         dev: {
-          writeToDisk: true,
           ...lazyCompilation,
           watchFiles: mergeWatchFiles(config.dev?.watchFiles, routeWatchFiles),
         },

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -33,7 +33,7 @@ describe('pluginReactRouter', () => {
       // The plugin should not override Rsbuild's HMR defaults.
       expect(config.dev.hmr).toBe(true);
       expect(config.dev.liveReload).toBe(true);
-      expect(config.dev.writeToDisk).toBe(true);
+      expect(config.dev.writeToDisk).toBe(false);
     });
 
     it('should register the dev server middleware via server.setup', async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -60,7 +60,7 @@ describe('pluginReactRouter', () => {
     // The plugin should not override Rsbuild's HMR defaults.
     expect(config.dev.hmr).toBe(true);
     expect(config.dev.liveReload).toBe(true);
-    expect(config.dev.writeToDisk).toBe(true);
+    expect(config.dev.writeToDisk).toBe(false);
     expect(config.dev.lazyCompilation).toMatchObject({
       entries: true,
       imports: true,

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -72,6 +72,19 @@ describe('pluginReactRouter', () => {
     ).toBe(false);
   });
 
+  it('preserves an explicit writeToDisk override', async () => {
+    const rsbuild = await createStubRsbuild({
+      rsbuildConfig: {
+        dev: { writeToDisk: true },
+      },
+    });
+
+    rsbuild.addPlugins([pluginReactRouter()]);
+    const config = await rsbuild.unwrapConfig();
+
+    expect(config.dev.writeToDisk).toBe(true);
+  });
+
   it('adds the committed custom-server build entry only in development', async () => {
     const devRsbuild = await createStubRsbuild({ rsbuildConfig: {} });
     devRsbuild.addPlugins([pluginReactRouter({ customServer: true })]);


### PR DESCRIPTION
## Summary

- stop forcing `dev.writeToDisk: true`
- preserve Rsbuild's in-memory development default and explicit `writeToDisk: false`
- align the route-watch E2E with in-memory route additions: require the route to become available, without requiring a disk restart marker
- add a patch changeset

## Root cause

The plugin unconditionally overrode Rsbuild's development output setting, forcing every dev compilation to write to disk. The existing route-add E2E also treated a disk restart marker as part of the contract, although in-memory compilation can expose the new route without that signal.

## Verification

- `pnpm exec rstest run -c ./rstest.config.ts tests/index.test.ts tests/features.test.ts` (red before fix, 42 passed after, including explicit `writeToDisk: true` preservation)
- `pnpm exec rstest run -c ./rstest.config.ts tests/dev-runtime.integration.test.ts` (2 passed)
- `pnpm test:core` (481 passed)
- `pnpm build`
- `pnpm --filter default-template exec playwright test tests/e2e/dev-route-watch.test.ts --workers=1 --repeat-each=3` (3 passed)
- Prettier checks on all changed files
- `git diff --check`

Forward-ports the `writeToDisk` portion of #86 without its unrelated optimization changes.
