### PR TITLE
Version Packages

### DIFF
--- a/.changeset/quiet-disks-rest.md
+++ b/.changeset/quiet-disks-rest.md
@@ -1,5 +1,0 @@
----
-'rsbuild-plugin-react-router': patch
----
-
-Stop forcing development output to disk so `dev.writeToDisk: false` and Rsbuild's in-memory default are preserved.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rsbuild-plugin-react-router
 
+## 0.4.1
+
+### Patch Changes
+
+- dde2a2d: Stop forcing development output to disk so `dev.writeToDisk: false` and Rsbuild's in-memory default are preserved.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsbuild-plugin-react-router",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "React Router plugin for Rsbuild",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release

- `rsbuild-plugin-react-router@0.4.1`
- patch: preserve Rsbuild's `writeToDisk: false` default and user override

After merge, rerun the `Release` workflow on `main` to publish the stable release.